### PR TITLE
Create signing method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.66.0
 )
 
+require github.com/golang-jwt/jwt/v5 v5.2.1
+
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.2-20240717164558-a6c49f84cc0f.2 // indirect
 	buf.build/gen/go/bufbuild/registry/connectrpc/go v1.16.2-20240821192916-45ba72cdd479.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-migrate/migrate/v4 v4.17.1 h1:4zQ6iqL6t6AiItphxJctQb3cFqWiSpMnX7wLTPnnYO4=
 github.com/golang-migrate/migrate/v4 v4.17.1/go.mod h1:m8hinFyWBn0SA4QKHuKh175Pm9wjmxj3S2Mia7dbXzM=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=

--- a/pkg/authn/signingMethod.go
+++ b/pkg/authn/signingMethod.go
@@ -1,0 +1,88 @@
+package authn
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	ALGORITHM               = "ES256K"
+	SIG_LENGTH              = 65
+	R_LENGTH                = 32
+	S_LENGTH                = 32
+	DOMAIN_SEPARATION_LABEL = "jwt"
+)
+
+var (
+	ErrWrongKeyFormat = errors.New("wrong key type")
+	ErrBadSignature   = errors.New("bad signature")
+	ErrVerification   = errors.New("signature verification failed")
+)
+
+/*
+*
+The JWT signing method for secp256k1. Inspired by https://github.com/ureeves/jwt-go-secp256k1/blob/master/secp256k1.go
+but updated to work with the latest version of jwt-go.
+*/
+type SigningMethodSecp256k1 struct{}
+
+func (sm *SigningMethodSecp256k1) Verify(signingString string, sig []byte, key interface{}) error {
+	pub, ok := key.(*ecdsa.PublicKey)
+	if !ok {
+		return ErrWrongKeyFormat
+	}
+
+	hashedString := hashStringWithDomainSeparation(signingString)
+
+	if len(sig) != SIG_LENGTH {
+		return ErrBadSignature
+	}
+
+	r := new(big.Int).SetBytes(sig[:R_LENGTH])                    // R
+	s := new(big.Int).SetBytes(sig[R_LENGTH : R_LENGTH+S_LENGTH]) // S
+
+	if !ecdsa.Verify(pub, hashedString, r, s) {
+		return ErrVerification
+	}
+
+	return nil
+}
+
+func (sm *SigningMethodSecp256k1) Sign(signingString string, key interface{}) ([]byte, error) {
+	priv, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, ErrWrongKeyFormat
+	}
+
+	hashedString := hashStringWithDomainSeparation(signingString)
+
+	sig, err := ethcrypto.Sign(hashedString, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sig) != SIG_LENGTH {
+		return nil, ErrBadSignature
+	}
+
+	return sig, nil
+}
+
+func (sm *SigningMethodSecp256k1) Alg() string {
+	return ALGORITHM
+}
+
+func hashStringWithDomainSeparation(signingString string) []byte {
+	return ethcrypto.Keccak256([]byte(DOMAIN_SEPARATION_LABEL + signingString))
+}
+
+func init() {
+	method := &SigningMethodSecp256k1{}
+	jwt.RegisterSigningMethod(ALGORITHM, func() jwt.SigningMethod {
+		return method
+	})
+}

--- a/pkg/authn/signingMethod_test.go
+++ b/pkg/authn/signingMethod_test.go
@@ -1,0 +1,74 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+)
+
+func TestSign(t *testing.T) {
+	privateKey := testutils.RandomPrivateKey(t)
+	publicKey := privateKey.Public()
+
+	method := &SigningMethodSecp256k1{}
+
+	signingString := "test"
+	signature, err := method.Sign(signingString, privateKey)
+	require.NoError(t, err)
+
+	err = method.Verify(signingString, signature, publicKey)
+	require.NoError(t, err)
+}
+
+func TestWrongSigner(t *testing.T) {
+	goodPrivateKey := testutils.RandomPrivateKey(t)
+
+	badPrivateKey := testutils.RandomPrivateKey(t)
+	badPublicKey := badPrivateKey.Public()
+
+	method := &SigningMethodSecp256k1{}
+
+	signingString := "test"
+	signature, err := method.Sign(signingString, goodPrivateKey)
+	require.NoError(t, err)
+
+	err = method.Verify(signingString, signature, badPublicKey)
+	require.Error(t, err)
+}
+
+func TestWrongSigningString(t *testing.T) {
+	privateKey := testutils.RandomPrivateKey(t)
+	publicKey := privateKey.Public()
+
+	method := &SigningMethodSecp256k1{}
+
+	signingString := "test"
+	signature, err := method.Sign(signingString, privateKey)
+	require.NoError(t, err)
+
+	err = method.Verify("wrong signing string", signature, publicKey)
+	require.Error(t, err)
+}
+
+func TestFullJWT(t *testing.T) {
+	privateKey := testutils.RandomPrivateKey(t)
+	claims := &jwt.RegisteredClaims{
+		Issuer: "test",
+	}
+	token := jwt.NewWithClaims(&SigningMethodSecp256k1{}, claims)
+
+	// Sign and get the complete encoded token as a string using the secret
+	tokenString, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+
+	parsedToken, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		return privateKey.Public(), nil
+	})
+	require.NoError(t, err)
+
+	issuer, err := parsedToken.Claims.GetIssuer()
+	require.NoError(t, err)
+	require.Equal(t, issuer, claims.Issuer)
+}


### PR DESCRIPTION
## tl;dr
The most widely used [JWT library in Go](https://pkg.go.dev/github.com/golang-jwt/jwt/v5#example-Parse-Hmac) doesn't support secp256k1 signatures natively, so this adds the support by registering a new signing method

## AI Generated Summary

Implemented a custom JWT signing method for secp256k1 and added necessary dependencies.

### What changed?

- Added `github.com/golang-jwt/jwt/v5` dependency to `go.mod` and `go.sum`.
- Created a new `SigningMethodSecp256k1` struct in `pkg/authn/signingMethod.go` that implements a custom JWT signing method for secp256k1.
- Implemented `Verify`, `Sign`, and `Alg` methods for the custom signing method.
- Added unit tests in `pkg/authn/signingMethod_test.go` to verify the functionality of the new signing method.

### How to test?

1. Run the newly added unit tests in `pkg/authn/signingMethod_test.go`.
2. Verify that all tests pass, including:
   - Signing and verifying a message
   - Testing with wrong signer
   - Testing with wrong signing string
   - Full JWT flow with custom signing method

### Why make this change?

This change introduces a custom JWT signing method for secp256k1, which is not natively supported by the standard JWT library. This allows for the use of Ethereum-compatible keys in JWT authentication, enhancing the compatibility of the authentication system with blockchain-based identities.