### PR TITLE
Build xmtpd docker image and push to ghcr

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -1,0 +1,42 @@
+name: Build xmtpd image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/xmtp/xmtpd
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        id: push
+        with:
+          context: .
+          file: ./dev/docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD IMAGE --------------------------------------------------------
-ARG GO_VERSION=unknown
+ARG GO_VERSION=1.22
 FROM golang:${GO_VERSION}-alpine as builder
 
 # Get build tools and required header files


### PR DESCRIPTION
Builds the xmtpd docker image and pushes it to GHCR.

Based on [libxmtp](https://github.com/xmtp/libxmtp/blob/533efcb221cfa334198a0d0b81131b0175c4f5f2/.github/workflows/deploy-validation-server.yml#L18-L42).
The notable difference is that it also builds the image (but does not push) on PRs. Useful for CI.

The resulting image example can already be seen [here](https://github.com/xmtp/xmtpd/actions/runs/10356333475?pr=108)

Fixes #104 