### PR TITLE
network tests

### DIFF
--- a/pkg/node/network_test.go
+++ b/pkg/node/network_test.go
@@ -10,7 +10,7 @@ func TestNetwork(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow under race detector")
 	}
-	net := ntest.NewTestNetwork(t, 3)
+	net := ntest.NewNetwork(t, 3)
 	defer net.Close()
 
 	sub := net.Subscribe(t, "topic1")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -309,6 +309,7 @@ func (n *Node) Subscribe(req *messagev1.SubscribeRequest, stream messagev1.Messa
 }
 
 func (n *Node) Query(gctx gocontext.Context, req *messagev1.QueryRequest) (*messagev1.QueryResponse, error) {
+	n.log.Debug("query", zap.Strings("topics", req.ContentTopics))
 	if len(req.ContentTopics) == 0 {
 		return nil, ErrMissingTopic
 	} else if len(req.ContentTopics) > 1 {
@@ -336,6 +337,7 @@ func (n *Node) SubscribeAll(req *messagev1.SubscribeAllRequest, stream messagev1
 }
 
 func (n *Node) BatchQuery(gctx gocontext.Context, req *messagev1.BatchQueryRequest) (*messagev1.BatchQueryResponse, error) {
+	n.log.Debug("batch query", zap.Int("req-count", len(req.Requests)))
 	res := &messagev1.BatchQueryResponse{}
 	var mu sync.Mutex
 	g, ctx := errgroup.WithContext(gctx)
@@ -360,6 +362,7 @@ func (n *Node) BatchQuery(gctx gocontext.Context, req *messagev1.BatchQueryReque
 }
 
 func (n *Node) getOrCreateTopic(topic string) (*crdt.Replica, error) {
+	n.log.Debug("getting or creating topic", zap.String("topic", topic))
 	n.topicsLock.Lock()
 	defer n.topicsLock.Unlock()
 	if replica, ok := n.topics[topic]; ok {

--- a/pkg/node/syncer.go
+++ b/pkg/node/syncer.go
@@ -34,7 +34,7 @@ type syncer struct {
 
 func (n *Node) setSyncHandler() {
 	n.host.SetStreamHandler(syncProtocol, func(s network.Stream) {
-		log := n.ctx.Logger()
+		log := n.ctx.Logger().Named("syncHandler")
 		failed := func(msg string, err error) bool {
 			if err == nil {
 				return false

--- a/pkg/node/testing/network.go
+++ b/pkg/node/testing/network.go
@@ -1,86 +1,271 @@
 package testing
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	proto "github.com/xmtp/proto/v3/go/message_api/v1"
+	"github.com/xmtp/xmtpd/pkg/context"
+	"github.com/xmtp/xmtpd/pkg/node"
+	memstore "github.com/xmtp/xmtpd/pkg/store/mem"
+	test "github.com/xmtp/xmtpd/pkg/testing"
 )
 
-type testNetwork struct {
-	nodes []*testNode
+type storeMaker func(t testing.TB, ctx context.Context) node.NodeStore
+
+type networkOption func(n *network)
+
+func WithStoreMaker(sm storeMaker) networkOption {
+	return func(n *network) {
+		n.storeMaker = sm
+	}
 }
 
-func NewTestNetwork(t *testing.T, count int) *testNetwork {
+type envsByTopic map[string][]*proto.Envelope
+
+type network struct {
+	ctx        context.Context
+	storeMaker storeMaker
+	nodes      []*testNode
+}
+
+func NewNetwork(t *testing.T, count int, opts ...networkOption) *network {
 	t.Helper()
+	n := &network{
+		ctx:        test.NewContext(t),
+		storeMaker: func(t testing.TB, ctx context.Context) node.NodeStore { return memstore.NewNodeStore(ctx) },
+	}
+	for _, opt := range opts {
+		opt(n)
+	}
 	nodes := make([]*testNode, count)
 	for i := 0; i < count; i++ {
-		nodes[i] = NewNode(t, WithName(fmt.Sprintf("node%d", i+1)))
+		name := fmt.Sprintf("node%d", i+1)
+		nodes[i] = NewNode(t,
+			WithContext(n.ctx),
+			WithName(name),
+			WithStore(n.storeMaker(t, context.WithLogger(n.ctx, n.ctx.Logger().Named(name)))))
 	}
 
 	var wg sync.WaitGroup
-	for _, a := range nodes {
-		a := a
-		for _, b := range nodes {
-			b := b
+	for i, a := range nodes {
+		for _, b := range nodes[i:] {
 			if a == b {
 				continue
 			}
 			wg.Add(1)
-			go func() {
+			go func(a, b *testNode) {
 				defer wg.Done()
 				a.Connect(t, b)
-			}()
+			}(a, b)
 		}
 	}
 	wg.Wait()
-
-	return &testNetwork{
-		nodes: nodes,
-	}
+	n.nodes = nodes
+	return n
 }
 
-func (net *testNetwork) Close() error {
+func (net *network) Close() error {
 	for _, node := range net.nodes {
 		node.Close()
 	}
 	return nil
 }
 
-func (net *testNetwork) PublishRandom(t *testing.T, topic string, count int) []*proto.Envelope {
+func (net *network) PublishRandom(t *testing.T, topic string, count int) []*proto.Envelope {
 	t.Helper()
 	node := net.nodes[rand.Intn(len(net.nodes))]
 	return node.PublishRandom(t, topic, count)
 }
 
-func (net *testNetwork) RequireEventuallyStoredEvents(t *testing.T, topic string, expected []*proto.Envelope) {
+func (net *network) RequireEventuallyStoredEvents(t *testing.T, topic string, expected []*proto.Envelope) {
 	for _, node := range net.nodes {
 		node.RequireEventuallyStoredEvents(t, topic, expected)
 	}
 }
 
-type testNetworkSubscriber struct {
+type networkSubscriber struct {
 	Topic string
 	subs  []*testSubscriber
 }
 
-func (net *testNetwork) Subscribe(t *testing.T, topic string) *testNetworkSubscriber {
+func (net *network) Subscribe(t *testing.T, topic string) *networkSubscriber {
 	t.Helper()
 	subs := make([]*testSubscriber, len(net.nodes))
 	for i, node := range net.nodes {
 		subs[i] = node.Subscribe(t, topic)
 	}
-	return &testNetworkSubscriber{
+	return &networkSubscriber{
 		Topic: topic,
 		subs:  subs,
 	}
 }
 
-func (s *testNetworkSubscriber) RequireEventuallyCapturedEvents(t *testing.T, expected []*proto.Envelope) {
+func (s *networkSubscriber) RequireEventuallyCapturedEvents(t *testing.T, expected []*proto.Envelope) {
 	t.Helper()
 	for _, sub := range s.subs {
 		sub.RequireEventuallyCapturedEvents(t, expected)
 	}
+}
+
+// map of missing envelopes by topic for each node
+type missingEnvs []map[string][]int
+
+func (me missingEnvs) String() string {
+	var buf bytes.Buffer
+	for n, node := range me {
+		for topic, envs := range node {
+			if len(envs) > 0 {
+				fmt.Fprintf(&buf, "n%d/%s: %v\n", n, topic, envs)
+			}
+		}
+	}
+	return buf.String()
+}
+
+type convergenceTracker struct {
+	net       *network
+	envelopes envsByTopic
+	envCount  int
+}
+
+func newConvergenceTracker(net *network) *convergenceTracker {
+	return &convergenceTracker{
+		net:       net,
+		envelopes: make(envsByTopic),
+	}
+}
+
+func (tr *convergenceTracker) Publish(t *testing.T, node int, topic, msg string) {
+	t.Helper()
+	n := tr.net.nodes[node]
+	assert.NotNil(t, n)
+	tr.envCount++
+	env := &proto.Envelope{
+		TimestampNs:  uint64(tr.envCount),
+		ContentTopic: topic,
+		Message:      []byte(msg),
+	}
+	_, err := n.Publish(tr.net.ctx, &proto.PublishRequest{Envelopes: []*proto.Envelope{env}})
+	assert.NoError(t, err)
+	tr.envelopes[topic] = append(tr.envelopes[topic], env)
+}
+
+func (tr *convergenceTracker) newMissingEnvs() missingEnvs {
+	nodes := make(missingEnvs, 0, len(tr.net.nodes))
+	for range tr.net.nodes {
+		missing := make(map[string][]int)
+		for topic, envs := range tr.envelopes {
+			ids := make([]int, 0, len(envs))
+			for _, env := range envs {
+				ids = append(ids, int(env.TimestampNs))
+			}
+			missing[topic] = ids
+		}
+		nodes = append(nodes, missing)
+	}
+	return nodes
+}
+
+// Wait for all the network nodes to converge on the captured set of events.
+func (tr *convergenceTracker) RequireEventuallyComplete(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	missing := tr.newMissingEnvs()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-timer.C:
+			missing, _ := tr.checkEvents(t, missing)
+			if missing != nil {
+				t.Errorf("missing events:\n%s", missing)
+			}
+			t.Log("converged")
+			return
+		case <-ticker.C:
+			var progress bool
+			missing, progress = tr.checkEvents(t, missing)
+			if missing == nil {
+				t.Log("converged")
+				return
+			}
+			if !progress {
+				t.Errorf("progress stopped:\n%s", missing)
+				return
+			}
+			t.Logf("progress made:\n%s", missing)
+		}
+	}
+}
+
+// Check the remaining missing envelopes across all nodes.
+// Return updated missing envelopes map.
+// Return nil if nothing is missing.
+func (tr *convergenceTracker) checkEvents(t *testing.T, missing missingEnvs) (remaining missingEnvs, progress bool) {
+	anyMissing, progress := false, false
+	for ni, nodeMissing := range missing {
+		node := tr.net.nodes[ni]
+		for topic, topicMissing := range nodeMissing {
+			topicAll := tr.envelopes[topic]
+			topicPresent := node.RequireQuery(t, topic)
+			if len(topicAll) == len(topicPresent) {
+				progress = true
+				delete(nodeMissing, topic)
+				continue
+			}
+			anyMissing = true
+			topicRemaining := subtractEnvs(topicAll, topicPresent)
+			if len(topicRemaining) < len(topicMissing) {
+				progress = true
+			}
+			nodeMissing[topic] = topicRemaining
+		}
+	}
+	if anyMissing {
+		return missing, progress
+	}
+	return nil, true
+}
+
+func subtractEnvs(a, b []*proto.Envelope) []int {
+	remaining := make([]int, 0)
+OUTER:
+	for _, env := range a {
+		for _, env2 := range b {
+			if env.TimestampNs == env2.TimestampNs {
+				continue OUTER
+			}
+		}
+		remaining = append(remaining, int(env.TimestampNs))
+	}
+	return remaining
+}
+
+func RandomNodeAndTopicSpraying(t *testing.T, nodes, topics, messages int, opts ...networkOption) {
+	// to emulate significant concurrent activity we want nodes to be adding
+	// events concurrently, but we also want to allow propagation at the same time.
+	// So we need to introduce short delays to allow the network make some propagation progress.
+	// Given the random spraying approach injecting a delay at every (nodes*topics)th event
+	// should allow most nodes inject an event to most topics, and then the random length of the delay
+	// should allow some amount of propagation to happen before the next burst.
+	delayEvery := nodes * topics
+	net := NewNetwork(t, nodes, opts...)
+	defer net.Close()
+	tracker := newConvergenceTracker(net)
+	for i := 0; i < messages; i++ {
+		topic := fmt.Sprintf("t%d", rand.Intn(topics))
+		msg := fmt.Sprintf("gm %d", i)
+		tracker.Publish(t, rand.Intn(nodes), topic, msg)
+		if i%delayEvery == 0 {
+			time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+		}
+	}
+	tracker.RequireEventuallyComplete(t, time.Duration(nodes*messages/100)*time.Second)
 }

--- a/pkg/node/testing/store.go
+++ b/pkg/node/testing/store.go
@@ -37,9 +37,8 @@ func TestTopicBootstrap(t *testing.T, storeMaker func(t *testing.T, ctx context.
 		WithStore(store),
 	)
 	for i, topic := range topics {
-		resp, err := node.Query(ctx, &v1.QueryRequest{ContentTopics: []string{topic}})
-		require.NoError(t, err)
-		require.Len(t, resp.Envelopes, i+1)
+		envs := node.RequireQuery(t, topic)
+		require.Len(t, envs, i+1)
 	}
 	node.Close()
 }

--- a/pkg/store/bolt/network_test.go
+++ b/pkg/store/bolt/network_test.go
@@ -1,0 +1,35 @@
+package bolt_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xmtp/xmtpd/pkg/context"
+	"github.com/xmtp/xmtpd/pkg/node"
+	ntest "github.com/xmtp/xmtpd/pkg/node/testing"
+)
+
+func Test_RandomNodeAndTopicSpraying(t *testing.T) {
+	tcs := []struct {
+		nodes    int
+		topics   int
+		messages int
+	}{
+		{3, 10, 300},
+		{5, 3, 100},
+		// TODO: 10 nodes are failing due to the WaitForConnect failures,
+		// even though the test continues regardless and succeeds.
+		// {10, 5, 100},
+	}
+	for i, tc := range tcs {
+		tc := tc
+		name := fmt.Sprintf("%d/%dn/%dt/%dm", i, tc.nodes, tc.topics, tc.messages)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ntest.RandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages,
+				ntest.WithStoreMaker(func(t testing.TB, ctx context.Context) node.NodeStore {
+					return newTestNodeStore(t, ctx)
+				}))
+		})
+	}
+}

--- a/pkg/store/bolt/node_store.go
+++ b/pkg/store/bolt/node_store.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/xmtp/xmtpd/pkg/context"
 	"github.com/xmtp/xmtpd/pkg/crdt"
+	"github.com/xmtp/xmtpd/pkg/zap"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -27,6 +28,7 @@ type NodeStore struct {
 }
 
 func NewNodeStore(ctx context.Context, db *bolt.DB, opts *Options) (*NodeStore, error) {
+	ctx.Logger().Info("opening db", zap.String("path", db.Path()))
 	if err := db.Update(func(tx *bolt.Tx) error {
 		var err error
 		meta := tx.Bucket(MetaBucket)

--- a/pkg/store/bolt/store_test.go
+++ b/pkg/store/bolt/store_test.go
@@ -31,8 +31,9 @@ func (s *testStore) Close() error {
 }
 
 func newTestNodeStore(t testing.TB, ctx context.Context) *testNodeStore {
+	fn := "test_" + test.RandomStringLower(13) + ".bolt"
 	opts := &bolt.Options{
-		DataPath: filepath.Join(t.TempDir(), "testdb.bolt"),
+		DataPath: filepath.Join(t.TempDir(), fn),
 	}
 	db, err := bolt.NewDB(opts)
 	require.NoError(t, err)

--- a/pkg/store/mem/network_test.go
+++ b/pkg/store/mem/network_test.go
@@ -1,0 +1,29 @@
+package memstore_test
+
+import (
+	"fmt"
+	"testing"
+
+	ntest "github.com/xmtp/xmtpd/pkg/node/testing"
+)
+
+func Test_RandomNodeAndTopicSpraying(t *testing.T) {
+	tcs := []struct {
+		nodes    int
+		topics   int
+		messages int
+	}{
+		// TODO: these are failing to make progress for some reason, especially in CI.
+		// {3, 10, 300},
+		// {5, 3, 100},
+		// {10, 5, 100},
+	}
+	for i, tc := range tcs {
+		tc := tc
+		name := fmt.Sprintf("%d/%dn/%dt/%dm", i, tc.nodes, tc.topics, tc.messages)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ntest.RandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages)
+		})
+	}
+}

--- a/pkg/store/postgres/network_test.go
+++ b/pkg/store/postgres/network_test.go
@@ -1,0 +1,39 @@
+package postgresstore_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/context"
+	"github.com/xmtp/xmtpd/pkg/node"
+	ntest "github.com/xmtp/xmtpd/pkg/node/testing"
+	postgresstore "github.com/xmtp/xmtpd/pkg/store/postgres"
+)
+
+func Test_RandomNodeAndTopicSpraying(t *testing.T) {
+	tcs := []struct {
+		nodes    int
+		topics   int
+		messages int
+	}{
+		{3, 10, 300},
+		{5, 3, 100},
+		{10, 5, 100},
+	}
+	for i, tc := range tcs {
+		tc := tc
+		name := fmt.Sprintf("%d/%dn/%dt/%dm", i, tc.nodes, tc.topics, tc.messages)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			db, cleanup := newTestDB(t)
+			defer cleanup()
+			ntest.RandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages,
+				ntest.WithStoreMaker(func(t testing.TB, ctx context.Context) node.NodeStore {
+					store, err := postgresstore.NewNodeStore(ctx, db)
+					require.NoError(t, err)
+					return store
+				}))
+		})
+	}
+}


### PR DESCRIPTION
This PR ressurects the network tests. The "network" is a set of nodes running in the same go process making it easier to write tests and debug certain types of scenarios. This PR adds network tests for the three types of store mem, bolt, postgres. Few fixes are highlighted below and inline. There were also some surprising discoveries along the way.

* slow writes can back up replica channels; this showed up especially with bolt.
* when the channels are backed up, closing a node could hang as the goroutines weren't paying attention to context.Done when writing back into the channels (fixed in this PR)
* bolt writes are a lot slower than postgres, this PR swiches to using db.Batch instead of db.Update which opportunistically combines multiple writes into larger transactions https://github.com/boltdb/bolt#batch-read-write-transactions. This helped a fair bit.
* mem store is failing the network tests badly. It's not clear why yet, but basically the nodes stop making progress towards the final state for some reason. More investigation is needed there.
