### PR TITLE
Add CLI

### DIFF
--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/utils"
+)
+
+func TestRegisterNodeArgParse(t *testing.T) {
+	httpAddress := "http://localhost:8545"
+	ownerAddress := testutils.RandomAddress()
+	adminPrivateKey := utils.EcdsaPrivateKeyToString(testutils.RandomPrivateKey(t))
+	signingKeyPub := utils.EcdsaPublicKeyToString(
+		testutils.RandomPrivateKey(t).Public().(*ecdsa.PublicKey),
+	)
+	options, err := parseOptions(
+		[]string{
+			"register-node",
+			"--http-address",
+			httpAddress,
+			"--admin-private-key",
+			adminPrivateKey,
+			"--owner-address",
+			ownerAddress.Hex(),
+			"--signing-key",
+			signingKeyPub,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, options.Command, "register-node")
+	require.Equal(t, options.RegisterNode.AdminPrivateKey, adminPrivateKey)
+	require.Equal(t, options.RegisterNode.OwnerAddress, ownerAddress.Hex())
+	require.Equal(t, options.RegisterNode.SigningKey, signingKeyPub)
+
+	// Test missing options
+	_, err = parseOptions([]string{"register-node"})
+	require.Error(t, err)
+	require.Equal(
+		t,
+		err.Error(),
+		"Could not parse options: the required flags `--admin-private-key', `--http-address', `--owner-address' and `--signing-key' were not specified",
+	)
+}
+
+func TestGenerateKeyArgParse(t *testing.T) {
+	options, err := parseOptions([]string{"generate-key"})
+	require.NoError(t, err)
+	require.Equal(t, options.Command, "generate-key")
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/xmtp/xmtpd/pkg/blockchain"
+	"github.com/xmtp/xmtpd/pkg/config"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"go.uber.org/zap"
+)
+
+type globalOptions struct {
+	Contracts config.ContractsOptions `group:"Contracts Options" namespace:"contracts"`
+	Log       config.LogOptions       `group:"Log Options"       namespace:"log"`
+}
+
+type CLI struct {
+	globalOptions
+	Command      string
+	GenerateKey  config.GenerateKeyOptions
+	RegisterNode config.RegisterNodeOptions
+}
+
+/*
+*
+Parse the command line options and return the CLI struct.
+
+Some special care has to be made here to ensure that the required options are only evaluated for the correct command.
+We use a wrapper type to scope the parser to only the universal options, allowing us to have required fields on
+the options for each subcommand.
+*
+*/
+func parseOptions(args []string) (*CLI, error) {
+	var options globalOptions
+	var generateKeyOptions config.GenerateKeyOptions
+	var registerNodeOptions config.RegisterNodeOptions
+
+	parser := flags.NewParser(&options, flags.Default)
+	if _, err := parser.AddCommand("generate-key", "Generate a public/private keypair", "", &generateKeyOptions); err != nil {
+		return nil, fmt.Errorf("Could not add generate-key command: %s", err)
+	}
+	if _, err := parser.AddCommand("register-node", "Register a node", "", &registerNodeOptions); err != nil {
+		return nil, fmt.Errorf("Could not add register-node command: %s", err)
+	}
+	if _, err := parser.ParseArgs(args); err != nil {
+		if err, ok := err.(*flags.Error); !ok || err.Type != flags.ErrHelp {
+			return nil, fmt.Errorf("Could not parse options: %s", err)
+		}
+		return nil, nil
+	}
+
+	if parser.Active == nil {
+		return nil, errors.New("No command provided")
+	}
+
+	return &CLI{
+		options,
+		parser.Active.Name,
+		generateKeyOptions,
+		registerNodeOptions,
+	}, nil
+}
+
+func registerNode(logger *zap.Logger, options *CLI) {
+	ctx := context.Background()
+	chainClient, err := blockchain.NewClient(ctx, options.Contracts.RpcUrl)
+	if err != nil {
+		logger.Fatal("could not create chain client", zap.Error(err))
+	}
+
+	signer, err := blockchain.NewPrivateKeySigner(
+		options.RegisterNode.AdminPrivateKey,
+		options.Contracts.ChainID,
+	)
+
+	if err != nil {
+		logger.Fatal("could not create signer", zap.Error(err))
+	}
+
+	registryAdmin, err := blockchain.NewNodeRegistryAdmin(
+		logger,
+		chainClient,
+		signer,
+		options.Contracts,
+	)
+	if err != nil {
+		logger.Fatal("could not create registry admin", zap.Error(err))
+	}
+
+	signingKeyPub, err := utils.ParseEcdsaPublicKey(options.RegisterNode.SigningKey)
+	if err != nil {
+		logger.Fatal("could not decompress public key", zap.Error(err))
+	}
+
+	err = registryAdmin.AddNode(
+		ctx,
+		options.RegisterNode.OwnerAddress,
+		signingKeyPub,
+		options.RegisterNode.HttpAddress,
+	)
+	if err != nil {
+		logger.Fatal("could not add node", zap.Error(err))
+	}
+	logger.Info(
+		"successfully added node",
+		zap.String("node-address", options.RegisterNode.OwnerAddress),
+		zap.String("node-http-address", options.RegisterNode.HttpAddress),
+		zap.String("node-signing-key-pub", utils.EcdsaPublicKeyToString(signingKeyPub)),
+	)
+}
+
+func generateKey(logger *zap.Logger) {
+	privKey, err := utils.GenerateEcdsaPrivateKey()
+	if err != nil {
+		logger.Fatal("could not generate private key", zap.Error(err))
+	}
+	logger.Info(
+		"generated private key",
+		zap.String("private-key", utils.EcdsaPrivateKeyToString(privKey)),
+		zap.String("public-key", utils.EcdsaPublicKeyToString(privKey.Public().(*ecdsa.PublicKey))),
+	)
+}
+
+func main() {
+	options, err := parseOptions(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Could not parse options: %s", err)
+	}
+	if options == nil {
+		return
+	}
+
+	logger, _, err := utils.BuildLogger(options.Log)
+	if err != nil {
+		log.Fatalf("Could not build logger: %s", err)
+	}
+	switch options.Command {
+	case "generate-key":
+		generateKey(logger)
+		return
+	case "register-node":
+		registerNode(logger, options)
+		return
+	}
+
+}

--- a/dev/cli
+++ b/dev/cli
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu
+
+go run cmd/cli/main.go "$@"

--- a/dev/local.env
+++ b/dev/local.env
@@ -11,6 +11,8 @@ XMTPD_CONTRACTS_NODES_ADDRESS="$(jq -r '.deployedTo' build/Nodes.json)" # Built 
 export XMTPD_CONTRACTS_NODES_ADDRESS
 XMTPD_CONTRACTS_MESSAGES_ADDRESS="$(jq -r '.deployedTo' build/GroupMessages.json)" # Built by contracts/deploy-local
 export XMTPD_CONTRACTS_MESSAGES_ADDRESS
+XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS="$(jq -r '.deployedTo' build/IdentityUpdates.json)" # Built by contracts/deploy-local
+export XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS
 
 # Top Level Options
 export XMTPD_SIGNER_PRIVATE_KEY=$PRIVATE_KEY # From contracts/.env

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -51,11 +51,25 @@ type ReflectionOptions struct {
 	Enable bool `long:"enable" env:"XMTPD_REFLECTION_ENABLE" description:"Enable GRPC reflection"`
 }
 
-type ServerOptions struct {
-	LogLevel         string `short:"l" long:"log-level"          env:"XMTPD_LOG_LEVEL"          description:"Define the logging level, supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and their lower-case forms." default:"INFO"`
-	LogEncoding      string `          long:"log-encoding"       env:"XMTPD_LOG_ENCODING"       description:"Log encoding format. Either console or json"                                                                                  default:"console" choice:"console"`
-	SignerPrivateKey string `          long:"signer-private-key" env:"XMTPD_SIGNER_PRIVATE_KEY" description:"Private key used to sign messages"                                                                                                                               required:"true"`
+type LogOptions struct {
+	LogLevel    string `short:"l" long:"log-level"    env:"XMTPD_LOG_LEVEL"    description:"Define the logging level, supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and their lower-case forms." default:"INFO"`
+	LogEncoding string `          long:"log-encoding" env:"XMTPD_LOG_ENCODING" description:"Log encoding format. Either console or json"                                                                                  default:"console"`
+}
 
+type SignerOptions struct {
+	PrivateKey string `long:"private-key" env:"XMTPD_SIGNER_PRIVATE_KEY" description:"Private key used to sign messages" required:"true"`
+}
+
+type GenerateKeyOptions struct{}
+
+type RegisterNodeOptions struct {
+	HttpAddress     string `long:"http-address"      description:"HTTP address to register for the node"                            required:"true"`
+	OwnerAddress    string `long:"owner-address"     description:"Blockchain address of the intended owner of the registration NFT" required:"true"`
+	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to register the node"                    required:"true"`
+	SigningKey      string `long:"signing-key"       description:"Signing key of the node to register"                              required:"true"`
+}
+
+type ServerOptions struct {
 	API           ApiOptions           `group:"API Options"            namespace:"api"`
 	DB            DbOptions            `group:"Database Options"       namespace:"db"`
 	Contracts     ContractsOptions     `group:"Contracts Options"      namespace:"contracts"`
@@ -64,4 +78,6 @@ type ServerOptions struct {
 	Reflection    ReflectionOptions    `group:"Reflection Options"     namespace:"reflection"`
 	Tracing       TracingOptions       `group:"DD APM Tracing Options" namespace:"tracing"`
 	MlsValidation MlsValidationOptions `group:"MLS Validation Options" namespace:"mls-validation"`
+	Log           LogOptions           `group:"Log Options"            namespace:"log"`
+	Signer        SignerOptions        `group:"Signer Options"         namespace:"signer"`
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -74,7 +74,7 @@ func NewReplicationServer(
 		s.ctx,
 		queries.New(s.writerDB),
 		nodeRegistry,
-		options.SignerPrivateKey,
+		options.Signer.PrivateKey,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -25,7 +25,9 @@ func NewTestServer(
 	log := testutils.NewLog(t)
 
 	server, err := s.NewReplicationServer(context.Background(), log, config.ServerOptions{
-		SignerPrivateKey: hex.EncodeToString(crypto.FromECDSA(privateKey)),
+		Signer: config.SignerOptions{
+			PrivateKey: hex.EncodeToString(crypto.FromECDSA(privateKey)),
+		},
 		API: config.ApiOptions{
 			Port: 0,
 		},

--- a/pkg/utils/keys.go
+++ b/pkg/utils/keys.go
@@ -5,8 +5,13 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
+
+func GenerateEcdsaPrivateKey() (*ecdsa.PrivateKey, error) {
+	return crypto.GenerateKey()
+}
 
 func ParseEcdsaPrivateKey(key string) (*ecdsa.PrivateKey, error) {
 	return crypto.HexToECDSA(strings.TrimPrefix(key, "0x"))
@@ -15,4 +20,13 @@ func ParseEcdsaPrivateKey(key string) (*ecdsa.PrivateKey, error) {
 func EcdsaPrivateKeyToString(key *ecdsa.PrivateKey) string {
 	keyBytes := crypto.FromECDSA(key)
 	return "0x" + hex.EncodeToString(keyBytes)
+}
+
+// Take the stringified form of an ECDSA public key and return the *ecdsa.PublicKey
+func ParseEcdsaPublicKey(key string) (*ecdsa.PublicKey, error) {
+	return crypto.DecompressPubkey(common.FromHex(key))
+}
+
+func EcdsaPublicKeyToString(key *ecdsa.PublicKey) string {
+	return "0x" + common.Bytes2Hex(crypto.CompressPubkey(key))
 }

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"github.com/xmtp/xmtpd/pkg/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func BuildLogger(options config.LogOptions) (*zap.Logger, *zap.Config, error) {
+	atom := zap.NewAtomicLevel()
+	level := zapcore.InfoLevel
+	err := level.Set(options.LogLevel)
+	if err != nil {
+		return nil, nil, err
+	}
+	atom.SetLevel(level)
+
+	cfg := zap.Config{
+		Encoding:         options.LogEncoding,
+		Level:            atom,
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:   "message",
+			LevelKey:     "level",
+			EncodeLevel:  zapcore.CapitalLevelEncoder,
+			TimeKey:      "time",
+			EncodeTime:   zapcore.ISO8601TimeEncoder,
+			NameKey:      "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+	logger, err := cfg.Build()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	logger = logger.Named("replication")
+
+	return logger, &cfg, nil
+}


### PR DESCRIPTION
## tl;dr

- Adds a CLI with two commands (`generate-key`, `register-node`)
- Refactors the config to better handle CLI commands

## Why this way?

I spent a fair bit of time on Friday looking at different "CLI frameworks" and tools and ultimately decided not to use any of them.  [urfave/cli](https://cli.urfave.org/v2/examples/flags/), [Cobra](https://cobra.dev/), and [Kong](https://github.com/alecthomas/kong) all require a bunch of framework-specific boilerplate for little upside.

Even after you've written all that boilerplate, it's still a bunch of work to map those CLI args to a nice config struct like what we have.

The requirements we have for command line parsing are pretty simple:

- Parse the command line arguments and environment variables into a nice struct
- Validate required fields are present (with different required fields per command)
- Show good errors when required fields are missing or invalid values are set
- Generate help text

## Known issues

I haven't figured out how to get good help text for the command-specific arguments. If I put everything into one big command struct, then the required fields for one command become required for every command. That's why I have broken up the `globalOptions` and the command-specific option structs.

Will keep working to make sure we have good help text