### PR TITLE
Thread-safe subscriptions and listener cleanup

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -79,10 +79,11 @@ func (s *Service) BatchSubscribeEnvelopes(
 		return status.Errorf(codes.InvalidArgument, "missing requests")
 	}
 
-	ch, err := s.subscribeWorker.listen(requests)
+	ch, cleanup, err := s.subscribeWorker.listen(requests)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid subscription request: %v", err)
 	}
+	defer cleanup()
 
 	for {
 		select {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -79,11 +79,10 @@ func (s *Service) BatchSubscribeEnvelopes(
 		return status.Errorf(codes.InvalidArgument, "missing requests")
 	}
 
-	ch, cleanup, err := s.subscribeWorker.listen(requests)
+	ch, err := s.subscribeWorker.listen(stream.Context(), requests)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid subscription request: %v", err)
 	}
-	defer cleanup()
 
 	for {
 		select {
@@ -97,7 +96,7 @@ func (s *Service) BatchSubscribeEnvelopes(
 				}
 			} else {
 				// TODO(rich) Recover from backpressure
-				log.Info("stream closed due to backpressure")
+				log.Debug("channel closed by worker")
 				return nil
 			}
 		case <-stream.Context().Done():

--- a/pkg/api/subscribeWorker.go
+++ b/pkg/api/subscribeWorker.go
@@ -44,7 +44,7 @@ func (ls *listenerSet) removeListener(l *listener) {
 	ls.Delete(l)
 }
 
-func (ls *listenerSet) isEmpty() bool {
+func (ls *listenerSet) IsEmpty() bool {
 	empty := true
 	ls.Range(func(_, _ interface{}) bool {
 		empty = false
@@ -65,20 +65,13 @@ func (lm *listenersMap[K]) addListener(key K, l *listener) {
 }
 
 func (lm *listenersMap[K]) removeListener(key K, l *listener) {
-	for {
-		value, ok := lm.Load(key)
-		if !ok || value == nil {
-			return // Key doesn't exist, nothing to do
-		}
-		set := value.(*listenerSet)
-		set.removeListener(l)
-
-		if !set.isEmpty() || lm.CompareAndDelete(key, value) {
-			return
-		}
-		// Another goroutine either removed the key already or added a listener,
-		// try again. Should only retry once at most.
+	value, ok := lm.Load(key)
+	if !ok || value == nil {
+		return // Key doesn't exist, nothing to do
 	}
+	set := value.(*listenerSet)
+	set.removeListener(l)
+	// TODO(rich): Delete keys that hold empty sets
 }
 
 // A worker that listens for new envelopes in the DB and sends them to subscribers

--- a/pkg/api/subscribeWorker.go
+++ b/pkg/api/subscribeWorker.go
@@ -228,9 +228,11 @@ func (s *subscribeWorker) closeListener(l *listener) {
 	go func() {
 		if l.isGlobal {
 			s.globalListeners.Delete(l)
+		} else if len(l.topics) > 0 {
+			s.topicListeners.removeListener(l.topics, l)
+		} else if len(l.originators) > 0 {
+			s.originatorListeners.removeListener(l.originators, l)
 		}
-		s.topicListeners.removeListener(l.topics, l)
-		s.originatorListeners.removeListener(l.originators, l)
 	}()
 }
 

--- a/pkg/api/subscribe_test.go
+++ b/pkg/api/subscribe_test.go
@@ -104,7 +104,6 @@ func validateUpdates(
 }
 
 func TestSubscribeEnvelopesAll(t *testing.T) {
-	t.Skip("TODO(rich) thread safety for race tests")
 	client, db, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, db)
@@ -131,7 +130,6 @@ func TestSubscribeEnvelopesAll(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesByTopic(t *testing.T) {
-	t.Skip("TODO(rich) thread safety for race tests")
 	client, db, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, db)
@@ -164,7 +162,6 @@ func TestSubscribeEnvelopesByTopic(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesByOriginator(t *testing.T) {
-	t.Skip("TODO(rich) thread safety for race tests")
 	client, db, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, db)
@@ -197,7 +194,6 @@ func TestSubscribeEnvelopesByOriginator(t *testing.T) {
 }
 
 func TestSimultaneousSubscriptions(t *testing.T) {
-	t.Skip("TODO(rich) thread safety for race tests")
 	client, db, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, db)
@@ -256,7 +252,6 @@ func TestSimultaneousSubscriptions(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesInvalidRequest(t *testing.T) {
-	t.Skip("TODO(rich) thread safety for race tests")
 	client, _, cleanup := setupTest(t)
 	defer cleanup()
 


### PR DESCRIPTION
This PR adds:
- Thread-safety for mutation of listener maps
- Safe cleanup flow for listener channels

As a general principle, we use Golang's `sync.map`. This is an optimistic concurrency pattern that restricts contention to a per-key level, and separates reads and writes via a read-only map and dirty map. So the dispatch loop is not affected - any mutations to the sync maps are performed outside of the dispatching goroutine.

I've also added a `RWMutex` to synchronize between adding and removing listeners. The main thing we are protecting against is that when removing a listener, we may want to delete the `listenerset` if it is empty - but we can't perform the emptiness check and the deletion step atomically without a mutex. I think this should be okay, because in the current server we are getting something like 10 new subscriptions a second.

Would love to do some benchmarking on this later to make sure we've made the right tradeoffs, I can see us changing out the implementation underneath depending on where the bottleneck is.

Closes https://github.com/xmtp/xmtpd/issues/125