### PR TITLE
Combined small improvements

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -31,5 +31,3 @@ EXPOSE 5050
 COPY --from=builder /app/bin/xmtpd /usr/bin/
 
 ENTRYPOINT ["/usr/bin/xmtpd"]
-# By default just show help if called without arguments
-CMD ["--help"]

--- a/dev/psql
+++ b/dev/psql
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+PGPASSWORD=xmtp psql --host=localhost --port=8765 -U postgres

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -34,7 +34,7 @@ type ServerOptions struct {
 	//nolint:staticcheck
 	LogEncoding string `          long:"log-encoding" env:"XMTPD_LOG_ENCODING" description:"Log encoding format. Either console or json"                                                                                  default:"console" choice:"console"`
 
-	SignerPrivateKey string `long:"signer-private-key" env:"XMTPD_SIGNER_PRIVATE_KEY" description:"Private key used to sign messages"`
+	SignerPrivateKey string `long:"signer-private-key" env:"XMTPD_SIGNER_PRIVATE_KEY" description:"Private key used to sign messages" required:"true"`
 
 	API       ApiOptions       `group:"API Options"       namespace:"api"`
 	DB        DbOptions        `group:"Database Options"  namespace:"db"`


### PR DESCRIPTION
1) Do not pass `--help` to the docker image. This forces the caller which only wishes to use ENV variables to pass an empty command. This makes it hard in Terraform.

2) add a psql convenience script to connect to the local PG instance

3) mark `signer-private-key` as `required`