### PR TITLE
Fix up instructions

### DIFF
--- a/dev/up
+++ b/dev/up
@@ -4,7 +4,7 @@ set -e
 go mod tidy
 git submodule update --init --recursive
 
-if ! which forge &>/dev/null; then curl -L https://foundry.paradigm.xyz | bash ; fi
+if ! which forge &>/dev/null; then echo "ERROR: Missing foundry binaries. Run 'curl -L https://foundry.paradigm.xyz | bash' and follow the instructions" && exit 1; fi
 if ! which migrate &>/dev/null; then go install github.com/golang-migrate/migrate/v4/cmd/migrate; fi
 if ! which golangci-lint &>/dev/null; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.56.0; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi


### PR DESCRIPTION
One needs to run `foundryup` and add the `bin` to the path. Given that every user might prefer a different manipulation of their PATH, it is hard to automate.

This tripped up @codabrink when trying things out