### PR TITLE
Fix container build/publish in GH workflow

### DIFF
--- a/dev/docker/xmtpd/.env.default
+++ b/dev/docker/xmtpd/.env.default
@@ -1,1 +1,1 @@
-BUILD_CONTAINER_IMAGE=xmtpdev/xmtpd:dev
+BUILD_CONTAINER_IMAGE="${BUILD_CONTAINER_IMAGE:-xmtpdev/xmtpd:dev}"


### PR DESCRIPTION
The publish.yaml GH workflow is currently failing: https://github.com/xmtp/xmtpd/actions/runs/4447407144/jobs/7808914527

This PR allows for the `BUILD_CONTAINER_IMAGE` env variable to be overridden by the workflow, which is already set up to do.