### PR TITLE
Enable server reflection

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,11 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/contracts/lib/forge-std" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/erc4626-tests" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/forge-std" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/forge-std/lib/ds-test" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/halmos-cheatcodes" vcs="Git" />
   </component>
 </project>

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jessevdk/go-flags v1.6.1
+	github.com/lib/pq v1.10.9
 	github.com/pires/go-proxyproto v0.7.0
+	github.com/prometheus/client_golang v1.19.1
 	github.com/segmentio/golines v0.12.2
 	github.com/sqlc-dev/sqlc v1.27.0
 	github.com/stretchr/testify v1.9.0
@@ -219,7 +221,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/ktrysmt/go-bitbucket v0.6.4 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -271,7 +272,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"google.golang.org/grpc/reflection"
 	"net"
 	"strings"
 	"sync"
@@ -38,6 +39,7 @@ func NewAPIServer(
 	log *zap.Logger,
 	port int,
 	registrant *registrant.Registrant,
+	enableReflection bool,
 ) (*ApiServer, error) {
 	grpcListener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 
@@ -71,6 +73,12 @@ func NewAPIServer(
 	}
 
 	s.grpcServer = grpc.NewServer(options...)
+
+	if enableReflection {
+		// Register reflection service on gRPC server.
+		reflection.Register(s.grpcServer)
+		s.log.Info("enabling gRPC Server Reflection")
+	}
 
 	healthcheck := health.NewServer()
 	healthgrpc.RegisterHealthServer(s.grpcServer, healthcheck)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -41,15 +41,21 @@ type ServerOptions struct {
 	LogEncoding      string `          long:"log-encoding"       env:"XMTPD_LOG_ENCODING"       description:"Log encoding format. Either console or json"                                                                                  default:"console" choice:"console"`
 	SignerPrivateKey string `          long:"signer-private-key" env:"XMTPD_SIGNER_PRIVATE_KEY" description:"Private key used to sign messages"                                                                                                                               required:"true"`
 
-	API       ApiOptions       `group:"API Options"            namespace:"api"`
-	DB        DbOptions        `group:"Database Options"       namespace:"db"`
-	Contracts ContractsOptions `group:"Contracts Options"      namespace:"contracts"`
-	Metrics   MetricsOptions   `group:"Metrics Options"        namespace:"metrics"`
-	Payer     PayerOptions     `group:"Payer Options"          namespace:"payer"`
-	Tracing   TracingOptions   `group:"DD APM Tracing Options" namespace:"tracing"`
+	API        ApiOptions        `group:"API Options"            namespace:"api"`
+	DB         DbOptions         `group:"Database Options"       namespace:"db"`
+	Contracts  ContractsOptions  `group:"Contracts Options"      namespace:"contracts"`
+	Metrics    MetricsOptions    `group:"Metrics Options"        namespace:"metrics"`
+	Payer      PayerOptions      `group:"Payer Options"          namespace:"payer"`
+	Reflection ReflectionOptions `group:"Reflection Options"     namespace:"reflection"`
+	Tracing    TracingOptions    `group:"DD APM Tracing Options" namespace:"tracing"`
 }
 
 // TracingOptions are settings controlling collection of DD APM traces and error tracking.
 type TracingOptions struct {
 	Enable bool `long:"enable" env:"XMTPD_TRACING_ENABLE" description:"Enable DD APM trace collection"`
+}
+
+// ReflectionOptions are settings controlling collection of GRPC reflection settings.
+type ReflectionOptions struct {
+	Enable bool `long:"enable" env:"XMTPD_REFLECTION_ENABLE" description:"Enable GRPC reflection"`
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -78,7 +78,14 @@ func NewReplicationServer(
 		return nil, err
 	}
 
-	s.apiServer, err = api.NewAPIServer(s.ctx, s.writerDB, log, options.API.Port, s.registrant)
+	s.apiServer, err = api.NewAPIServer(
+		s.ctx,
+		s.writerDB,
+		log,
+		options.API.Port,
+		s.registrant,
+		options.Reflection.Enable,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md

This enables stuff like:
```
$ grpcurl -plaintext localhost:1005 grpc.health.v1.Health.Check
{
  "status": "SERVING"
}
```

And later more advanced endpoint querying.

I am not sure I would enable this in `prod`, but for `testnet` it's amazing.