### PR TITLE
Add Topic package with parsing and testing

### DIFF
--- a/pkg/indexer/e2e_test.go
+++ b/pkg/indexer/e2e_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
-	"github.com/xmtp/xmtpd/pkg/indexer/storer"
 	"github.com/xmtp/xmtpd/pkg/mocks/mlsvalidate"
 	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/topic"
 )
 
 func startIndexing(t *testing.T) (*queries.Queries, context.Context, func()) {
@@ -57,7 +57,7 @@ func TestStoreMessages(t *testing.T) {
 
 	message := testutils.RandomBytes(32)
 	groupID := testutils.RandomGroupID()
-	topic := []byte(storer.BuildGroupMessageTopic(groupID))
+	topic := topic.NewTopic(topic.TOPIC_KIND_GROUP_MESSAGES_V1, groupID[:]).Bytes()
 
 	// Publish the message onto the blockchain
 	require.NoError(t, publisher.PublishGroupMessage(ctx, groupID, message))

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -1,0 +1,78 @@
+package topic
+
+import (
+	"errors"
+	"fmt"
+)
+
+type TopicKind uint8
+
+const (
+	TOPIC_KIND_GROUP_MESSAGES_V1 TopicKind = iota
+	TOPIC_KIND_WELCOME_MESSAGES_V1
+	TOPIC_KIND_IDENTITY_UPDATES_V1
+	TOPIC_KIND_KEY_PACKAGES_V1
+)
+
+func (k TopicKind) String() string {
+	switch k {
+	case TOPIC_KIND_GROUP_MESSAGES_V1:
+		return "group_messages_v1"
+	case TOPIC_KIND_WELCOME_MESSAGES_V1:
+		return "welcome_message_v1"
+	case TOPIC_KIND_IDENTITY_UPDATES_V1:
+		return "identity_updates_v1"
+	case TOPIC_KIND_KEY_PACKAGES_V1:
+		return "key_packages_v1"
+	default:
+		return "unknown"
+	}
+}
+
+type Topic struct {
+	kind       TopicKind
+	identifier []byte
+}
+
+func NewTopic(kind TopicKind, identifier []byte) *Topic {
+	return &Topic{
+		kind:       kind,
+		identifier: identifier,
+	}
+}
+
+func (t *Topic) Bytes() []byte {
+	result := make([]byte, 1+len(t.identifier))
+	result[0] = byte(t.kind)
+	copy(result[1:], t.identifier)
+	return result
+}
+
+func (t *Topic) String() string {
+	return fmt.Sprintf("%s/%x", t.kind.String(), t.identifier)
+}
+
+func ParseTopic(topic []byte) (*Topic, error) {
+	if len(topic) < 2 {
+		return nil, errors.New("topic must be at least 2 bytes long")
+	}
+
+	kind := TopicKind(topic[0])
+	identifier := topic[1:]
+
+	newTopic := NewTopic(kind, identifier)
+
+	if newTopic.Kind().String() == "unknown" {
+		return nil, fmt.Errorf("unknown topic kind %d", kind)
+	}
+
+	return newTopic, nil
+}
+
+func (t *Topic) Kind() TopicKind {
+	return t.kind
+}
+
+func (t *Topic) Identifier() []byte {
+	return t.identifier
+}

--- a/pkg/topic/topic_test.go
+++ b/pkg/topic/topic_test.go
@@ -1,0 +1,53 @@
+package topic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/utils"
+)
+
+func TestValidTopic(t *testing.T) {
+	newTopic := []byte{1, 2, 3}
+	topic, err := ParseTopic(newTopic)
+	require.NoError(t, err)
+	require.Equal(t, TOPIC_KIND_WELCOME_MESSAGES_V1, topic.Kind())
+	require.Equal(t, []byte{2, 3}, topic.Identifier())
+}
+
+func TestMissingIdentifier(t *testing.T) {
+	newTopic := []byte{1}
+	topic, err := ParseTopic(newTopic)
+	require.Error(t, err)
+	require.Nil(t, topic)
+}
+
+func TestInvalidKind(t *testing.T) {
+	newTopic := []byte{255, 2, 3}
+	topic, err := ParseTopic(newTopic)
+	require.Error(t, err)
+	require.Nil(t, topic)
+}
+
+func TestTopicString(t *testing.T) {
+	identifier := testutils.RandomBytes(32)
+
+	groupMessagesTopic := NewTopic(TOPIC_KIND_GROUP_MESSAGES_V1, identifier)
+	require.Equal(t, "group_messages_v1", groupMessagesTopic.Kind().String())
+	require.Equal(t, identifier, groupMessagesTopic.Identifier())
+	require.Equal(
+		t,
+		"group_messages_v1/"+utils.HexEncode(identifier),
+		groupMessagesTopic.String(),
+	)
+
+	identityUpdatesTopic := NewTopic(TOPIC_KIND_IDENTITY_UPDATES_V1, identifier)
+	require.Equal(t, "identity_updates_v1", identityUpdatesTopic.Kind().String())
+	require.Equal(t, identifier, identityUpdatesTopic.Identifier())
+	require.Equal(
+		t,
+		"identity_updates_v1/"+utils.HexEncode(identifier),
+		identityUpdatesTopic.String(),
+	)
+}


### PR DESCRIPTION
### TL;DR

Introduced a new `topic` package to standardize topic handling across the codebase.

### What changed?

- Created a new `topic` package with a `Topic` struct and related functions.
- Implemented `TopicKind` enum to represent different types of topics.
- Updated `groupMessage.go` and `identityUpdate.go` to use the new `Topic` struct.
- Removed the `BuildGroupMessageTopic` function and replaced its usage with the new `Topic` struct.
- Updated the e2e test to use the new topic creation method.

### How to test?

1. Run the existing test suite to ensure all tests pass with the new changes.
2. Check the new `topic_test.go` file for specific tests related to the new `Topic` struct and its functions.
3. Verify that the e2e test in `e2e_test.go` still functions correctly with the updated topic creation.

### Why make this change?

This change standardizes the way topics are handled across the codebase, making it easier to manage and extend topic-related functionality. It also improves type safety and provides a more structured approach to working with different kinds of topics, reducing the likelihood of errors and improving code maintainability.