### PR TITLE
Document go 1.22 and golangci-lint 1.56 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ To keep up with and provide feedback about `xmtpd` development, see the [Issues 
 
 ## Prerequisites
 
-- [Go](https://go.dev/doc/install)
+- [Go 1.22](https://go.dev/doc/install) -- On macOS install with `brew install go@1.22`
 - [Docker](https://www.docker.com/get-started/)
+
+Note that a dependency of this repo will not compile with version of go newer than 1.22.
 
 ## Install and build dependencies
 

--- a/dev/up
+++ b/dev/up
@@ -6,7 +6,7 @@ git submodule update --init --recursive
 
 if ! which forge &>/dev/null; then curl -L https://foundry.paradigm.xyz | bash ; fi
 if ! which migrate &>/dev/null; then go install github.com/golang-migrate/migrate/v4/cmd/migrate; fi
-if ! which golangci-lint &>/dev/null; then brew install golangci-lint; fi
+if ! which golangci-lint &>/dev/null; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.56.0; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
 if ! which mockery &>/dev/null; then go install github.com/vektra/mockery/v2; fi
 if ! which sqlc &> /dev/null; then go install github.com/sqlc-dev/sqlc/cmd/sqlc; fi


### PR DESCRIPTION
TL;DR: Due to an incompatibility with go 1.23 and a dependency of abigen, devs must explicitly install go 1.22 (ex: using brew install go@1.22) and golangci-lint 1.56.

xmtpd requires abigen which uses memsize. memsize relies on access to `runtime.stopTheWorld` and `runtime.startTheWorld` [1] which was OK in go 1.22 and forbidden in go 1.23

[1] https://github.com/golang/go/issues/68167
