### PR TITLE
tf: store_type

### DIFF
--- a/dev/net/k8s-env
+++ b/dev/net/k8s-env
@@ -1,8 +1,6 @@
 #!/bin/bash
-(
-    set -a; source .env.local; set +a
-)
 
+PLAN=$(source .env.local; echo "$PLAN")
 export KUBECONFIG="${PWD}/dev/terraform/plans/${PLAN}/.xmtp/kubeconfig.yaml"
 
 alias k=kubectl

--- a/dev/terraform/modules/cluster-nodes/_variables.tf
+++ b/dev/terraform/modules/cluster-nodes/_variables.tf
@@ -9,8 +9,7 @@ variable "nodes" {
     node_id                  = string
     p2p_public_address       = string
     p2p_persistent_peers     = list(string)
-    enable_postgres          = optional(bool, false)
-    enable_persistent_volume = optional(bool, false)
+    store_type               = optional(string, "mem")
   }))
 }
 variable "node_keys" {

--- a/dev/terraform/modules/cluster-nodes/main.tf
+++ b/dev/terraform/modules/cluster-nodes/main.tf
@@ -65,9 +65,8 @@ module "nodes_group1" {
   ingress_class_name        = var.ingress_class_name
   wait_for_ready            = var.wait_for_ready
   debug                     = var.debug
-  enable_postgres           = local.nodes_group1[count.index].enable_postgres
-  enable_persistent_volume  = local.nodes_group1[count.index].enable_persistent_volume
-}
+  store_type                = local.nodes_group1[count.index].store_type
+}              
 
 module "nodes_group2" {
   source     = "./node"
@@ -95,8 +94,7 @@ module "nodes_group2" {
   ingress_class_name        = var.ingress_class_name
   wait_for_ready            = var.wait_for_ready
   debug                     = var.debug
-  enable_postgres           = local.nodes_group2[count.index].enable_postgres
-  enable_persistent_volume  = local.nodes_group2[count.index].enable_persistent_volume
+  store_type                = local.nodes_group2[count.index].store_type
 }
 
 resource "kubernetes_service" "nodes_api" {

--- a/dev/terraform/modules/cluster-nodes/node/_variables.tf
+++ b/dev/terraform/modules/cluster-nodes/node/_variables.tf
@@ -17,7 +17,14 @@ variable "one_instance_per_k8s_node" { type = bool }
 variable "ingress_class_name" {}
 variable "wait_for_ready" { type = bool }
 variable "debug" { type = bool }
-variable "enable_postgres" { type = bool }
-variable "enable_persistent_volume" { type = bool }
+variable "store_type" {
+    type = string
+    description = "type of persistent store to use"
+    default = "mem"
+    validation {
+        condition = contains(["mem", "bolt", "postgres"], var.store_type)
+        error_message = "Recognized store types are mem, bolt or postgres"
+    }
+}
 variable "argocd_project" {}
 variable "argocd_namespace" {}

--- a/dev/terraform/modules/cluster-nodes/node/postgres.tf
+++ b/dev/terraform/modules/cluster-nodes/node/postgres.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 resource "argocd_application" "postgres" {
-  count = var.enable_postgres ? 1 : 0
+  count = var.store_type == "postgres" ? 1 : 0
   wait  = true
   metadata {
     name      = local.postgres_name
@@ -41,7 +41,7 @@ resource "argocd_application" "postgres" {
 }
 
 data "kubernetes_secret" "postgres" {
-  count      = var.enable_postgres ? 1 : 0
+  count      = var.store_type == "postgres" ? 1 : 0
   depends_on = [argocd_application.postgres]
   metadata {
     name      = "${local.postgres_name}-postgresql"

--- a/dev/terraform/plans/devnet-local/_variables.tf
+++ b/dev/terraform/plans/devnet-local/_variables.tf
@@ -6,8 +6,7 @@ variable "nodes" {
     node_id                  = string
     p2p_public_address       = string
     p2p_persistent_peers     = list(string)
-    enable_postgres          = optional(bool, false)
-    enable_persistent_volume = optional(bool, false)
+    store_type               = optional(string, "mem")
   }))
 }
 variable "node_keys" {

--- a/dev/terraform/plans/devnet-local/terraform.tfvars.json
+++ b/dev/terraform/plans/devnet-local/terraform.tfvars.json
@@ -9,7 +9,7 @@
         "/dns4/node2/tcp/9000/p2p/12D3KooWFfse73aHJGBkZpUVymoozyMXKmBH7f4Y6kKcp4rviTyY",
         "/dns4/node3/tcp/9000/p2p/12D3KooWQcjJL43hPyGHGQx3RCrQC2HLxVyvMUH8GoAL2pqR7wZv"
       ],
-      "enable_postgres": true
+      "store_type": "postgres"
     },
     {
       "name": "node2",
@@ -20,7 +20,7 @@
         "/dns4/node2/tcp/9000/p2p/12D3KooWFfse73aHJGBkZpUVymoozyMXKmBH7f4Y6kKcp4rviTyY",
         "/dns4/node3/tcp/9000/p2p/12D3KooWQcjJL43hPyGHGQx3RCrQC2HLxVyvMUH8GoAL2pqR7wZv"
       ],
-      "enable_persistent_volume": true
+      "store_type": "bolt"
     },
     {
       "name": "node3",


### PR DESCRIPTION
Replacing the `enable_postgres` and `enable_persistent_volume` flags with `store_type` (matching the xmtp option), since they are exclusive. There doesn't seem to be a native `enum` type for TF, so went with the recommended workaround.