### PR TITLE
store benchmark fixes

### DIFF
--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -2,6 +2,17 @@ package api
 
 import proto "github.com/xmtp/proto/v3/go/message_api/v1"
 
+func NewQuery(topic string, modifiers ...QueryModifier) *proto.QueryRequest {
+	q := &proto.QueryRequest{}
+	if topic != "" {
+		q.ContentTopics = []string{topic}
+	}
+	for _, m := range modifiers {
+		m(q)
+	}
+	return q
+}
+
 // QueryModifiers are handy for building more complex queries.
 type QueryModifier func(*proto.QueryRequest)
 
@@ -46,7 +57,7 @@ func Ascending() QueryModifier {
 // Set cursor from previous response if present
 func Cursor(resp *proto.QueryResponse) QueryModifier {
 	return func(q *proto.QueryRequest) {
-		if resp.PagingInfo == nil || resp.PagingInfo.Cursor == nil {
+		if resp == nil || resp.PagingInfo == nil || resp.PagingInfo.Cursor == nil {
 			return
 		}
 		withPagingInfo(q, func(pi *proto.PagingInfo) {

--- a/pkg/crdt/testing/store.go
+++ b/pkg/crdt/testing/store.go
@@ -150,10 +150,7 @@ func (s *TestStore) Seed(t testing.TB, topic string, count int) []*types.Event {
 func (s *TestStore) query(t *testing.T, topic string, modifiers ...api.QueryModifier) *messagev1.QueryResponse {
 	t.Helper()
 	ctx := test.NewContext(t)
-	req := &messagev1.QueryRequest{ContentTopics: []string{topic}}
-	for _, m := range modifiers {
-		m(req)
-	}
+	req := api.NewQuery(topic, modifiers...)
 	res, err := s.Query(ctx, req)
 	require.NoError(t, err)
 	return res


### PR DESCRIPTION
There were few more fixes needed to be able to finally run the query benchmarks on both bolt and postgres (I actually broke the benchmark with the previous query cleanup PR).

This is somewhat of an apples and oranges comparison given how vastly different the two configurations are (in-memory db vs external db accessed over the network), but the magnitude of the difference is interesting I think. In the worst case of small pages of 10 envelopes it's (155000 vs 35 ms), in the more reasonable 1000 envelope page case it's (1600 vs 17 ms).

I don't think this makes an argument for not using something like Aurora for large nodes, but it may make bolt an attractive option for smaller nodes after decentralization.

```
% go test -bench=. -run=XXX ./pkg/store/postgres
goos: darwin
goarch: arm64
pkg: github.com/xmtp/xmtpd/pkg/store/postgres
BenchmarkQuery/1000/10000/10-10                        1        9499304958 ns/op
BenchmarkQuery/1000/99000/10-10                        1        155083202000 ns/op
BenchmarkQuery/1000/10000/100-10                       1        1131195583 ns/op
BenchmarkQuery/1000/99000/100-10                       1        15488247083 ns/op
BenchmarkQuery/1000/10000/1000-10                      9         116020875 ns/op
BenchmarkQuery/1000/99000/1000-10                      1        1656606791 ns/op
PASS
ok      github.com/xmtp/xmtpd/pkg/store/postgres        227.952s
```
```
% go test -bench=. -run=XXX ./pkg/store/bolt    
goos: darwin
goarch: arm64
pkg: github.com/xmtp/xmtpd/pkg/store/bolt
BenchmarkQuery/1000/10000/10-10                      376           3167527 ns/op
BenchmarkQuery/1000/99000/10-10                       31          35799594 ns/op
BenchmarkQuery/1000/10000/100-10                     716           1694066 ns/op
BenchmarkQuery/1000/99000/100-10                      66          19445218 ns/op
BenchmarkQuery/1000/10000/1000-10                    792           1514174 ns/op
BenchmarkQuery/1000/99000/1000-10                     75          17392713 ns/op
PASS
ok      github.com/xmtp/xmtpd/pkg/store/bolt    12.399s

```