### PR TITLE
Rename testing to testutils

### DIFF
--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -14,17 +14,17 @@ import (
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/registrant"
 	"github.com/xmtp/xmtpd/pkg/registry"
-	test "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 	"google.golang.org/protobuf/proto"
 )
 
 func newTestService(t *testing.T) (*Service, *sql.DB, func()) {
 	ctx := context.Background()
-	log := test.NewLog(t)
-	db, _, dbCleanup := test.NewDB(t, ctx)
+	log := testutils.NewLog(t)
+	db, _, dbCleanup := testutils.NewDB(t, ctx)
 	privKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	privKeyStr := "0x" + test.HexEncode(crypto.FromECDSA(privKey))
+	privKeyStr := "0x" + testutils.HexEncode(crypto.FromECDSA(privKey))
 	mockRegistry := mocks.NewMockNodeRegistry(t)
 	mockRegistry.EXPECT().GetNodes().Return([]registry.Node{
 		{NodeID: 1, SigningKey: &privKey.PublicKey},

--- a/pkg/db/subscription_test.go
+++ b/pkg/db/subscription_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
-	test "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 	"go.uber.org/zap"
 )
 
@@ -37,7 +37,7 @@ func insertGatewayEnvelopes(
 
 func setup(t *testing.T) (*sql.DB, *zap.Logger, func()) {
 	ctx := context.Background()
-	db, _, dbCleanup := test.NewDB(t, ctx)
+	db, _, dbCleanup := testutils.NewDB(t, ctx)
 	log, err := zap.NewDevelopment()
 	require.NoError(t, err)
 

--- a/pkg/indexer/blockchain/rpcLogStreamer_test.go
+++ b/pkg/indexer/blockchain/rpcLogStreamer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/xmtp/xmtpd/pkg/mocks"
-	testutils "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/xmtp/xmtpd/pkg/indexer/storer"
 	"github.com/xmtp/xmtpd/pkg/mocks"
-	testutils "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 )
 
 func TestIndexLogsSuccess(t *testing.T) {

--- a/pkg/indexer/storer/groupMessage_test.go
+++ b/pkg/indexer/storer/groupMessage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/indexer/blockchain"
-	testutils "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 	"github.com/xmtp/xmtpd/pkg/utils"
 )
 

--- a/pkg/registrant/registrant_test.go
+++ b/pkg/registrant/registrant_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/registrant"
 	"github.com/xmtp/xmtpd/pkg/registry"
-	test "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -30,7 +30,7 @@ type deps struct {
 func setup(t *testing.T) (deps, func()) {
 	ctx := context.Background()
 	mockRegistry := mocks.NewMockNodeRegistry(t)
-	db, _, dbCleanup := test.NewDB(t, ctx)
+	db, _, dbCleanup := testutils.NewDB(t, ctx)
 	queries := queries.New(db)
 	privKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func setup(t *testing.T) (deps, func()) {
 	require.NoError(t, err)
 	privKey3, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	privKey1Str := "0x" + test.HexEncode(crypto.FromECDSA(privKey1))
+	privKey1Str := "0x" + testutils.HexEncode(crypto.FromECDSA(privKey1))
 
 	return deps{
 		ctx:         ctx,
@@ -179,7 +179,7 @@ func TestNewRegistrantPrivateKeyNo0x(t *testing.T) {
 		deps.ctx,
 		deps.db,
 		deps.registry,
-		test.HexEncode(crypto.FromECDSA(deps.privKey1)),
+		testutils.HexEncode(crypto.FromECDSA(deps.privKey1)),
 	)
 	require.NoError(t, err)
 }

--- a/pkg/registry/contractRegistry_test.go
+++ b/pkg/registry/contractRegistry_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/xmtp/xmtpd/pkg/config"
 	"github.com/xmtp/xmtpd/pkg/mocks"
 	r "github.com/xmtp/xmtpd/pkg/registry"
-	testUtils "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 )
 
 func TestContractRegistryNewNodes(t *testing.T) {
 	registry, err := r.NewSmartContractRegistry(
 		nil,
-		testUtils.NewLog(t),
+		testutils.NewLog(t),
 		config.ContractsOptions{RefreshInterval: 100 * time.Millisecond},
 	)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestContractRegistryNewNodes(t *testing.T) {
 func TestContractRegistryChangedNodes(t *testing.T) {
 	registry, err := r.NewSmartContractRegistry(
 		nil,
-		testUtils.NewLog(t),
+		testutils.NewLog(t),
 		config.ContractsOptions{RefreshInterval: 10 * time.Millisecond},
 	)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestContractRegistryChangedNodes(t *testing.T) {
 func TestStopOnContextCancel(t *testing.T) {
 	registry, err := r.NewSmartContractRegistry(
 		nil,
-		testUtils.NewLog(t),
+		testutils.NewLog(t),
 		config.ContractsOptions{RefreshInterval: 10 * time.Millisecond},
 	)
 	require.NoError(t, err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/mocks"
 	r "github.com/xmtp/xmtpd/pkg/registry"
 	s "github.com/xmtp/xmtpd/pkg/server"
-	test "github.com/xmtp/xmtpd/pkg/testing"
+	"github.com/xmtp/xmtpd/pkg/testutils"
 )
 
 func NewTestServer(
@@ -22,7 +22,7 @@ func NewTestServer(
 	registry r.NodeRegistry,
 	privateKey *ecdsa.PrivateKey,
 ) *s.ReplicationServer {
-	log := test.NewLog(t)
+	log := testutils.NewLog(t)
 
 	server, err := s.NewReplicationServer(context.Background(), log, config.ServerOptions{
 		PrivateKeyString: hex.EncodeToString(crypto.FromECDSA(privateKey)),
@@ -36,7 +36,7 @@ func NewTestServer(
 }
 
 func TestCreateServer(t *testing.T) {
-	dbs, dbCleanup := test.NewDBs(t, context.Background(), 2)
+	dbs, dbCleanup := testutils.NewDBs(t, context.Background(), 2)
 	defer dbCleanup()
 	privateKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -1,4 +1,4 @@
-package testing
+package testutils
 
 import (
 	"encoding/json"

--- a/pkg/testutils/contracts.go
+++ b/pkg/testutils/contracts.go
@@ -1,4 +1,4 @@
-package testing
+package testutils
 
 import (
 	"testing"

--- a/pkg/testutils/hex.go
+++ b/pkg/testutils/hex.go
@@ -1,4 +1,4 @@
-package testing
+package testutils
 
 import "encoding/hex"
 

--- a/pkg/testutils/log.go
+++ b/pkg/testutils/log.go
@@ -1,4 +1,4 @@
-package testing
+package testutils
 
 import (
 	"flag"

--- a/pkg/testutils/random.go
+++ b/pkg/testutils/random.go
@@ -1,4 +1,4 @@
-package testing
+package testutils
 
 import (
 	cryptoRand "crypto/rand"

--- a/pkg/testutils/store.go
+++ b/pkg/testutils/store.go
@@ -1,4 +1,4 @@
-package testing
+package testutils
 
 import (
 	"context"


### PR DESCRIPTION
## tl;dr

- It was annoying having to alias the `testing` package everywhere it was used because the name conflicts with the standard `testing` package. This renames it