### PR TITLE
Add more queries, fix DB sequence ID's

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ dev/generate
 Create a new migration by running:
 
 ```sh
-dev/gen-migration
+dev/gen-migration {migration-name}
 ```
 
 Fill in the migrations in the generated files. If you are unfamiliar with migrations, you may follow [this guide](https://github.com/golang-migrate/migrate/blob/master/MIGRATIONS.md). The database is PostgreSQL and the driver is PGX.
@@ -106,5 +106,5 @@ Fill in the migrations in the generated files. If you are unfamiliar with migrat
 We use [sqlc](https://docs.sqlc.dev/en/latest/index.html) to generate the code for our DB queries. Modify the `queries.sql` file, and then run:
 
 ```sh
-sqlc generate
+dev/generate
 ```

--- a/dev/generate
+++ b/dev/generate
@@ -6,6 +6,7 @@ go generate ./...
 rm -f pkg/mocks/*
 ./dev/abigen
 mockery
+sqlc generate
 
 rm -rf pkg/proto/**/*.pb.go pkg/proto/**/*.pb.gw.go pkg/proto/**/*.swagger.json
 if ! buf generate https://github.com/xmtp/proto.git#subdir=proto; then

--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -1,13 +1,39 @@
--- name: InsertStagedOriginatorEnvelope :one
-INSERT INTO staged_originator_envelopes(payer_envelope)
-	VALUES (@payer_envelope)
-RETURNING
-	*;
-
--- name: InsertNodeInfo :one
+-- name: InsertNodeInfo :execrows
 INSERT INTO node_info(node_id, public_key)
 	VALUES (@node_id, @public_key)
-	RETURNING *;
+ON CONFLICT
+	DO NOTHING;
 
 -- name: SelectNodeInfo :one
-SELECT * FROM node_info WHERE singleton_id = 1;
+SELECT
+	*
+FROM
+	node_info
+WHERE
+	singleton_id = 1;
+
+-- name: InsertGatewayEnvelope :execrows
+SELECT
+	insert_gateway_envelope(@originator_id, @sequence_id, @topic, @originator_envelope);
+
+-- name: InsertStagedOriginatorEnvelope :one
+SELECT
+	*
+FROM
+	insert_staged_originator_envelope(@payer_envelope);
+
+-- name: SelectStagedOriginatorEnvelopes :many
+SELECT
+	*
+FROM
+	staged_originator_envelopes
+WHERE
+	id > @last_seen_id
+ORDER BY
+	id ASC
+LIMIT @num_rows;
+
+-- name: DeleteStagedOriginatorEnvelope :execrows
+DELETE FROM staged_originator_envelopes
+WHERE id = @id;
+

--- a/pkg/db/queries/models.go
+++ b/pkg/db/queries/models.go
@@ -18,7 +18,8 @@ type AddressLog struct {
 
 type GatewayEnvelope struct {
 	ID                 int64
-	OriginatorSid      int64
+	OriginatorID       int32
+	SequenceID         int64
 	Topic              []byte
 	OriginatorEnvelope []byte
 }

--- a/pkg/migrations/00001_init-schema.up.sql
+++ b/pkg/migrations/00001_init-schema.up.sql
@@ -3,7 +3,6 @@
 CREATE TABLE node_info(
 	node_id INTEGER NOT NULL,
 	public_key BYTEA NOT NULL,
-
 	singleton_id SMALLINT PRIMARY KEY DEFAULT 1,
 	CONSTRAINT is_singleton CHECK (singleton_id = 1)
 );
@@ -12,15 +11,35 @@ CREATE TABLE node_info(
 CREATE TABLE gateway_envelopes(
 	-- used to construct gateway_sid
 	id BIGSERIAL PRIMARY KEY,
-	originator_sid BIGINT NOT NULL,
+	originator_id INT NOT NULL,
+	sequence_id BIGINT NOT NULL,
 	topic BYTEA NOT NULL,
 	originator_envelope BYTEA NOT NULL
 );
+
 -- Client queries
 CREATE INDEX idx_gateway_envelopes_topic ON gateway_envelopes(topic);
--- Node queries
-CREATE UNIQUE INDEX idx_gateway_envelopes_originator_sid ON gateway_envelopes(originator_sid);
 
+-- Node queries
+CREATE UNIQUE INDEX idx_gateway_envelopes_originator_sid ON gateway_envelopes(originator_id, sequence_id);
+
+CREATE FUNCTION insert_gateway_envelope(originator_id INT, sequence_id BIGINT, topic BYTEA, originator_envelope BYTEA)
+	RETURNS SETOF gateway_envelopes
+	AS $$
+BEGIN
+	-- Ensures that the generated sequence ID matches the insertion order
+	-- Only released at the end of the enclosing transaction - beware if called within a long transaction
+	PERFORM
+		pg_advisory_xact_lock(hashtext('gateway_envelopes_sequence'));
+	RETURN QUERY INSERT INTO gateway_envelopes(originator_id, sequence_id, topic, originator_envelope)
+		VALUES(originator_id, sequence_id, topic, originator_envelope)
+	ON CONFLICT
+		DO NOTHING
+	RETURNING
+		*;
+END;
+$$
+LANGUAGE plpgsql;
 
 -- Process for originating envelopes:
 -- 1. Perform any necessary validation
@@ -38,6 +57,22 @@ CREATE TABLE staged_originator_envelopes(
 	payer_envelope BYTEA NOT NULL
 );
 
+CREATE FUNCTION insert_staged_originator_envelope(payer_envelope BYTEA)
+	RETURNS SETOF staged_originator_envelopes
+	AS $$
+BEGIN
+	PERFORM
+		pg_advisory_xact_lock(hashtext('staged_originator_envelopes_sequence'));
+	RETURN QUERY INSERT INTO staged_originator_envelopes(payer_envelope)
+		VALUES(payer_envelope)
+	ON CONFLICT
+		DO NOTHING
+	RETURNING
+		*;
+END;
+$$
+LANGUAGE plpgsql;
+
 -- A cached view for looking up the inbox_id that an address belongs to.
 -- Relies on a total ordering of updates across all inbox_ids, from which this
 -- view can be deterministically generated.
@@ -46,6 +81,6 @@ CREATE TABLE address_log(
 	inbox_id BYTEA NOT NULL,
 	association_sequence_id BIGINT,
 	revocation_sequence_id BIGINT,
-
 	PRIMARY KEY (address, inbox_id)
 );
+

--- a/pkg/utils/sid.go
+++ b/pkg/utils/sid.go
@@ -1,13 +1,13 @@
 package utils
 
 // SIDS are 64-bit numbers consisting of 16 bits for the node ID
-// followed by 48 bits for the sequence ID (local ID). This file
+// followed by 48 bits for the sequence ID. This file
 // contains methods for reading and constructing sids.
 //
 // We also leverage type-checking throughout the repo to avoid confusion:
 // - SIDs are uint64
 // - node IDs are uint16
-// - local IDs are int64
+// - sequence IDs are int64
 
 const (
 	// Number of bits used for node ID
@@ -20,7 +20,7 @@ const (
 	localIDMask uint64 = ^nodeIDMask
 )
 
-func IsValidLocalID(localID int64) bool {
+func IsValidSequenceID(localID int64) bool {
 	return localID > 0 && localID>>localIDBits == 0
 }
 
@@ -28,7 +28,7 @@ func NodeID(sid uint64) uint16 {
 	return uint16(sid >> localIDBits)
 }
 
-func LocalID(sid uint64) int64 {
+func SequenceID(sid uint64) int64 {
 	return int64(sid & localIDMask)
 }
 

--- a/pkg/utils/sid_test.go
+++ b/pkg/utils/sid_test.go
@@ -6,20 +6,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInvalidLocalID(t *testing.T) {
-	localID := int64(-1)
-	require.False(t, IsValidLocalID(localID))
-	localID = int64(0)
-	require.False(t, IsValidLocalID(localID))
-	localID = int64(0b0000000000000001000000000000000000000000000000000000000000000000)
-	require.False(t, IsValidLocalID(localID))
+func TestInvalidSequenceID(t *testing.T) {
+	sequenceID := int64(-1)
+	require.False(t, IsValidSequenceID(sequenceID))
+	sequenceID = int64(0)
+	require.False(t, IsValidSequenceID(sequenceID))
+	sequenceID = int64(0b0000000000000001000000000000000000000000000000000000000000000000)
+	require.False(t, IsValidSequenceID(sequenceID))
 }
 
-func TestValidLocalID(t *testing.T) {
-	localID := int64(1)
-	require.True(t, IsValidLocalID(localID))
-	localID = int64(0b0000000000000000111111111111111111111111111111111111111111111111)
-	require.True(t, IsValidLocalID(localID))
+func TestValidSequenceID(t *testing.T) {
+	sequenceID := int64(1)
+	require.True(t, IsValidSequenceID(sequenceID))
+	sequenceID = int64(0b0000000000000000111111111111111111111111111111111111111111111111)
+	require.True(t, IsValidSequenceID(sequenceID))
 }
 
 func TestGetNodeID(t *testing.T) {
@@ -29,23 +29,23 @@ func TestGetNodeID(t *testing.T) {
 	require.Equal(t, uint16(1), NodeID(sid))
 }
 
-func TestGetLocalID(t *testing.T) {
+func TestGetSequenceID(t *testing.T) {
 	sid := uint64(0b0000000000000001111111111111111111111111111111111111111111111111)
-	require.Equal(t, int64(0b0000000000000000111111111111111111111111111111111111111111111111), LocalID(sid))
+	require.Equal(t, int64(0b0000000000000000111111111111111111111111111111111111111111111111), SequenceID(sid))
 	sid = uint64(0b0000000000000001000000000000000000000000000000000000000000000000)
-	require.Equal(t, int64(0), LocalID(sid))
+	require.Equal(t, int64(0), SequenceID(sid))
 	sid = uint64(0b0000000000000001000000000000000000000000000000000000000000000001)
-	require.Equal(t, int64(1), LocalID(sid))
+	require.Equal(t, int64(1), SequenceID(sid))
 }
 
 func TestGetSID(t *testing.T) {
 	nodeID := uint16(1)
-	localID := int64(1)
-	require.Equal(t, uint64(0b0000000000000001000000000000000000000000000000000000000000000001), SID(nodeID, localID))
+	sequenceID := int64(1)
+	require.Equal(t, uint64(0b0000000000000001000000000000000000000000000000000000000000000001), SID(nodeID, sequenceID))
 	nodeID = uint16(1)
-	localID = int64(0)
-	require.Equal(t, uint64(0b0000000000000001000000000000000000000000000000000000000000000000), SID(nodeID, localID))
+	sequenceID = int64(0)
+	require.Equal(t, uint64(0b0000000000000001000000000000000000000000000000000000000000000000), SID(nodeID, sequenceID))
 	nodeID = uint16(0)
-	localID = int64(1)
-	require.Equal(t, uint64(0b0000000000000000000000000000000000000000000000000000000000000001), SID(nodeID, localID))
+	sequenceID = int64(1)
+	require.Equal(t, uint64(0b0000000000000000000000000000000000000000000000000000000000000001), SID(nodeID, sequenceID))
 }


### PR DESCRIPTION
I've fixed a number of issues, would like to suggest some best practices going forward that I've implemented here:

1. **Reliable sequence ID's**. Whenever we add a table that uses a sequence for ordering, we should also add a Postgres stored function immediately below it that performs insertions by taking an advisory lock first. This ensures that inserts on the table are [processed serially](https://espadrine.github.io/blog/posts/two-postgresql-sequence-misconceptions.html#Order_violation).
2. **Idempotent inserts**. Whenever we add an insert query, we should add an `ON CONFLICT DO NOTHING` clause, and either return the inserted count via `:execrows` or the row itself via `:one`. This saves the caller from having to parse untyped errors in search of unique constraint violations, which are sometimes expected.
3. **Result granularity**.
    - Postgres functions should always return the inserted rows via `RETURNING *`, even if the result is not currently used. This is because any future changes to the function would require a DB migration. 
    - In `queries.sql`, results should be defined as narrowly as possible - for example, do not return the row via `:one` if the code is not using it. This saves networking bandwidth, and the query can easily be changed later on without a migration.
4. **Consistent SID terminology**. Settling on the terms `Node ID` and `Sequence ID` as the components of a `SID`, removing references to `LocalID`.

Some other stuff I've done:

1. I've split up the `sid` field in the `gateway_envelopes` table into `node_id` and `sequence_id`, because the postgres `BIGINT` type is a signed 64-bit int that cannot hold a `uint64` without bad side effects.
2. I've added the `insert_gateway_envelope` and `delete_staged_originator_envelope` queries which are needed for the stacked PR's.