### PR TITLE
Initial publish implementation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": ["bradymholt.pgformatter", "golang.go"],
+  "recommendations": ["bradymholt.pgformatter", "golang.go", "emeraldwalk.runonsave"],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,14 @@
   "pgFormatter.tabs": true,
   "[sql]": {
     "editor.defaultFormatter": "bradymholt.pgformatter"
+  },
+  // Instructions from https://github.com/segmentio/golines
+  "emeraldwalk.runonsave": {
+    "commands": [
+        {
+            "match": "\\.go$",
+            "cmd": "golines ${file} -w"
+        }
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The `xmtpd` node build provides two options for monitoring your node.
 
     To learn how to visualize node data in Grafana, see [Prometheus Histograms with Grafana Heatmaps](https://towardsdatascience.com/prometheus-histograms-with-grafana-heatmaps-d556c28612c7) and [How to visualize Prometheus histograms in Grafana](https://grafana.com/blog/2020/06/23/how-to-visualize-prometheus-histograms-in-grafana/).
 
+# Contributing
+
+Please follow the [style guide](https://google.github.io/styleguide/go/decisions).
+
 ## Modifying the protobuf schema
 
 Submit and land a PR to https://github.com/xmtp/proto. Then run:

--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -69,7 +69,7 @@ func addEnvVars() {
 	}
 
 	if connStr, hasConnstr := os.LookupEnv("READER_DB_CONNECTION_STRING"); hasConnstr {
-		options.DB.WriterConnectionString = connStr
+		options.DB.ReaderConnectionString = connStr
 	}
 
 	if privKey, hasPrivKey := os.LookupEnv("PRIVATE_KEY"); hasPrivKey {

--- a/dev/up
+++ b/dev/up
@@ -8,6 +8,7 @@ if ! which golangci-lint &>/dev/null; then brew install golangci-lint; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
 if ! which mockery &>/dev/null; then brew install mockery; fi
 if ! which sqlc &> /dev/null; then brew install sqlc; fi
+if ! which golines &>/dev/null; then go install github.com/segmentio/golines@latest; fi
 
 dev/generate
 dev/docker/up

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"go.uber.org/zap"
 )
@@ -13,18 +17,67 @@ import (
 type Service struct {
 	message_api.UnimplementedReplicationApiServer
 
-	ctx context.Context
-	log *zap.Logger
+	ctx     context.Context
+	log     *zap.Logger
+	queries *queries.Queries
 }
 
-func NewReplicationApiService(ctx context.Context, log *zap.Logger) (message_api.ReplicationApiServer, error) {
-	return &Service{ctx: ctx, log: log}, nil
+func NewReplicationApiService(
+	ctx context.Context,
+	log *zap.Logger,
+	writerDB *sql.DB,
+) (*Service, error) {
+	return &Service{ctx: ctx, log: log, queries: queries.New(writerDB)}, nil
 }
 
-func (s *Service) BatchSubscribeEnvelopes(req *message_api.BatchSubscribeEnvelopesRequest, server message_api.ReplicationApi_BatchSubscribeEnvelopesServer) error {
+func (s *Service) Close() {
+	s.log.Info("closed")
+}
+
+func (s *Service) BatchSubscribeEnvelopes(
+	req *message_api.BatchSubscribeEnvelopesRequest,
+	server message_api.ReplicationApi_BatchSubscribeEnvelopesServer,
+) error {
 	return status.Errorf(codes.Unimplemented, "method BatchSubscribeEnvelopes not implemented")
 }
 
-func (s *Service) QueryEnvelopes(ctx context.Context, req *message_api.QueryEnvelopesRequest) (*message_api.QueryEnvelopesResponse, error) {
+func (s *Service) QueryEnvelopes(
+	ctx context.Context,
+	req *message_api.QueryEnvelopesRequest,
+) (*message_api.QueryEnvelopesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method QueryEnvelopes not implemented")
+}
+
+func (s *Service) PublishEnvelope(
+	ctx context.Context,
+	req *message_api.PublishEnvelopeRequest,
+) (*message_api.PublishEnvelopeResponse, error) {
+	payerEnv := req.GetPayerEnvelope()
+	clientBytes := payerEnv.GetUnsignedClientEnvelope()
+	sig := payerEnv.GetPayerSignature()
+	if (clientBytes == nil) || (sig == nil) {
+		return nil, status.Errorf(codes.InvalidArgument, "missing envelope or signature")
+	}
+	// TODO(rich): Verify payer signature
+	// TODO(rich): Verify all originators have synced past `last_originator_sids`
+	// TODO(rich): Check that the blockchain sequence ID is equal to the latest on the group
+	// TODO(rich): Perform any payload-specific validation (e.g. identity updates)
+	// TODO(rich): If it is a commit, publish it to blockchain instead
+
+	payerBytes, err := proto.Marshal(payerEnv)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not marshal envelope: %v", err)
+	}
+
+	stagedEnv, err := s.queries.InsertStagedOriginatorEnvelope(ctx, payerBytes)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not insert staged envelope: %v", err)
+	}
+
+	originatorEnv, err := utils.SignStagedEnvelope(stagedEnv)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not sign envelope: %v", err)
+	}
+
+	return &message_api.PublishEnvelopeResponse{OriginatorEnvelope: originatorEnv}, nil
 }

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/proto/identity/associations"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	test "github.com/xmtp/xmtpd/pkg/testing"
+	"google.golang.org/protobuf/proto"
+)
+
+func newTestService(t *testing.T) (*Service, *sql.DB, func()) {
+	ctx := context.Background()
+	log := test.NewLog(t)
+	db, _, dbCleanup := test.NewDB(t, ctx)
+
+	svc, err := NewReplicationApiService(ctx, log, db)
+	require.NoError(t, err)
+
+	return svc, db, func() {
+		svc.Close()
+		dbCleanup()
+	}
+}
+
+func TestSimplePublish(t *testing.T) {
+	svc, _, cleanup := newTestService(t)
+	defer cleanup()
+
+	resp, err := svc.PublishEnvelope(
+		context.Background(),
+		&message_api.PublishEnvelopeRequest{
+			PayerEnvelope: &message_api.PayerEnvelope{
+				UnsignedClientEnvelope: []byte{0x5},
+				PayerSignature:         &associations.RecoverableEcdsaSignature{},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	unsignedEnv := &message_api.UnsignedOriginatorEnvelope{}
+	require.NoError(
+		t,
+		proto.Unmarshal(resp.GetOriginatorEnvelope().GetUnsignedOriginatorEnvelope(), unsignedEnv),
+	)
+	require.Equal(t, uint8(0x5), unsignedEnv.GetPayerEnvelope().GetUnsignedClientEnvelope()[0])
+
+	// TODO(rich) Test that the published envelope is retrievable via the query API
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -43,9 +43,3 @@ func TestCreateServer(t *testing.T) {
 	server2 := NewTestServer(t, registry)
 	require.NotEqual(t, server1.Addr(), server2.Addr())
 }
-
-func TestMigrate(t *testing.T) {
-	registry := registry.NewFixedNodeRegistry([]registry.Node{})
-	server := NewTestServer(t, registry)
-	require.NoError(t, server.Migrate())
-}

--- a/pkg/testing/store.go
+++ b/pkg/testing/store.go
@@ -1,0 +1,46 @@
+package testing
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/migrations"
+)
+
+const (
+	localTestDBDSNPrefix = "postgres://postgres:xmtp@localhost:8765"
+	localTestDBDSNSuffix = "?sslmode=disable"
+)
+
+func newPGXDB(t testing.TB) (*sql.DB, string, func()) {
+	dsn := localTestDBDSNPrefix + localTestDBDSNSuffix
+	config, err := pgx.ParseConfig(dsn)
+	require.NoError(t, err)
+	ctlDB := stdlib.OpenDB(*config)
+	dbName := "test_" + RandomStringLower(12)
+	_, err = ctlDB.Exec("CREATE DATABASE " + dbName)
+	require.NoError(t, err)
+
+	dsn = localTestDBDSNPrefix + "/" + dbName + localTestDBDSNSuffix
+	config2, err := pgx.ParseConfig(dsn)
+	require.NoError(t, err)
+	db := stdlib.OpenDB(*config2)
+	return db, dsn, func() {
+		err := db.Close()
+		require.NoError(t, err)
+		_, err = ctlDB.Exec("DROP DATABASE " + dbName)
+		require.NoError(t, err)
+		ctlDB.Close()
+	}
+}
+
+func NewDB(t *testing.T, ctx context.Context) (*sql.DB, string, func()) {
+	db, dsn, cleanup := newPGXDB(t)
+	require.NoError(t, migrations.Migrate(ctx, db))
+
+	return db, dsn, cleanup
+}

--- a/pkg/utils/envelope.go
+++ b/pkg/utils/envelope.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"google.golang.org/protobuf/proto"
+)
+
+func SignStagedEnvelope(
+	stagedEnv queries.StagedOriginatorEnvelope,
+) (*message_api.OriginatorEnvelope, error) {
+	payerEnv := &message_api.PayerEnvelope{}
+	if err := proto.Unmarshal(stagedEnv.PayerEnvelope, payerEnv); err != nil {
+		return nil, err
+	}
+	unsignedEnv := message_api.UnsignedOriginatorEnvelope{
+		OriginatorSid: SID(stagedEnv.ID),
+		OriginatorNs:  stagedEnv.OriginatorTime.UnixNano(),
+		PayerEnvelope: payerEnv,
+	}
+	unsignedBytes, err := proto.Marshal(&unsignedEnv)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(rich): Plumb through public key and properly sign envelope
+	signedEnv := message_api.OriginatorEnvelope{
+		UnsignedOriginatorEnvelope: unsignedBytes,
+		Proof:                      nil,
+	}
+	return &signedEnv, nil
+}

--- a/pkg/utils/sid.go
+++ b/pkg/utils/sid.go
@@ -1,0 +1,18 @@
+package utils
+
+const (
+	nodeIDMask  uint64 = 0xFFFF << 48
+	localIDMask uint64 = ^nodeIDMask
+)
+
+// Converts a local serial ID from the database into a global SID with a node ID prefix
+func SID(localID int64) uint64 {
+	nodeMask := uint64(localID) & nodeIDMask
+	if localID < 0 || nodeMask != 0 {
+		// Either indicates ID exhaustion or developer error -
+		// the service should not continue running either way
+		panic("Invalid local ID")
+	}
+	// TODO(rich): Plumb through and set node ID
+	return uint64(localID)
+}


### PR DESCRIPTION
Initial implementation of the publish endpoint and unit test setup. Simply writes to the staged envelopes table and does nothing else.

Also fixed some issues around DB and connection lifetimes - the migration step now closes the connection it uses (but not the whole DB instance).