### PR TITLE
Tag by SHA

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -14,12 +14,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      DOCKER_METADATA_PR_HEAD_SHA: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        # we want the HEAD commit instead of the merge SHA for the docker tag
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Log in to the container registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # we want the HEAD commit instead of the merge SHA for the docker tag
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Log in to the container registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -30,6 +30,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/xmtp/xmtpd
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/dev/run
+++ b/dev/run
@@ -4,4 +4,4 @@ set -eu
 
 . dev/local.env
 
-go run cmd/replication/main.go
+go run cmd/replication/main.go "$@"


### PR DESCRIPTION
Automatically tag a docker image by it's git sha.

This is useful for pinning and debugging.

For example:
```
Docker tags
  ghcr.io/xmtp/xmtpd:pr-134
  ghcr.io/xmtp/xmtpd:sha-56e2af4
```

Drive-by allow passing args to `dev/run` such as `./dev/run --api.port=1000`