### PR TITLE
Colorized topic visualization

### DIFF
--- a/pkg/crdt/tests/network.go
+++ b/pkg/crdt/tests/network.go
@@ -248,12 +248,22 @@ func (net *network) checkEvents(t *testing.T, ignore []int) (missing map[int]str
 // showing the individual events and their links
 func (net *network) visualiseTopic(w io.Writer, topic string) {
 	fmt.Fprintf(w, "strict digraph %s {\n", topic)
+	fmt.Fprintln(w, "\tnode [colorscheme=pastel19]")
 	for i := len(net.events) - 1; i >= 0; i-- {
 		ev := net.events[i]
 		if ev.ContentTopic != topic {
 			continue
 		}
-		fmt.Fprintf(w, "\t\"%s\" [label=\"%d: \\N\"]\n", zap.ShortCid(ev.Cid), i)
+		prefix := strconv.Itoa(i)
+		var color string
+		var msg, node int
+		if n, err := fmt.Sscanf(string(ev.Message), "%d/n%d", &msg, &node); err == nil && n == 2 {
+			prefix = string(ev.Message)
+			if len(net.nodes) < 10 {
+				color = fmt.Sprintf(" style=filled color=%d", node+1)
+			}
+		}
+		fmt.Fprintf(w, "\t\"%s\" [label=\"%s: \\N\"%s]\n", zap.ShortCid(ev.Cid), prefix, color)
 		fmt.Fprintf(w, "\t\"%s\" -> { ", zap.ShortCid(ev.Cid))
 		for _, l := range ev.Links {
 			fmt.Fprintf(w, "\"%s\" ", zap.ShortCid(l))

--- a/pkg/crdt/tests/utils.go
+++ b/pkg/crdt/tests/utils.go
@@ -22,8 +22,9 @@ func RandomMsgTest(t *testing.T, nodes, topics, messages int, modifiers ...Confi
 	net := NewNetwork(t, nodes, modifiers...)
 	for i := 0; i < messages; i++ {
 		topic := fmt.Sprintf("t%d", rand.Intn(topics))
-		msg := fmt.Sprintf("gm %d", i)
-		net.Publish(t, rand.Intn(nodes), topic, msg)
+		node := rand.Intn(nodes)
+		msg := fmt.Sprintf("%d/n%d", i, node)
+		net.Publish(t, node, topic, msg)
 		if i%nrTopicReplicas == 0 {
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
 		}


### PR DESCRIPTION
I wanted to highlight which node generated which event in the topic vis, so I decided to colour the nodes based on that (for up to 9 nodes). For that I needed to embed the node id in the event payload so that I can extract it later when the visualization runs.

![t0](https://user-images.githubusercontent.com/871693/217954527-fabe4d7e-2710-4b87-ae47-026bd74dae52.svg)
