### PR TITLE
Add envelope structs

### DIFF
--- a/pkg/envelopes/client.go
+++ b/pkg/envelopes/client.go
@@ -37,7 +37,7 @@ func NewClientEnvelopeFromBytes(bytes []byte) (*ClientEnvelope, error) {
 	return NewClientEnvelope(&message)
 }
 
-func (c *ClientEnvelope) ToBytes() ([]byte, error) {
+func (c *ClientEnvelope) Bytes() ([]byte, error) {
 	bytes, err := proto.Marshal(c.proto)
 	if err != nil {
 		return nil, err

--- a/pkg/envelopes/client.go
+++ b/pkg/envelopes/client.go
@@ -24,6 +24,8 @@ func NewClientEnvelope(proto *message_api.ClientEnvelope) (*ClientEnvelope, erro
 		return nil, errors.New("payload is missing")
 	}
 
+	// TODO:(nm) Validate topic
+
 	return &ClientEnvelope{proto: proto}, nil
 }
 
@@ -41,6 +43,10 @@ func (c *ClientEnvelope) ToBytes() ([]byte, error) {
 		return nil, err
 	}
 	return bytes, nil
+}
+
+func (c *ClientEnvelope) Aad() *message_api.AuthenticatedData {
+	return c.proto.Aad
 }
 
 func (c *ClientEnvelope) Proto() *message_api.ClientEnvelope {

--- a/pkg/envelopes/client.go
+++ b/pkg/envelopes/client.go
@@ -1,0 +1,48 @@
+package envelopes
+
+import (
+	"errors"
+
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"google.golang.org/protobuf/proto"
+)
+
+type ClientEnvelope struct {
+	proto *message_api.ClientEnvelope
+}
+
+func NewClientEnvelope(proto *message_api.ClientEnvelope) (*ClientEnvelope, error) {
+	if proto == nil {
+		return nil, errors.New("proto is nil")
+	}
+
+	if proto.Aad == nil {
+		return nil, errors.New("aad is missing")
+	}
+
+	if proto.Payload == nil {
+		return nil, errors.New("payload is missing")
+	}
+
+	return &ClientEnvelope{proto: proto}, nil
+}
+
+func NewClientEnvelopeFromBytes(bytes []byte) (*ClientEnvelope, error) {
+	var message message_api.ClientEnvelope
+	if err := proto.Unmarshal(bytes, &message); err != nil {
+		return nil, err
+	}
+	return NewClientEnvelope(&message)
+}
+
+func (c *ClientEnvelope) ToBytes() ([]byte, error) {
+	bytes, err := proto.Marshal(c.proto)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+func (c *ClientEnvelope) Proto() *message_api.ClientEnvelope {
+	return c.proto
+}

--- a/pkg/envelopes/envelopes_test.go
+++ b/pkg/envelopes/envelopes_test.go
@@ -38,6 +38,30 @@ func TestValidOriginatorEnvelope(t *testing.T) {
 	require.Equal(t, serializedClientEnv, serializedClientEnvAfterParse)
 }
 
+func TestSerialize(t *testing.T) {
+	originatorNodeId := uint32(1)
+	originatorSequenceId := uint64(1)
+
+	clientEnv := testutils.CreateClientEnvelope()
+	payerEnvelope := testutils.CreatePayerEnvelope(t, clientEnv)
+	originatorEnvelope := testutils.CreateOriginatorEnvelope(
+		t,
+		originatorNodeId,
+		originatorSequenceId,
+		payerEnvelope,
+	)
+
+	serializedFromProto, err := proto.Marshal(originatorEnvelope)
+	require.NoError(t, err)
+
+	originatorStruct, err := NewOriginatorEnvelope(originatorEnvelope)
+	require.NoError(t, err)
+	serializedFromStruct, err := originatorStruct.ToBytes()
+	require.NoError(t, err)
+
+	require.Equal(t, serializedFromProto, serializedFromStruct)
+}
+
 func TestInvalidOriginatorEnvelope(t *testing.T) {
 	_, err := NewOriginatorEnvelope(nil)
 	require.Error(t, err)

--- a/pkg/envelopes/envelopes_test.go
+++ b/pkg/envelopes/envelopes_test.go
@@ -33,7 +33,7 @@ func TestValidOriginatorEnvelope(t *testing.T) {
 
 	serializedClientEnv, err := proto.Marshal(clientEnv)
 	require.NoError(t, err)
-	serializedClientEnvAfterParse, err := processed.UnsignedOriginatorEnvelope.PayerEnvelope.ClientEnvelope.ToBytes()
+	serializedClientEnvAfterParse, err := processed.UnsignedOriginatorEnvelope.PayerEnvelope.ClientEnvelope.Bytes()
 	require.NoError(t, err)
 	require.Equal(t, serializedClientEnv, serializedClientEnvAfterParse)
 }
@@ -56,7 +56,7 @@ func TestSerialize(t *testing.T) {
 
 	originatorStruct, err := NewOriginatorEnvelope(originatorEnvelope)
 	require.NoError(t, err)
-	serializedFromStruct, err := originatorStruct.ToBytes()
+	serializedFromStruct, err := originatorStruct.Bytes()
 	require.NoError(t, err)
 
 	require.Equal(t, serializedFromProto, serializedFromStruct)

--- a/pkg/envelopes/envelopes_test.go
+++ b/pkg/envelopes/envelopes_test.go
@@ -1,0 +1,75 @@
+package envelopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestValidOriginatorEnvelope(t *testing.T) {
+	originatorNodeId := uint32(1)
+	originatorSequenceId := uint64(1)
+
+	clientEnv := testutils.CreateClientEnvelope()
+	payerEnvelope := testutils.CreatePayerEnvelope(t, clientEnv)
+	originatorEnvelope := testutils.CreateOriginatorEnvelope(
+		t,
+		originatorNodeId,
+		originatorSequenceId,
+		payerEnvelope,
+	)
+
+	processed, err := NewOriginatorEnvelope(originatorEnvelope)
+	require.NoError(t, err)
+	require.Equal(t, originatorNodeId, processed.UnsignedOriginatorEnvelope.OriginatorNodeID())
+	require.Equal(
+		t,
+		originatorSequenceId,
+		processed.UnsignedOriginatorEnvelope.OriginatorSequenceID(),
+	)
+
+	serializedClientEnv, err := proto.Marshal(clientEnv)
+	require.NoError(t, err)
+	serializedClientEnvAfterParse, err := processed.UnsignedOriginatorEnvelope.PayerEnvelope.ClientEnvelope.ToBytes()
+	require.NoError(t, err)
+	require.Equal(t, serializedClientEnv, serializedClientEnvAfterParse)
+}
+
+func TestInvalidOriginatorEnvelope(t *testing.T) {
+	_, err := NewOriginatorEnvelope(nil)
+	require.Error(t, err)
+
+	empty := &message_api.OriginatorEnvelope{}
+	_, err = NewOriginatorEnvelope(empty)
+	require.Error(t, err)
+}
+
+func TestInvalidUnsignedOriginatorEnvelope(t *testing.T) {
+	_, err := NewUnsignedOriginatorEnvelope(nil)
+	require.Error(t, err)
+
+	empty := &message_api.UnsignedOriginatorEnvelope{}
+	_, err = NewUnsignedOriginatorEnvelope(empty)
+	require.Error(t, err)
+}
+
+func TestInvalidPayerEnvelope(t *testing.T) {
+	_, err := NewPayerEnvelope(nil)
+	require.Error(t, err)
+
+	empty := &message_api.PayerEnvelope{}
+	_, err = NewPayerEnvelope(empty)
+	require.Error(t, err)
+}
+
+func TestInvalidClientEnvelope(t *testing.T) {
+	_, err := NewClientEnvelope(nil)
+	require.Error(t, err)
+
+	empty := &message_api.ClientEnvelope{}
+	_, err = NewClientEnvelope(empty)
+	require.Error(t, err)
+}

--- a/pkg/envelopes/originator.go
+++ b/pkg/envelopes/originator.go
@@ -28,7 +28,7 @@ func NewOriginatorEnvelope(proto *message_api.OriginatorEnvelope) (*OriginatorEn
 	}, nil
 }
 
-func (o *OriginatorEnvelope) ToBytes() ([]byte, error) {
+func (o *OriginatorEnvelope) Bytes() ([]byte, error) {
 	bytes, err := proto.Marshal(o.proto)
 	if err != nil {
 		return nil, err

--- a/pkg/envelopes/originator.go
+++ b/pkg/envelopes/originator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"google.golang.org/protobuf/proto"
 )
 
 type OriginatorEnvelope struct {
@@ -25,6 +26,14 @@ func NewOriginatorEnvelope(proto *message_api.OriginatorEnvelope) (*OriginatorEn
 		proto:                      proto,
 		UnsignedOriginatorEnvelope: *unsigned,
 	}, nil
+}
+
+func (o *OriginatorEnvelope) ToBytes() ([]byte, error) {
+	bytes, err := proto.Marshal(o.proto)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
 }
 
 func (o *OriginatorEnvelope) Proto() *message_api.OriginatorEnvelope {

--- a/pkg/envelopes/originator.go
+++ b/pkg/envelopes/originator.go
@@ -1,0 +1,32 @@
+package envelopes
+
+import (
+	"errors"
+
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+)
+
+type OriginatorEnvelope struct {
+	proto                      *message_api.OriginatorEnvelope
+	UnsignedOriginatorEnvelope UnsignedOriginatorEnvelope
+}
+
+func NewOriginatorEnvelope(proto *message_api.OriginatorEnvelope) (*OriginatorEnvelope, error) {
+	if proto == nil {
+		return nil, errors.New("proto is nil")
+	}
+
+	unsigned, err := NewUnsignedOriginatorEnvelopeFromBytes(proto.UnsignedOriginatorEnvelope)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OriginatorEnvelope{
+		proto:                      proto,
+		UnsignedOriginatorEnvelope: *unsigned,
+	}, nil
+}
+
+func (o *OriginatorEnvelope) Proto() *message_api.OriginatorEnvelope {
+	return o.proto
+}

--- a/pkg/envelopes/payer.go
+++ b/pkg/envelopes/payer.go
@@ -1,0 +1,28 @@
+package envelopes
+
+import (
+	"errors"
+
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+)
+
+type PayerEnvelope struct {
+	proto          *message_api.PayerEnvelope
+	ClientEnvelope ClientEnvelope
+}
+
+func NewPayerEnvelope(proto *message_api.PayerEnvelope) (*PayerEnvelope, error) {
+	if proto == nil {
+		return nil, errors.New("proto is nil")
+	}
+
+	clientEnv, err := NewClientEnvelopeFromBytes(proto.UnsignedClientEnvelope)
+	if err != nil {
+		return nil, err
+	}
+	return &PayerEnvelope{proto: proto, ClientEnvelope: *clientEnv}, nil
+}
+
+func (p *PayerEnvelope) Proto() *message_api.PayerEnvelope {
+	return p.proto
+}

--- a/pkg/envelopes/unsignedOriginator.go
+++ b/pkg/envelopes/unsignedOriginator.go
@@ -1,0 +1,57 @@
+package envelopes
+
+import (
+	"errors"
+
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"google.golang.org/protobuf/proto"
+)
+
+type UnsignedOriginatorEnvelope struct {
+	proto         *message_api.UnsignedOriginatorEnvelope
+	PayerEnvelope PayerEnvelope
+}
+
+// Construct an UnsignedOriginatorEnvelope and perform validations on any child fields.
+// Does not verify signatures
+func NewUnsignedOriginatorEnvelope(
+	proto *message_api.UnsignedOriginatorEnvelope,
+) (*UnsignedOriginatorEnvelope, error) {
+	if proto == nil {
+		return nil, errors.New("proto is nil")
+	}
+
+	payer, err := NewPayerEnvelope(proto.PayerEnvelope)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UnsignedOriginatorEnvelope{proto: proto, PayerEnvelope: *payer}, nil
+}
+
+func (u *UnsignedOriginatorEnvelope) OriginatorNodeID() uint32 {
+	// Skip nil check because it is in the constructor
+	return u.proto.OriginatorNodeId
+}
+
+func (u *UnsignedOriginatorEnvelope) OriginatorSequenceID() uint64 {
+	// Skip nil check because it is in the constructor
+	return u.proto.OriginatorSequenceId
+}
+
+func (u *UnsignedOriginatorEnvelope) OriginatorNs() int64 {
+	// Skip nil check because it is in the constructor
+	return u.proto.OriginatorNs
+}
+
+func NewUnsignedOriginatorEnvelopeFromBytes(bytes []byte) (*UnsignedOriginatorEnvelope, error) {
+	var message message_api.UnsignedOriginatorEnvelope
+	if err := proto.Unmarshal(bytes, &message); err != nil {
+		return nil, err
+	}
+	return NewUnsignedOriginatorEnvelope(&message)
+}
+
+func (u *UnsignedOriginatorEnvelope) Proto() *message_api.UnsignedOriginatorEnvelope {
+	return u.proto
+}

--- a/pkg/testutils/envelopes.go
+++ b/pkg/testutils/envelopes.go
@@ -30,7 +30,7 @@ func UnmarshalUnsignedOriginatorEnvelope(
 
 func CreateClientEnvelope() *message_api.ClientEnvelope {
 	return &message_api.ClientEnvelope{
-		Payload: nil,
+		Payload: &message_api.ClientEnvelope_GroupMessage{},
 		Aad: &message_api.AuthenticatedData{
 			TargetOriginator: 1,
 			TargetTopic:      []byte{0x5},


### PR DESCRIPTION
## tl;dr

Parsing and dealing with envelopes is a pain because of all the nested serialization. This simplifies some of that by creating a struct that can deserialize all the child protos and make it easier to perform validations.

## Next up

- Add signature verification methods to this struct
- Add topic validations
- Add better handling of `ClientEnvelope` payloads