### PR TITLE
Enable uptrace on local devnet

### DIFF
--- a/dev/terraform/modules/cluster-tools/_variables.tf
+++ b/dev/terraform/modules/cluster-tools/_variables.tf
@@ -11,4 +11,5 @@ variable "chat_app_hostnames" { type = list(string) }
 variable "grafana_hostnames" { type = list(string) }
 variable "jaeger_hostnames" { type = list(string) }
 variable "prometheus_hostnames" { type = list(string) }
+variable "uptrace_hostnames" { type = list(string) }
 variable "public_api_url" {}

--- a/dev/terraform/modules/cluster-tools/otelcollector.tf
+++ b/dev/terraform/modules/cluster-tools/otelcollector.tf
@@ -37,6 +37,11 @@ module "argocd_app_otelcollector" {
             endpoint: "${local.jaeger_collector_endpoint}"
             tls:
               insecure: true
+          otlp/uptrace:
+            endpoint: "${local.uptrace_endpoint}"
+            tls:
+              insecure: true
+            headers: { 'uptrace-dsn': 'http://6789@uptrace:14317/2' }
           logging: {}
           prometheus:
             endpoint: "0.0.0.0:9464"
@@ -62,7 +67,7 @@ module "argocd_app_otelcollector" {
             metrics:
               receivers: [otlp, prometheus]
               processors: [transform, batch]
-              exporters: [prometheus, logging]
+              exporters: [prometheus, logging, otlp/uptrace]
     EOF
   ]
 }

--- a/dev/terraform/modules/cluster-tools/uptrace.tf
+++ b/dev/terraform/modules/cluster-tools/uptrace.tf
@@ -1,0 +1,46 @@
+locals {
+    uptrace_endpoint = "uptrace:14317"
+    uptrace_hosts = [
+      for name in var.uptrace_hostnames:
+      { host: name, paths: [ { path: "/", pathType: "Prefix" } ] }
+    ]
+}
+
+module "argocd_app_uptrace" {
+  count  = var.enable_monitoring ? 1 : 0
+  source = "../argocd-application"
+
+  argocd_namespace = var.argocd_namespace
+  argocd_project   = module.argocd_project.name
+  name             = "uptrace"
+  namespace        = var.namespace
+  wait             = var.wait_for_ready
+  repo_url         = "https://charts.uptrace.dev"
+  chart            = "uptrace"
+  target_revision  = "1.3.1"
+  helm_values = [
+    <<EOF
+      ingress:
+        enabled: true
+        hosts: ${jsonencode(local.uptrace_hosts)}
+      uptrace:
+        config:
+          projects:
+            - id: 1
+              name: uptrace
+              token: 12345
+              pinned_attrs:
+                - service
+                - host.name
+                - deployment.environment
+            - id: 2
+              name: devnet
+              token: 6789
+              pinned_attrs:
+                - service
+                - host.name
+          site:
+            addr: 'http:uptrace.localhost'
+    EOF
+  ]
+}

--- a/dev/terraform/plans/devnet-local/main.tf
+++ b/dev/terraform/plans/devnet-local/main.tf
@@ -22,6 +22,7 @@ locals {
   grafana_hostnames    = [for hostname in local.hostnames : "grafana.${hostname}"]
   jaeger_hostnames     = [for hostname in local.hostnames : "jaeger.${hostname}"]
   prometheus_hostnames = [for hostname in local.hostnames : "prometheus.${hostname}"]
+  uptrace_hostnames    = [for hostname in local.hostnames : "uptrace.${hostname}"]
 }
 
 module "cluster" {
@@ -81,6 +82,7 @@ module "tools" {
   grafana_hostnames    = local.grafana_hostnames
   jaeger_hostnames     = local.jaeger_hostnames
   prometheus_hostnames = local.prometheus_hostnames
+  uptrace_hostnames    = local.uptrace_hostnames
 }
 
 module "nodes" {


### PR DESCRIPTION
This doesn't quite work yet, the latest released version of the helm chart, 1.3.1, is missing https://github.com/uptrace/helm-charts/pull/7, which enables the grpc otlp port which is necessary to point the otel collector at uptrace (the http port doesn't seem to apply for go client).

I got it somewhat working by manually screwing around with the service and pod ports directly in the cluster, but things were still somewhat janky.