### PR TITLE
devnet spraying tests

### DIFF
--- a/pkg/node/testing/network_test.go
+++ b/pkg/node/testing/network_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/api/client"
+	test "github.com/xmtp/xmtpd/pkg/testing"
+)
+
+var (
+	devnet string
+)
+
+func init() {
+	flag.StringVar(&devnet, "devnet", "", "run devnet tests with given number of topics and messages, format topics/messages, e.g. 30/1000")
+}
+
+func Test_DevnetSpraying(t *testing.T) {
+	if len(devnet) == 0 {
+		return
+	}
+	var topics, messages int
+	n, err := fmt.Sscanf(devnet, "%d/%d", &topics, &messages)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	ctx := test.NewContext(t)
+	var clients []trackerNode
+	for _, n := range []string{"node1", "node2", "node3"} {
+		client := client.NewHTTPClient(ctx.Logger(),
+			"http://localhost", "test", n,
+			client.WithHeader("Host", n+".localhost"))
+		clients = append(clients, client)
+	}
+	tracker := newConvergenceTracker(ctx, clients)
+	tracker.runRandomNodeAndTopicSpraying(t, topics, messages, "-"+time.Now().Format("060102T150405"))
+}

--- a/pkg/store/bolt/network_test.go
+++ b/pkg/store/bolt/network_test.go
@@ -26,7 +26,7 @@ func Test_RandomNodeAndTopicSpraying(t *testing.T) {
 		name := fmt.Sprintf("%d/%dn/%dt/%dm", i, tc.nodes, tc.topics, tc.messages)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ntest.RandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages,
+			ntest.RunRandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages,
 				ntest.WithStoreMaker(func(t testing.TB, ctx context.Context) node.NodeStore {
 					return newTestNodeStore(t, ctx)
 				}))

--- a/pkg/store/mem/network_test.go
+++ b/pkg/store/mem/network_test.go
@@ -23,7 +23,7 @@ func Test_RandomNodeAndTopicSpraying(t *testing.T) {
 		name := fmt.Sprintf("%d/%dn/%dt/%dm", i, tc.nodes, tc.topics, tc.messages)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ntest.RandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages)
+			ntest.RunRandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages)
 		})
 	}
 }

--- a/pkg/store/postgres/network_test.go
+++ b/pkg/store/postgres/network_test.go
@@ -28,7 +28,7 @@ func Test_RandomNodeAndTopicSpraying(t *testing.T) {
 			t.Parallel()
 			db, cleanup := newTestDB(t)
 			defer cleanup()
-			ntest.RandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages,
+			ntest.RunRandomNodeAndTopicSpraying(t, tc.nodes, tc.topics, tc.messages,
 				ntest.WithStoreMaker(func(t testing.TB, ctx context.Context) node.NodeStore {
 					store, err := postgresstore.NewNodeStore(ctx, db)
 					require.NoError(t, err)


### PR DESCRIPTION
This PR generalizes the convergenceTracker to allow pointing it at the `devnet`. The run is packaged as `Test_DeventSpraying` that is enabled with `-devnet=topic/messages` option.

To be able to target the devnet nodes individually using the `nodeX.localhost`, I had to extend the httpClient to allow overriding the `Host` header, because go fails to resolve those domains. So you have to use plain `http://localhost` in the URL and pass the node specific domain as the Host header.

```
% go test -v -run Devnet ./pkg/node/testing -devnet=10/1000
=== RUN   Test_DevnetSpraying
    network.go:280: progress made:
        n0/t9-230322T093056: [844 856 860 889 902 904 916 929 985 991]
        n0/t3-230322T093056: [911 914 920 940 949 955 958 962 994]
        n0/t6-230322T093056: [905 913 922 923 938 946 947 952 982 988]
        n1/t9-230322T093056: [856 860 889 902 904 916 929 985 991]
        n1/t5-230322T093056: [974 977 989 997 1000]
        n2/t6-230322T093056: [905 913 922 923 938 946 947 952 982 988]
        n2/t1-230322T093056: [661 664 667 713 728 754 805 847 850 854 881 925 964 980 983]
    network.go:280: progress made:
        n0/t9-230322T093056: [889 902 904 916 929 985 991]
        n1/t9-230322T093056: [889 902 904 916 929 985 991]
    network.go:280: progress made:
        n0/t9-230322T093056: [889 902 904 916 929 985 991]
    network.go:280: converged
--- PASS: Test_DevnetSpraying (4.97s)
PASS
ok      github.com/xmtp/xmtpd/pkg/node/testing  5.302s
```