### PR TITLE
Add support for batch query

### DIFF
--- a/dev/generate
+++ b/dev/generate
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 ./dev/gen_protos
+sqlc generate
 go generate ./...
 rm -rf pkg/mocks/*
 ./dev/abigen
 mockery
-sqlc generate

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/testutils"
@@ -116,15 +117,15 @@ func TestQueryEnvelopesByOriginator(t *testing.T) {
 }
 
 func TestQueryEnvelopesByTopic(t *testing.T) {
-	api, db, cleanup := apiTestUtils.NewTestAPIClient(t)
+	api, store, cleanup := apiTestUtils.NewTestAPIClient(t)
 	defer cleanup()
-	db_rows := setupQueryTest(t, db)
+	db_rows := setupQueryTest(t, store)
 
 	resp, err := api.QueryEnvelopes(
 		context.Background(),
 		&message_api.QueryEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
-				Topics:   [][]byte{[]byte("topicA")},
+				Topics:   []db.Topic{db.Topic("topicA")},
 				LastSeen: nil,
 			},
 			Limit: 0,
@@ -153,15 +154,15 @@ func TestQueryEnvelopesFromLastSeen(t *testing.T) {
 }
 
 func TestQueryEnvelopesWithEmptyResult(t *testing.T) {
-	api, db, cleanup := apiTestUtils.NewTestAPIClient(t)
+	api, store, cleanup := apiTestUtils.NewTestAPIClient(t)
 	defer cleanup()
-	db_rows := setupQueryTest(t, db)
+	db_rows := setupQueryTest(t, store)
 
 	resp, err := api.QueryEnvelopes(
 		context.Background(),
 		&message_api.QueryEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
-				Topics: [][]byte{[]byte("topicC")},
+				Topics: []db.Topic{db.Topic("topicC")},
 			},
 			Limit: 0,
 		},

--- a/pkg/db/subscription_test.go
+++ b/pkg/db/subscription_test.go
@@ -44,8 +44,8 @@ func envelopesQuery(store *sql.DB) db.PollableDBQuery[queries.GatewayEnvelope, d
 	return func(ctx context.Context, lastSeen db.VectorClock, numRows int32) ([]queries.GatewayEnvelope, db.VectorClock, error) {
 		envs, err := queries.New(store).
 			SelectGatewayEnvelopes(ctx, *db.SetVectorClock(&queries.SelectGatewayEnvelopesParams{
-				OriginatorNodeID: db.NullInt32(1),
-				RowLimit:         db.NullInt32(numRows),
+				OriginatorNodeIds: []int32{1},
+				RowLimit:          numRows,
 			}, lastSeen))
 		if err != nil {
 			return nil, lastSeen, err

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -7,6 +7,7 @@ import (
 )
 
 type VectorClock = map[uint32]uint64
+type Topic = []byte
 
 func NullInt32(v int32) sql.NullInt32 {
 	return sql.NullInt32{Int32: v, Valid: true}

--- a/pkg/indexer/e2e_test.go
+++ b/pkg/indexer/e2e_test.go
@@ -67,7 +67,7 @@ func TestStoreMessages(t *testing.T) {
 		envelopes, err := querier.SelectGatewayEnvelopes(
 			context.Background(),
 			queries.SelectGatewayEnvelopesParams{
-				Topic: topic,
+				Topics: [][]byte{topic},
 			},
 		)
 		require.NoError(t, err)

--- a/pkg/indexer/storer/groupMessage_test.go
+++ b/pkg/indexer/storer/groupMessage_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/abis"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
-	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	"github.com/xmtp/xmtpd/pkg/utils"
@@ -57,7 +56,7 @@ func TestStoreGroupMessages(t *testing.T) {
 
 	envelopes, queryErr := storer.queries.SelectGatewayEnvelopes(
 		ctx,
-		queries.SelectGatewayEnvelopesParams{OriginatorNodeID: db.NullInt32(0)},
+		queries.SelectGatewayEnvelopesParams{OriginatorNodeIds: []int32{0}},
 	)
 	require.NoError(t, queryErr)
 
@@ -93,7 +92,7 @@ func TestStoreGroupMessageDuplicate(t *testing.T) {
 
 	envelopes, queryErr := storer.queries.SelectGatewayEnvelopes(
 		ctx,
-		queries.SelectGatewayEnvelopesParams{OriginatorNodeID: db.NullInt32(0)},
+		queries.SelectGatewayEnvelopesParams{OriginatorNodeIds: []int32{0}},
 	)
 	require.NoError(t, queryErr)
 

--- a/pkg/indexer/storer/identityUpdate.go
+++ b/pkg/indexer/storer/identityUpdate.go
@@ -195,9 +195,9 @@ func (s *IdentityUpdateStorer) validateIdentityUpdate(
 	gatewayEnvelopes, err := querier.SelectGatewayEnvelopes(
 		ctx,
 		queries.SelectGatewayEnvelopesParams{
-			Topic:            []byte(BuildInboxTopic(inboxId)),
-			OriginatorNodeID: sql.NullInt32{Int32: IDENTITY_UPDATE_ORIGINATOR_ID, Valid: true},
-			RowLimit:         sql.NullInt32{Int32: 256, Valid: true},
+			Topics:            []db.Topic{db.Topic(BuildInboxTopic(inboxId))},
+			OriginatorNodeIds: []int32{IDENTITY_UPDATE_ORIGINATOR_ID},
+			RowLimit:          256,
 		},
 	)
 	if err != nil {

--- a/pkg/indexer/storer/identityUpdate_test.go
+++ b/pkg/indexer/storer/identityUpdate_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/abis"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
-	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/mlsvalidate"
 	mlsvalidateMock "github.com/xmtp/xmtpd/pkg/mocks/mlsvalidate"
@@ -83,7 +82,8 @@ func TestStoreIdentityUpdate(t *testing.T) {
 	envelopes, queryErr := querier.SelectGatewayEnvelopes(
 		ctx,
 		queries.SelectGatewayEnvelopesParams{
-			OriginatorNodeID: db.NullInt32(IDENTITY_UPDATE_ORIGINATOR_ID),
+			OriginatorNodeIds: []int32{IDENTITY_UPDATE_ORIGINATOR_ID},
+			RowLimit:          10,
 		},
 	)
 	require.NoError(t, queryErr)

--- a/pkg/migrations/00002_select-gateway-envelopes.down.sql
+++ b/pkg/migrations/00002_select-gateway-envelopes.down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION select_gateway_envelopes;
+

--- a/pkg/migrations/00002_select-gateway-envelopes.up.sql
+++ b/pkg/migrations/00002_select-gateway-envelopes.up.sql
@@ -1,0 +1,34 @@
+-- pgFormatter-ignore
+CREATE FUNCTION select_gateway_envelopes(cursor_node_ids INT[], cursor_sequence_ids BIGINT[], topics BYTEA[], originator_node_ids INT[], row_limit INT)
+	RETURNS SETOF gateway_envelopes
+	AS $$
+DECLARE
+	num_topics INT := COALESCE(ARRAY_LENGTH(topics, 1), 0);
+	num_originators INT := COALESCE(ARRAY_LENGTH(originator_node_ids, 1), 0);
+BEGIN
+	RETURN QUERY
+    WITH cursors AS (
+		SELECT
+			UNNEST(cursor_node_ids) AS cursor_node_id,
+			UNNEST(cursor_sequence_ids) AS cursor_sequence_id
+    )
+	SELECT
+		gateway_envelopes.*
+	FROM
+		gateway_envelopes
+	-- Assumption: There is only one cursor per node ID. Caller must verify this
+	LEFT JOIN cursors ON gateway_envelopes.originator_node_id = cursors.cursor_node_id
+    WHERE (num_topics = 0 OR topic = ANY (topics))
+		AND (num_originators = 0 OR originator_node_id = ANY (originator_node_ids))
+		AND originator_sequence_id > COALESCE(cursor_sequence_id, 0)
+	ORDER BY
+		-- Assumption: envelopes are inserted in sequence_id order per originator, therefore
+		-- gateway_time preserves sequence_id order
+		gateway_time,
+		originator_node_id,
+		originator_sequence_id ASC
+	LIMIT NULLIF(row_limit, 0);
+END;
+$$
+LANGUAGE plpgsql;
+


### PR DESCRIPTION
Implements batch querying and unit tests, which will also be used in the next PR for catch-up of historical messages when streaming. Also got rid of our use of NullInt32 in queries, which simplifies the go code a little.

For now we let up to 10k topics be specified in these queries - we can do proper benchmarking and SQL analyzing later to see how we should adjust it.

Closes #218