### PR TITLE
Clean node shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ Visit local [Jaeger](https://www.jaegertracing.io/) UI:
 ```sh
 open http://localhost:16686
 ```
+
+## Resources
+
+* OpenTelemetry intro https://www.komu.engineer/blogs/11/opentelemetry-and-go

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/uptrace/opentelemetry-go-extra/otelsql v0.1.21
 	github.com/xmtp/proto/v3 v3.12.3
+	go.etcd.io/bbolt v1.3.7
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.39.0
 	go.opentelemetry.io/otel v1.13.0
@@ -31,7 +32,6 @@ require (
 	go.opentelemetry.io/otel/metric v0.36.0
 	go.opentelemetry.io/otel/sdk v1.13.0
 	go.opentelemetry.io/otel/sdk/metric v0.36.0
-	go.etcd.io/bbolt v1.3.7
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/grpc v1.53.0

--- a/pkg/api/gateway/server.go
+++ b/pkg/api/gateway/server.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/zap"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -29,13 +29,13 @@ type Server struct {
 	http net.Listener
 }
 
-func New(ctx context.Context, log *zap.Logger, messagev1 messagev1.MessageApiServer, opts *Options) (*Server, error) {
+func New(ctx context.Context, messagev1 messagev1.MessageApiServer, opts *Options) (*Server, error) {
 	err := opts.validate()
 	if err != nil {
 		return nil, err
 	}
 
-	log = log.Named("api")
+	log := ctx.Logger().Named("api")
 
 	s := &Server{
 		ctx:       ctx,

--- a/pkg/api/gateway/server_test.go
+++ b/pkg/api/gateway/server_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	memstore "github.com/xmtp/xmtpd/pkg/crdt/stores/mem"
 	test "github.com/xmtp/xmtpd/pkg/testing"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -40,7 +38,7 @@ func Test_HTTPRootPath(t *testing.T) {
 }
 
 func Test_Health(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.NewContext(t)
 	server, cleanup := newTestServer(t)
 	conn, err := server.dialGRPC(ctx)
 	assert.NoError(t, err)
@@ -53,11 +51,9 @@ func Test_Health(t *testing.T) {
 }
 
 func newTestServer(t *testing.T) (*Server, func()) {
-	ctx := context.Background()
-	log := test.NewLogger(t)
+	ctx := test.NewContext(t)
 
-	store := memstore.New(log)
-	s, err := New(ctx, log, nil, &Options{
+	s, err := New(ctx, nil, &Options{
 		GRPCAddress: "localhost",
 		GRPCPort:    0,
 		HTTPAddress: "localhost",
@@ -67,6 +63,5 @@ func newTestServer(t *testing.T) (*Server, func()) {
 	require.NoError(t, err)
 	return s, func() {
 		s.Close()
-		store.Close()
 	}
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,115 @@
+package context
+
+import (
+	"context"
+	"time"
+
+	"github.com/xmtp/xmtpd/pkg/zap"
+)
+
+var _ Context = &runtimeContext{}
+
+var (
+	// re-export commonly used bits
+	Background       = context.Background
+	Canceled         = context.Canceled
+	DeadlineExceeded = context.DeadlineExceeded
+)
+
+// Context is a cancellable context that provides synchronization
+// primitives with goroutines it controls and common runtime facilities, e.g. Logger.
+//
+// Child Context's goroutines are controlled by both the child and the parent.
+// Parent's goroutines are out of scope of the child context.
+type Context interface {
+	context.Context
+	// Go runs f in a goroutine that can be cancelled and waited for its exit.
+	// f MUST respond to ctx.Done()
+	Go(f func(ctx Context))
+	// Close cancels All goroutines and waits for them to exit.
+	Close()
+	// Logger returns the logger carried by this context.
+	Logger() *zap.Logger
+
+	// This is a private helper that we need to implement the standard Context API.
+	// It will also prevent others from implementing this interface.
+	clone() *runtimeContext
+}
+
+type runtimeContext struct {
+	context.Context
+	cancel context.CancelFunc
+	wg     *waitGroup
+	logger *zap.Logger
+}
+
+// New converts a standard Context into our Context,
+// it also attaches the logger to it.
+func New(ctx context.Context, logger *zap.Logger) Context {
+	ctx, cancel := context.WithCancel(ctx)
+	return &runtimeContext{
+		Context: ctx,
+		cancel:  cancel,
+		logger:  logger,
+		wg:      newWaitGroup(nil),
+	}
+}
+
+func WithCancel(ctx Context) Context {
+	rc := ctx.clone()
+	rc.wg = newWaitGroup(rc.wg)
+	rc.Context, rc.cancel = context.WithCancel(ctx)
+	return rc
+}
+
+func WithTimeout(ctx Context, t time.Duration) Context {
+	rc := ctx.clone()
+	rc.wg = newWaitGroup(rc.wg)
+	rc.Context, rc.cancel = context.WithTimeout(ctx, t)
+	return rc
+}
+
+func WithDeadline(ctx Context, t time.Time) Context {
+	rc := ctx.clone()
+	rc.wg = newWaitGroup(rc.wg)
+	rc.Context, rc.cancel = context.WithDeadline(ctx, t)
+	return rc
+}
+
+func WithValue(ctx Context, key, val any) Context {
+	rc := ctx.clone()
+	rc.Context = context.WithValue(ctx, key, val)
+	return rc
+}
+
+func WithLogger(ctx Context, logger *zap.Logger) Context {
+	rc := ctx.clone()
+	rc.logger = logger
+	return rc
+}
+
+func (ctx *runtimeContext) Go(f func(context Context)) {
+	ctx.wg.Add(1)
+	go func() {
+		defer ctx.wg.Done()
+		f(ctx)
+	}()
+}
+
+func (ctx *runtimeContext) Close() {
+	ctx.cancel()
+	ctx.wg.Wait()
+}
+
+func (ctx *runtimeContext) Logger() *zap.Logger {
+	return ctx.logger
+}
+
+func (ctx *runtimeContext) clone() *runtimeContext {
+	return &runtimeContext{
+		Context: ctx.Context,
+		cancel:  ctx.cancel,
+		logger:  ctx.logger,
+		wg:      ctx.wg,
+	}
+}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -1,0 +1,112 @@
+package context_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/context"
+	tests "github.com/xmtp/xmtpd/pkg/testing"
+)
+
+func Test_GoClose(t *testing.T) {
+	ctx := context.New(context.Background(), tests.NewLogger(t))
+	ctx.Go(func(ctx context.Context) {
+		<-ctx.Done()
+	})
+	ctx.Close()
+}
+
+func Test_GoCloseWithCancel(t *testing.T) {
+	var finished sync.Map
+	ctx := context.New(context.Background(), tests.NewLogger(t))
+	ctx.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("one", true)
+	})
+	ctx2 := context.WithCancel(ctx)
+	ctx2.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("two", true)
+	})
+	// Close child
+	ctx2.Close()
+	_, ok := finished.Load("one")
+	require.False(t, ok)
+	_, ok = finished.Load("two")
+	require.True(t, ok)
+	// Close parent
+	ctx.Close()
+	_, ok = finished.Load("one")
+	require.True(t, ok)
+}
+
+func Test_GoCloseWithTimeout(t *testing.T) {
+	var finished sync.Map
+	ctx := context.New(context.Background(), tests.NewLogger(t))
+	ctx.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("one", true)
+	})
+	ctx2 := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx2.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("two", true)
+	})
+	// Wait for child to expire
+	time.Sleep(20 * time.Millisecond)
+	_, ok := finished.Load("two")
+	require.True(t, ok)
+	// Close the child
+	ctx2.Close()
+	_, ok = finished.Load("one")
+	require.False(t, ok)
+	// Close parent
+	ctx.Close()
+	_, ok = finished.Load("one")
+	require.True(t, ok)
+}
+
+func Test_GoCloseWithDeadline(t *testing.T) {
+	var finished sync.Map
+	ctx := context.New(context.Background(), tests.NewLogger(t))
+	ctx.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("one", true)
+	})
+	ctx2 := context.WithDeadline(ctx, time.Now().Add(10*time.Millisecond))
+	ctx2.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("two", true)
+	})
+	// Wait for child to expire
+	time.Sleep(20 * time.Millisecond)
+	_, ok := finished.Load("two")
+	require.True(t, ok)
+	// Close the child
+	ctx2.Close()
+	_, ok = finished.Load("one")
+	require.False(t, ok)
+	// Close parent
+	ctx.Close()
+	_, ok = finished.Load("one")
+	require.True(t, ok)
+}
+
+func Test_GoCloseWithWithValue(t *testing.T) {
+	var finished sync.Map
+	ctx := context.New(context.Background(), tests.NewLogger(t))
+	ctx.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Store("one", true)
+	})
+	key := "key"
+	ctx2 := context.WithValue(ctx, key, true)
+	require.Equal(t, true, ctx2.Value(key))
+
+	// Closing child closes the parent
+	ctx2.Close()
+	_, ok := finished.Load("one")
+	require.True(t, ok)
+}

--- a/pkg/context/waitGroup.go
+++ b/pkg/context/waitGroup.go
@@ -1,0 +1,36 @@
+package context
+
+import "sync"
+
+// waitGroup provides hierarchical structure of WaitGroups,
+// where children propagate Adds and Dones to the parents.
+// A child Waits only for its own Adds, but a parent Waits
+// for both its own and its childrens' Adds.
+type waitGroup struct {
+	parent *waitGroup
+	wg     sync.WaitGroup
+}
+
+func newWaitGroup(parent *waitGroup) *waitGroup {
+	return &waitGroup{parent: parent}
+}
+
+func (wg *waitGroup) Add(delta int) {
+	if wg == nil {
+		return
+	}
+	wg.wg.Add(delta)
+	wg.parent.Add(delta)
+}
+
+func (wg *waitGroup) Done() {
+	if wg == nil {
+		return
+	}
+	wg.wg.Done()
+	wg.parent.Done()
+}
+
+func (wg *waitGroup) Wait() {
+	wg.wg.Wait()
+}

--- a/pkg/crdt/broadcaster.go
+++ b/pkg/crdt/broadcaster.go
@@ -1,8 +1,7 @@
 package crdt
 
 import (
-	"context"
-
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 )
 

--- a/pkg/crdt/broadcasters/mem/broadcaster.go
+++ b/pkg/crdt/broadcasters/mem/broadcaster.go
@@ -1,10 +1,10 @@
 package membroadcaster
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/zap"
 )
@@ -15,9 +15,9 @@ type MemoryBroadcaster struct {
 	peers []*MemoryBroadcaster
 }
 
-func New(log *zap.Logger) *MemoryBroadcaster {
+func New(ctx context.Context) *MemoryBroadcaster {
 	return &MemoryBroadcaster{
-		log: log,
+		log: ctx.Logger(),
 		ch:  make(chan *types.Event, 100),
 	}
 }

--- a/pkg/crdt/broadcasters/mem/broadcaster_test.go
+++ b/pkg/crdt/broadcasters/mem/broadcaster_test.go
@@ -1,7 +1,6 @@
 package membroadcaster_test
 
 import (
-	"context"
 	"testing"
 
 	membroadcaster "github.com/xmtp/xmtpd/pkg/crdt/broadcasters/mem"
@@ -11,9 +10,8 @@ import (
 
 func TestMemoryBroadcaster(t *testing.T) {
 	crdttest.RunBroadcasterTests(t, func(t *testing.T) *crdttest.TestBroadcaster {
-		ctx := context.Background()
-		log := test.NewLogger(t)
-		bc := membroadcaster.New(log)
-		return crdttest.NewTestBroadcaster(ctx, log, bc)
+		ctx := test.NewContext(t)
+		bc := membroadcaster.New(ctx)
+		return crdttest.NewTestBroadcaster(ctx, bc)
 	})
 }

--- a/pkg/crdt/replica.go
+++ b/pkg/crdt/replica.go
@@ -1,10 +1,9 @@
 package crdt
 
 import (
-	"context"
-
 	mh "github.com/multiformats/go-multihash"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/zap"
 )
@@ -13,9 +12,9 @@ type NewEventFunc func(ev *types.Event)
 
 // Replica manages the DAG of a dataset replica.
 type Replica struct {
-	log        *zap.Logger
-	ctx        context.Context
-	ctxCancel  context.CancelFunc
+	log *zap.Logger
+	ctx context.Context
+
 	onNewEvent NewEventFunc
 
 	store       Store
@@ -27,12 +26,10 @@ type Replica struct {
 	pendingLinks         chan mh.Multihash // missing links that were discovered but not successfully fetched yet
 }
 
-func NewReplica(ctx context.Context, log *zap.Logger, store Store, bc Broadcaster, syncer Syncer, onNewEvent NewEventFunc) (*Replica, error) {
-	ctx, ctxCancel := context.WithCancel(ctx)
+func NewReplica(ctx context.Context, store Store, bc Broadcaster, syncer Syncer, onNewEvent NewEventFunc) (*Replica, error) {
 	r := &Replica{
-		log:        log,
+		log:        ctx.Logger(),
 		ctx:        ctx,
-		ctxCancel:  ctxCancel,
 		onNewEvent: onNewEvent,
 
 		store:       store,
@@ -46,10 +43,10 @@ func NewReplica(ctx context.Context, log *zap.Logger, store Store, bc Broadcaste
 		pendingLinks:         make(chan mh.Multihash, 20),
 	}
 
-	go r.receiveEventLoop()
-	go r.syncEventLoop()
-	go r.syncLinkLoop()
-	go r.nextBroadcastedEventLoop()
+	r.ctx.Go(r.receiveEventLoop)
+	r.ctx.Go(r.syncEventLoop)
+	r.ctx.Go(r.syncLinkLoop)
+	r.ctx.Go(r.nextBroadcastedEventLoop)
 
 	err := r.bootstrap()
 	if err != nil {
@@ -57,13 +54,6 @@ func NewReplica(ctx context.Context, log *zap.Logger, store Store, bc Broadcaste
 	}
 
 	return r, nil
-}
-
-func (r *Replica) Close() error {
-	if r.ctxCancel != nil {
-		r.ctxCancel()
-	}
-	return nil
 }
 
 func (r *Replica) BroadcastAppend(ctx context.Context, env *messagev1.Envelope) (*types.Event, error) {
@@ -78,10 +68,10 @@ func (r *Replica) Query(ctx context.Context, req *messagev1.QueryRequest) (*mess
 	return r.store.Query(ctx, req)
 }
 
-func (r *Replica) nextBroadcastedEventLoop() {
+func (r *Replica) nextBroadcastedEventLoop(ctx context.Context) {
 	log := r.log.Named("nextBroadcastedEventLoop")
 	for {
-		ev, err := r.broadcaster.Next(r.ctx)
+		ev, err := r.broadcaster.Next(ctx)
 		if err != nil {
 			if err == context.Canceled {
 				log.Debug("context closed", zap.Error(err))
@@ -101,15 +91,15 @@ func (r *Replica) nextBroadcastedEventLoop() {
 
 // receiveEventLoop processes incoming Events from broadcasts.
 // It consumes pendingReceiveEvents and writes into pendingLinks.
-func (r *Replica) receiveEventLoop() {
+func (r *Replica) receiveEventLoop(ctx context.Context) {
 	log := r.log.Named("receiveEventLoop")
 	for {
 		select {
-		case <-r.ctx.Done():
-			log.Debug("context closed", zap.Error(r.ctx.Err()))
+		case <-ctx.Done():
+			log.Debug("context closed", zap.Error(ctx.Err()))
 			return
 		case ev := <-r.pendingReceiveEvents:
-			added, err := r.store.InsertHead(r.ctx, ev)
+			added, err := r.store.InsertHead(ctx, ev)
 			if err != nil {
 				log.Error("error inserting head", zap.Cid("event", ev.Cid), zap.Error(err))
 				// requeue for later
@@ -128,19 +118,19 @@ func (r *Replica) receiveEventLoop() {
 
 // syncLoop fetches missing events from links.
 // It consumes pendingLinks and writes into pendingSyncEvents
-func (r *Replica) syncLinkLoop() {
+func (r *Replica) syncLinkLoop(ctx context.Context) {
 	log := r.log.Named("syncLinkLoop")
 	for {
 		select {
-		case <-r.ctx.Done():
-			log.Debug("context closed", zap.Error(r.ctx.Err()))
+		case <-ctx.Done():
+			log.Debug("context closed", zap.Error(ctx.Err()))
 			return
 		case cid := <-r.pendingLinks:
 			// r.log.Debug("checking link", zap.Cid("link", cid))
 			// If the CID is in heads, it should be removed because
 			// we have an event that points to it.
 			// We also don't need to fetch it since we already have it.
-			removed, err := r.store.RemoveHead(r.ctx, cid)
+			removed, err := r.store.RemoveHead(ctx, cid)
 			if err != nil {
 				log.Error("error removing head", zap.Cid("event", cid), zap.Error(err))
 				// requeue for later
@@ -154,7 +144,7 @@ func (r *Replica) syncLinkLoop() {
 			}
 			log.Debug("fetching link", zap.Cid("link", cid))
 			cids := []mh.Multihash{cid}
-			evs, err := r.syncer.Fetch(r.ctx, cids)
+			evs, err := r.syncer.Fetch(ctx, cids)
 			if err != nil {
 				log.Error("error fetching event", zap.Cids("event", cids...), zap.Error(err))
 				// requeue for later
@@ -178,15 +168,15 @@ func (r *Replica) syncLinkLoop() {
 // It consumes pendingSyncEvents and writes into pendingLinks.
 // TODO: There is channel read/write cycle between the two sync loops,
 // i.e. they could potentially lock up if both channels fill up.
-func (r *Replica) syncEventLoop() {
+func (r *Replica) syncEventLoop(ctx context.Context) {
 	log := r.log.Named("syncEventLoop")
 	for {
 		select {
-		case <-r.ctx.Done():
-			log.Debug("context closed", zap.Error(r.ctx.Err()))
+		case <-ctx.Done():
+			log.Debug("context closed", zap.Error(ctx.Err()))
 			return
 		case ev := <-r.pendingSyncEvents:
-			added, err := r.store.InsertEvent(r.ctx, ev)
+			added, err := r.store.InsertEvent(ctx, ev)
 			if err != nil {
 				log.Error("error inserting event", zap.Cid("event", ev.Cid), zap.Error(err))
 				// requeue for later

--- a/pkg/crdt/store.go
+++ b/pkg/crdt/store.go
@@ -1,11 +1,11 @@
 package crdt
 
 import (
-	"context"
 	"errors"
 
 	"github.com/multiformats/go-multihash"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 )
 
@@ -51,7 +51,4 @@ type Store interface {
 
 	// NewCursor builds and returns a new cursor instance.
 	NewCursor(ev *types.Event) *messagev1.Cursor
-
-	// Close gracefully closes the store.
-	Close() error
 }

--- a/pkg/crdt/stores/mem/store.go
+++ b/pkg/crdt/stores/mem/store.go
@@ -2,12 +2,12 @@ package memstore
 
 import (
 	"bytes"
-	"context"
 	"sort"
 	"sync"
 
 	"github.com/multiformats/go-multihash"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/zap"
 )
@@ -23,9 +23,9 @@ type MemoryStore struct {
 	eventsByTime []*types.Event
 }
 
-func New(log *zap.Logger) *MemoryStore {
+func New(ctx context.Context) *MemoryStore {
 	return &MemoryStore{
-		log:    log,
+		log:    ctx.Logger(),
 		heads:  make(map[string]bool),
 		events: make(map[string]*types.Event),
 	}

--- a/pkg/crdt/stores/mem/store_query.go
+++ b/pkg/crdt/stores/mem/store_query.go
@@ -2,11 +2,11 @@ package memstore
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"sort"
 
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/utils"
 )

--- a/pkg/crdt/stores/mem/store_test.go
+++ b/pkg/crdt/stores/mem/store_test.go
@@ -1,7 +1,6 @@
 package memstore_test
 
 import (
-	"context"
 	"testing"
 
 	memstore "github.com/xmtp/xmtpd/pkg/crdt/stores/mem"
@@ -10,17 +9,16 @@ import (
 )
 
 func TestMemoryStore(t *testing.T) {
-	ctx := context.Background()
-	log := test.NewLogger(t)
+	ctx := test.NewContext(t)
 	topic := "topic-" + test.RandomStringLower(13)
 
 	crdttest.RunStoreEventTests(t, topic, func(t *testing.T) *crdttest.TestStore {
-		store := memstore.New(log)
-		return crdttest.NewTestStore(ctx, log, store)
+		store := memstore.New(ctx)
+		return crdttest.NewTestStore(ctx, store)
 	})
 
 	crdttest.RunStoreQueryTests(t, topic, func(t *testing.T) *crdttest.TestStore {
-		s := memstore.New(test.NewLogger(t))
-		return crdttest.NewTestStore(ctx, log, s)
+		store := memstore.New(test.NewContext(t))
+		return crdttest.NewTestStore(ctx, store)
 	})
 }

--- a/pkg/crdt/syncer.go
+++ b/pkg/crdt/syncer.go
@@ -1,9 +1,8 @@
 package crdt
 
 import (
-	"context"
-
 	"github.com/multiformats/go-multihash"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 )
 

--- a/pkg/crdt/syncers/mem/syncer.go
+++ b/pkg/crdt/syncers/mem/syncer.go
@@ -1,11 +1,11 @@
 package memsyncer
 
 import (
-	"context"
 	"math/rand"
 	"reflect"
 
 	"github.com/multiformats/go-multihash"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/zap"
@@ -17,9 +17,9 @@ type MemorySyncer struct {
 	peers []*MemorySyncer
 }
 
-func New(log *zap.Logger, store crdt.Store) *MemorySyncer {
+func New(ctx context.Context, store crdt.Store) *MemorySyncer {
 	return &MemorySyncer{
-		log:   log,
+		log:   ctx.Logger(),
 		store: store,
 	}
 }

--- a/pkg/crdt/syncers/mem/syncer_test.go
+++ b/pkg/crdt/syncers/mem/syncer_test.go
@@ -1,7 +1,6 @@
 package memsyncer_test
 
 import (
-	"context"
 	"testing"
 
 	memstore "github.com/xmtp/xmtpd/pkg/crdt/stores/mem"
@@ -12,10 +11,9 @@ import (
 
 func TestMemorySyncer(t *testing.T) {
 	crdttest.RunSyncerTests(t, func(t *testing.T) *crdttest.TestSyncer {
-		ctx := context.Background()
-		log := test.NewLogger(t)
-		store := memstore.New(log)
-		syncer := memsyncer.New(log, store)
-		return crdttest.NewTestSyncer(ctx, log, syncer)
+		ctx := test.NewContext(t)
+		store := memstore.New(ctx)
+		syncer := memsyncer.New(ctx, store)
+		return crdttest.NewTestSyncer(ctx, syncer)
 	})
 }

--- a/pkg/crdt/testing/broadcaster.go
+++ b/pkg/crdt/testing/broadcaster.go
@@ -1,14 +1,13 @@
 package crdttest
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
-	"github.com/xmtp/xmtpd/pkg/zap"
 )
 
 type ITestBroadcaster interface {
@@ -21,17 +20,13 @@ type TestBroadcasterMaker func(t *testing.T) *TestBroadcaster
 
 type TestBroadcaster struct {
 	ITestBroadcaster
-
 	ctx context.Context
-	log *zap.Logger
 }
 
-func NewTestBroadcaster(ctx context.Context, log *zap.Logger, bc ITestBroadcaster) *TestBroadcaster {
+func NewTestBroadcaster(ctx context.Context, bc ITestBroadcaster) *TestBroadcaster {
 	return &TestBroadcaster{
 		ITestBroadcaster: bc,
-
-		ctx: ctx,
-		log: log,
+		ctx:              ctx,
 	}
 }
 
@@ -74,8 +69,8 @@ func (b *TestBroadcaster) broadcastRandom(t *testing.T, count int) []*types.Even
 
 func (b *TestBroadcaster) next(t *testing.T) *types.Event {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(b.ctx, time.Second)
-	defer cancel()
+	ctx := context.WithTimeout(b.ctx, time.Second)
+	defer ctx.Close()
 	ev, err := b.Next(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, ev)

--- a/pkg/crdt/testing/store.go
+++ b/pkg/crdt/testing/store.go
@@ -1,7 +1,6 @@
 package crdttest
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -9,11 +8,11 @@ import (
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	test "github.com/xmtp/xmtpd/pkg/testing"
 	"github.com/xmtp/xmtpd/pkg/utils"
-	"github.com/xmtp/xmtpd/pkg/zap"
 )
 
 type ITestStore interface {
@@ -21,23 +20,21 @@ type ITestStore interface {
 
 	Events(context.Context) ([]*types.Event, error)
 	Heads(context.Context) ([]multihash.Multihash, error)
+
+	Close() error
 }
 
 type TestStoreMaker func(t *testing.T) *TestStore
 
 type TestStore struct {
 	ITestStore
-
-	log *zap.Logger
 	ctx context.Context
 }
 
-func NewTestStore(ctx context.Context, log *zap.Logger, store ITestStore) *TestStore {
+func NewTestStore(ctx context.Context, store ITestStore) *TestStore {
 	return &TestStore{
 		ITestStore: store,
-
-		log: log,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
@@ -684,7 +681,7 @@ func (s *TestStore) requireNoEvents(t *testing.T) {
 
 func (s *TestStore) seed(t *testing.T, topic string, count int) []*types.Event {
 	t.Helper()
-	ctx := context.Background()
+	ctx := test.NewContext(t)
 	events := make([]*types.Event, count)
 	for i := 0; i < count; i++ {
 		ev, err := s.AppendEvent(ctx, &messagev1.Envelope{
@@ -700,7 +697,7 @@ func (s *TestStore) seed(t *testing.T, topic string, count int) []*types.Event {
 
 func (s *TestStore) query(t *testing.T, req *messagev1.QueryRequest) (*messagev1.QueryResponse, error) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := test.NewContext(t)
 	return s.Query(ctx, req)
 }
 

--- a/pkg/crdt/testing/syncer.go
+++ b/pkg/crdt/testing/syncer.go
@@ -1,14 +1,13 @@
 package crdttest
 
 import (
-	"context"
 	"testing"
 
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
-	"github.com/xmtp/xmtpd/pkg/zap"
 )
 
 type ITestSyncer interface {
@@ -22,17 +21,13 @@ type TestSyncerMaker func(t *testing.T) *TestSyncer
 
 type TestSyncer struct {
 	ITestSyncer
-
 	ctx context.Context
-	log *zap.Logger
 }
 
-func NewTestSyncer(ctx context.Context, log *zap.Logger, bc ITestSyncer) *TestSyncer {
+func NewTestSyncer(ctx context.Context, bc ITestSyncer) *TestSyncer {
 	return &TestSyncer{
 		ITestSyncer: bc,
-
-		ctx: ctx,
-		log: log,
+		ctx:         ctx,
 	}
 }
 

--- a/pkg/node/broadcaster.go
+++ b/pkg/node/broadcaster.go
@@ -1,9 +1,8 @@
 package node
 
 import (
-	"context"
-
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 )
 

--- a/pkg/node/network_test.go
+++ b/pkg/node/network_test.go
@@ -1,15 +1,12 @@
 package node_test
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
 
 	proto "github.com/xmtp/proto/v3/go/message_api/v1"
-	test "github.com/xmtp/xmtpd/pkg/testing"
-	"github.com/xmtp/xmtpd/pkg/zap"
 )
 
 func TestNetwork(t *testing.T) {
@@ -23,19 +20,11 @@ func TestNetwork(t *testing.T) {
 }
 
 type testNetwork struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	log    *zap.Logger
-
 	nodes []*testNode
 }
 
 func newTestNetwork(t *testing.T, count int) *testNetwork {
 	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	log := test.NewLogger(t)
-
 	nodes := make([]*testNode, count)
 	for i := 0; i < count; i++ {
 		nodes[i] = newTestNodeWithName(t, fmt.Sprintf("node%d", i+1))
@@ -63,10 +52,6 @@ func newTestNetwork(t *testing.T, count int) *testNetwork {
 	wg.Wait()
 
 	return &testNetwork{
-		ctx:    ctx,
-		cancel: cancel,
-		log:    log,
-
 		nodes: nodes,
 	}
 }

--- a/pkg/node/otel.go
+++ b/pkg/node/otel.go
@@ -1,10 +1,10 @@
 package node
 
 import (
-	"context"
 	"fmt"
 	"time"
 
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/zap"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
@@ -34,10 +34,10 @@ type openTelemetry struct {
 	metricsProvider *sdkmetric.MeterProvider
 }
 
-func newOpenTelemetry(ctx context.Context, log *zap.Logger, opts *OpenTelemetryOptions) (*openTelemetry, error) {
+func newOpenTelemetry(ctx context.Context, opts *OpenTelemetryOptions) (*openTelemetry, error) {
 	ot := &openTelemetry{
 		ctx: ctx,
-		log: log.Named("otel"),
+		log: ctx.Logger().Named("otel"),
 	}
 	collectorEndpoint := fmt.Sprintf("%s:%d", opts.CollectorAddress, opts.CollectorPort)
 

--- a/pkg/store/bolt/bench_test.go
+++ b/pkg/store/bolt/bench_test.go
@@ -1,12 +1,12 @@
 package bolt
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	test "github.com/xmtp/xmtpd/pkg/testing"
 )
 
@@ -18,9 +18,8 @@ import (
 */
 
 func BenchmarkQuery(b *testing.B) {
-	ctx := context.Background()
-	log := test.NewLogger(b)
-	store := newTestNodeStore(b, log)
+	ctx := test.NewContext(b)
+	store := newTestNodeStore(b, ctx)
 	defer store.Close()
 	topic := newTestStore(b, "topic", store)
 	defer topic.Close()

--- a/pkg/store/bolt/query.go
+++ b/pkg/store/bolt/query.go
@@ -2,9 +2,9 @@ package bolt
 
 import (
 	"bytes"
-	"context"
 
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	bolt "go.etcd.io/bbolt"
 )

--- a/pkg/store/bolt/store.go
+++ b/pkg/store/bolt/store.go
@@ -1,11 +1,11 @@
 package bolt
 
 import (
-	"context"
 	"errors"
 
 	"github.com/multiformats/go-multihash"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/zap"
 	bolt "go.etcd.io/bbolt"
@@ -25,6 +25,14 @@ type Store struct {
 	name []byte
 	db   *bolt.DB
 	log  *zap.Logger
+}
+
+func New(ctx context.Context, db *bolt.DB, topic string) *Store {
+	return &Store{
+		name: []byte(topic),
+		db:   db,
+		log:  ctx.Logger().With(zap.String("topic", topic)),
+	}
 }
 
 func (s *Store) InsertEvent(ctx context.Context, ev *types.Event) (added bool, err error) {
@@ -191,8 +199,6 @@ func (s *Store) NewCursor(ev *types.Event) *messagev1.Cursor {
 		},
 	}
 }
-
-func (s *Store) Close() error { return nil }
 
 // private functions
 

--- a/pkg/store/mem/node_store.go
+++ b/pkg/store/mem/node_store.go
@@ -1,21 +1,21 @@
 package memstore
 
 import (
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
 	memstore "github.com/xmtp/xmtpd/pkg/crdt/stores/mem"
-	"github.com/xmtp/xmtpd/pkg/zap"
 )
 
 type NodeStore struct {
-	log *zap.Logger
+	ctx context.Context
 }
 
-func NewNodeStore(log *zap.Logger) *NodeStore {
-	return &NodeStore{log}
+func NewNodeStore(ctx context.Context) *NodeStore {
+	return &NodeStore{ctx}
 }
 
 func (n *NodeStore) NewTopic(topic string) (crdt.Store, error) {
-	return memstore.New(n.log), nil
+	return memstore.New(n.ctx), nil
 }
 
 func (n *NodeStore) Close() error {

--- a/pkg/store/postgres/db.go
+++ b/pkg/store/postgres/db.go
@@ -13,8 +13,8 @@ type DB struct {
 	DSN string
 }
 
-func NewDB(dsn string) (*DB, error) {
-	db, err := otelsql.Open("pgx", dsn,
+func NewDB(opts *Options) (*DB, error) {
+	db, err := otelsql.Open("pgx", opts.DSN,
 		otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
 		otelsql.WithDBName("xmtpd"),
 	)
@@ -23,6 +23,6 @@ func NewDB(dsn string) (*DB, error) {
 	}
 	return &DB{
 		DB:  db,
-		DSN: dsn,
+		DSN: opts.DSN,
 	}, nil
 }

--- a/pkg/store/postgres/node_store.go
+++ b/pkg/store/postgres/node_store.go
@@ -1,19 +1,19 @@
 package postgresstore
 
 import (
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
 	"github.com/xmtp/xmtpd/pkg/store/postgres/migrations"
-	"github.com/xmtp/xmtpd/pkg/zap"
 )
 
 type NodeStore struct {
-	log *zap.Logger
+	ctx context.Context
 	db  *DB
 }
 
-func NewNodeStore(log *zap.Logger, db *DB) (*NodeStore, error) {
+func NewNodeStore(ctx context.Context, db *DB) (*NodeStore, error) {
 	s := &NodeStore{
-		log: log.Named("pgstore"),
+		ctx: context.WithLogger(ctx, ctx.Logger().Named("pgstore")),
 		db:  db,
 	}
 
@@ -30,5 +30,5 @@ func (s *NodeStore) Close() error {
 }
 
 func (s *NodeStore) NewTopic(topic string) (crdt.Store, error) {
-	return New(s.log, s.db, topic), nil
+	return New(s.ctx, s.db, topic), nil
 }

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -1,7 +1,6 @@
 package postgresstore
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -11,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/multiformats/go-multihash"
 	messagev1 "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt/types"
 	"github.com/xmtp/xmtpd/pkg/zap"
 )
@@ -28,17 +28,12 @@ type Store struct {
 	topic string
 }
 
-func New(log *zap.Logger, db *DB, topic string) *Store {
+func New(ctx context.Context, db *DB, topic string) *Store {
 	return &Store{
-		log: log.With(zap.String("topic", topic)),
-
+		log:   ctx.Logger().With(zap.String("topic", topic)),
 		db:    db,
 		topic: topic,
 	}
-}
-
-func (s *Store) Close() error {
-	return nil
 }
 
 func (s *Store) InsertEvent(ctx context.Context, ev *types.Event) (bool, error) {

--- a/pkg/testing/context.go
+++ b/pkg/testing/context.go
@@ -1,0 +1,11 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/xmtp/xmtpd/pkg/context"
+)
+
+func NewContext(t testing.TB) context.Context {
+	return context.New(context.Background(), NewLogger(t))
+}


### PR DESCRIPTION
The key change here is coordinating the shutdown of the crdt.Replica goroutines with the the Node shutdown. Without this the goroutines will potentially attempt to access the store or other infrastructure bits that are already closed and potentially blow up. This approach was already tested on the old bolt branch so any concerns of coordinating 10s or 100s of thousands of these goroutines should be alleviated. We haven't ported the large network tests yet, but this wasn't a problem on the old branch so I'm fairly confident about this.

Another part is rearranging the Node.Close() sequence into what should be the proper order of shutting things down. I tried to deliniate the various stages with comments, but am far from sure what's in this PR is the final version. More consideration is likely warranted.

Somewhat orthogonal cleanup is the removal of the crdt.Store.Close() function from the interface, it was doing nothing across all stores we have today, so I decided to nix it at least for now. That allowed getting rid of Node.topicStores as well. I did have to adjust crdt.TestStore to properly close the underlying store in the RunStore test suites.

More comments inline