### PR TITLE
Fix Versioning

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -48,3 +48,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: "GIT_COMMIT=${{sha}}"

--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: benjlevesque/short-sha@v3.0
-        id: short-sha
-        with:
-          length: 7
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:
@@ -51,4 +47,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: "GIT_COMMIT=${{steps.short-sha.outputs.sha}}"
+          build-args: "GIT_COMMIT=$${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - uses: benjlevesque/short-sha@v3.0
+        id: short-sha
+        with:
+          length: 7
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:
@@ -48,4 +51,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: "GIT_COMMIT=${{sha}}"
+          build-args: "GIT_COMMIT=${{steps.short-sha.outputs.sha}}"

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -21,7 +21,7 @@
       <option name="workingDir" value="" />
       <envs />
     </TaskOptions>
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="run --fast $FileDir$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 
@@ -25,6 +26,14 @@ func main() {
 		if err, ok := err.(*flags.Error); !ok || err.Type != flags.ErrHelp {
 			fatal("Could not parse options: %s", err)
 		}
+		return
+	}
+
+	if Commit != "" {
+		fmt.Printf("Version: %s\n", Commit)
+	}
+
+	if options.Version {
 		return
 	}
 

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -16,12 +16,9 @@ RUN go build -ldflags="-X 'main.Commit=$GIT_COMMIT'" -o bin/xmtpd cmd/replicatio
 
 FROM alpine:3.12
 
-ARG GIT_COMMIT=unknown
-
 LABEL maintainer="engineering@xmtp.com"
 LABEL source="https://github.com/xmtp/xmtpd"
 LABEL description="XMTP Node Software"
-LABEL commit=$GIT_COMMIT
 
 # color, nocolor, json
 ENV GOLOG_LOG_FMT=nocolor

--- a/dev/docker/build
+++ b/dev/docker/build
@@ -3,7 +3,7 @@ set -e
 
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
 DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/xmtpd}"
-GIT_COMMIT="$(git rev-parse --short HEAD)"
+GIT_COMMIT="$(git rev-parse HEAD)"
 
 docker buildx build \
     --build-arg="GIT_COMMIT=${GIT_COMMIT}" \

--- a/dev/docker/build
+++ b/dev/docker/build
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -e
+
+DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/xmtpd}"
+GIT_COMMIT="$(git rev-parse --short HEAD)"
+
+docker buildx build \
+    --build-arg="GIT_COMMIT=${GIT_COMMIT}" \
+    --tag "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" \
+    -f dev/docker/Dockerfile \
+    .

--- a/dev/run
+++ b/dev/run
@@ -4,4 +4,4 @@ set -eu
 
 . dev/local.env
 
-go run cmd/replication/main.go "$@"
+go run -ldflags="-X main.Commit=$(git rev-parse --short HEAD)" cmd/replication/main.go "$@"

--- a/dev/run
+++ b/dev/run
@@ -4,4 +4,4 @@ set -eu
 
 . dev/local.env
 
-go run -ldflags="-X main.Commit=$(git rev-parse --short HEAD)" cmd/replication/main.go "$@"
+go run -ldflags="-X main.Commit=$(git rev-parse HEAD)" cmd/replication/main.go "$@"

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -84,4 +84,5 @@ type ServerOptions struct {
 	MlsValidation MlsValidationOptions `group:"MLS Validation Options" namespace:"mls-validation"`
 	Log           LogOptions           `group:"Log Options"            namespace:"log"`
 	Signer        SignerOptions        `group:"Signer Options"         namespace:"signer"`
+	Version       bool                 `                                                          long:"version" description:"Output binary version and exit"`
 }


### PR DESCRIPTION
This correctly injects the git sha into the image so that we can query it with `--version`.

More importantly, the version will now show up in the datalog logs.