### PR TITLE
Wait for container processes

### DIFF
--- a/dev/docker/up
+++ b/dev/docker/up
@@ -3,4 +3,4 @@ set -e
 . dev/docker/env
 
 docker_compose build
-docker_compose up -d --remove-orphans
+docker_compose up -d --remove-orphans --wait


### PR DESCRIPTION
In some cases there is a race between the blockchain container and the process inserting new nodes.

Make sure the processes are all up in `detached` mode.