### PR TITLE
Configure P2P resource limits and add resource metrics

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -87,9 +87,16 @@ func New(ctx context.Context, metrics *Metrics, store NodeStore, opts *Options) 
 	if err != nil {
 		return nil, err
 	}
+
+	rcm, err := p2pResourceManager(metrics)
+	if err != nil {
+		return nil, err
+	}
+
 	n.host, err = libp2p.New(
 		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", opts.P2P.Port)),
 		libp2p.Identity(privKey),
+		libp2p.ResourceManager(rcm),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/node/p2p.go
+++ b/pkg/node/p2p.go
@@ -1,0 +1,60 @@
+package node
+
+import (
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func p2pResourceManager(metrics *Metrics) (network.ResourceManager, error) {
+	// From https://github.com/libp2p/go-libp2p/tree/410248e111b1169e5cbbab455267d35f2f38baba/p2p/host/resource-manager#usage
+	// Start with the default scaling limits.
+	scalingLimits := rcmgr.DefaultLimits
+
+	// Add limits around included libp2p protocols
+	libp2p.SetDefaultServiceLimits(&scalingLimits)
+
+	// Turn the scaling limits into a concrete set of limits using `.AutoScale`. This
+	// scales the limits proportional to your system memory.
+	scaledDefaultLimits := scalingLimits.AutoScale()
+
+	// Tweak certain settings
+	cfg := rcmgr.PartialLimitConfig{
+		Protocol: map[protocol.ID]rcmgr.ResourceLimits{
+			syncProtocol: {
+				// Allow unlimited outbound streams
+				StreamsOutbound: rcmgr.Unlimited,
+			},
+			// Everything else is default. The exact values will come from `scaledDefaultLimits` above.
+		}}
+
+	// Create our limits by using our cfg and replacing the default values with values from `scaledDefaultLimits`
+	limits := cfg.Build(scaledDefaultLimits)
+
+	// The resource manager expects a limiter, se we create one from our limits.
+	limiter := rcmgr.NewFixedLimiter(limits)
+
+	// (Optional if you want metrics)
+	var opts []rcmgr.Option
+	if metrics != nil {
+		rcmgrObs.MustRegisterWith(prometheus.DefaultRegisterer)
+		// The stats are emitted by the trace reporter so
+		// we have to add it to the resource manager options.
+		str, err := rcmgrObs.NewStatsTraceReporter()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, rcmgr.WithTraceReporter(str))
+	}
+
+	// Initialize the resource manager
+	rm, err := rcmgr.NewResourceManager(limiter, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return rm, nil
+}


### PR DESCRIPTION
I wanted to just add the metrics originally, but it seems you must configure the whole resource manager to do that, so I'm also trying to set the outbound streams for the sync protocol only to Unlimited. We'll see if it gets rid of the "stream limit" errors we're seeing on fetches.

<img width="1507" alt="Screenshot 2023-05-03 at 14 11 53" src="https://user-images.githubusercontent.com/871693/236007144-690ced92-8ac0-4939-a1ff-37acbb7dc5f0.png">

The code is lifted straight from https://github.com/libp2p/go-libp2p/tree/410248e111b1169e5cbbab455267d35f2f38baba/p2p/host/resource-manager#usage