### PR TITLE
Clean up shutdown logic

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -3,10 +3,7 @@ package main
 import (
 	"context"
 	"log"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/xmtp/xmtpd/pkg/config"
@@ -65,7 +62,7 @@ func main() {
 			registry.NewFixedNodeRegistry(
 				[]registry.Node{
 					{
-						NodeID:        0,
+						NodeID:        1,
 						SigningKey:    &privateKey.PublicKey,
 						IsHealthy:     true,
 						HttpAddress:   "http://example.com",
@@ -82,18 +79,7 @@ func main() {
 		doneC <- true
 	})
 
-	sigC := make(chan os.Signal, 1)
-	signal.Notify(sigC,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
-	select {
-	case sig := <-sigC:
-		log.Info("ending on signal", zap.String("signal", sig.String()))
-	case <-doneC:
-	}
+	<-doneC
 	cancel()
 	wg.Wait()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,15 +36,17 @@ func NewReplicationServer(
 	writerDB *sql.DB,
 ) (*ReplicationServer, error) {
 	var err error
+
 	s := &ReplicationServer{
 		options:      options,
 		log:          log,
 		nodeRegistry: nodeRegistry,
 		writerDB:     writerDB,
 	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	s.registrant, err = registrant.NewRegistrant(
-		ctx,
+		s.ctx,
 		queries.New(s.writerDB),
 		nodeRegistry,
 		options.SignerPrivateKey,
@@ -53,11 +55,11 @@ func NewReplicationServer(
 		return nil, err
 	}
 
-	s.ctx, s.cancel = context.WithCancel(ctx)
-	s.apiServer, err = api.NewAPIServer(ctx, s.writerDB, log, options.API.Port, s.registrant)
+	s.apiServer, err = api.NewAPIServer(s.ctx, s.writerDB, log, options.API.Port, s.registrant)
 	if err != nil {
 		return nil, err
 	}
+
 	log.Info("Replication server started", zap.Int("port", options.API.Port))
 	return s, nil
 }
@@ -68,14 +70,14 @@ func (s *ReplicationServer) Addr() net.Addr {
 
 func (s *ReplicationServer) WaitForShutdown() {
 	termChannel := make(chan os.Signal, 1)
-	signal.Notify(termChannel, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(termChannel, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 	<-termChannel
 	s.Shutdown()
 }
 
 func (s *ReplicationServer) Shutdown() {
-	s.cancel()
 	if s.apiServer != nil {
 		s.apiServer.Close()
 	}
+	s.cancel()
 }


### PR DESCRIPTION
## tl;dr

- Updates the way we shut down the server to be a little simpler
- Adds a `gracefulShutdown` function on the API server that will reject new connections but not immediately kill existing ones, so that the server can finish short-lived requests