### PR TITLE
Fix graceful shutdown

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -126,6 +126,8 @@ func (s *ApiServer) gracefulShutdown(timeout time.Duration) {
 	go func() {
 		defer cancel()
 		<-time.NewTimer(timeout).C
+		s.log.Info("Graceful shutdown timed out. Stopping...")
+		s.grpcServer.Stop()
 	}()
 
 	<-ctx.Done()


### PR DESCRIPTION
Once graceful shutdown times out, it does not actually kill itself. Fix it.