### PR TITLE
ci: run one-off e2e test in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,4 +22,4 @@ jobs:
           export TF_VAR_enable_e2e=false
           export TF_VAR_enable_chat_app=false
           dev/net/up
-      - run: curl localhost/healthz
+      - run: dev/e2e/run


### PR DESCRIPTION
Run the one-off `dev/e2e/run` test in the CI workflow instead of the placeholder curl.

https://github.com/xmtp/xmtpd/issues/58