### PR TITLE
Specify terraform provider versions

### DIFF
--- a/dev/net/up
+++ b/dev/net/up
@@ -9,5 +9,4 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
     if ! which tflint &>/dev/null; then brew install tflint; fi
 fi
 
-dev/terraform/tf init
 dev/terraform/apply "$@"

--- a/dev/terraform/modules/cluster-nodes/main.tf
+++ b/dev/terraform/modules/cluster-nodes/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source = "oboukili/argocd"
+      version = "4.3.0"
     }
   }
 }

--- a/dev/terraform/modules/cluster-nodes/node/main.tf
+++ b/dev/terraform/modules/cluster-nodes/node/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source = "oboukili/argocd"
+      version = "4.3.0"
     }
   }
 }

--- a/dev/terraform/modules/cluster-system/main.tf
+++ b/dev/terraform/modules/cluster-system/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source = "oboukili/argocd"
+      version = "4.3.0"
     }
   }
 }

--- a/dev/terraform/modules/cluster-tools/main.tf
+++ b/dev/terraform/modules/cluster-tools/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source = "oboukili/argocd"
+      version = "4.3.0"
     }
   }
 }

--- a/dev/terraform/modules/clusters/kind/main.tf
+++ b/dev/terraform/modules/clusters/kind/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     kind = {
       source = "tehcyx/kind"
+      version = "0.0.16"
     }
   }
 }

--- a/dev/terraform/plans/devnet-local/main.tf
+++ b/dev/terraform/plans/devnet-local/main.tf
@@ -2,6 +2,15 @@ terraform {
   required_providers {
     argocd = {
       source = "oboukili/argocd"
+      version = "4.3.0"
+    }
+    helm = {
+      source = "hashicorp/helm"
+      version = "2.9.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.18.1"
     }
   }
 }


### PR DESCRIPTION
Explicit versions on the terraform providers being used to avoid introducing breaking versions automatically, as is the case with https://github.com/oboukili/terraform-provider-argocd/releases/tag/v5.0.0