### PR TITLE
Allow override of DB id

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -6,7 +6,6 @@
     <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/erc4626-tests" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/forge-std" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/forge-std/lib/ds-test" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/contracts/lib/openzeppelin-contracts/lib/halmos-cheatcodes" vcs="Git" />
   </component>
 </project>

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -19,11 +19,12 @@ type ContractsOptions struct {
 
 type DbOptions struct {
 	ReaderConnectionString string        `long:"reader-connection-string" env:"XMTPD_DB_READER_CONNECTION_STRING" description:"Reader connection string"`
-	WriterConnectionString string        `long:"writer-connection-string" env:"XMTPD_DB_WRITER_CONNECTION_STRING" description:"Writer connection string"                       required:"true"`
-	ReadTimeout            time.Duration `long:"read-timeout"             env:"XMTPD_DB_READ_TIMEOUT"             description:"Timeout for reading from the database"                          default:"10s"`
-	WriteTimeout           time.Duration `long:"write-timeout"            env:"XMTPD_DB_WRITE_TIMEOUT"            description:"Timeout for writing to the database"                            default:"10s"`
-	MaxOpenConns           int           `long:"max-open-conns"           env:"XMTPD_DB_MAX_OPEN_CONNS"           description:"Maximum number of open connections"                             default:"80"`
+	WriterConnectionString string        `long:"writer-connection-string" env:"XMTPD_DB_WRITER_CONNECTION_STRING" description:"Writer connection string"                                 required:"true"`
+	ReadTimeout            time.Duration `long:"read-timeout"             env:"XMTPD_DB_READ_TIMEOUT"             description:"Timeout for reading from the database"                                    default:"10s"`
+	WriteTimeout           time.Duration `long:"write-timeout"            env:"XMTPD_DB_WRITE_TIMEOUT"            description:"Timeout for writing to the database"                                      default:"10s"`
+	MaxOpenConns           int           `long:"max-open-conns"           env:"XMTPD_DB_MAX_OPEN_CONNS"           description:"Maximum number of open connections"                                       default:"80"`
 	WaitForDB              time.Duration `long:"wait-for"                 env:"XMTPD_DB_WAIT_FOR"                 description:"wait for DB on start, up to specified duration"`
+	ForceOverride          bool          `long:"force-override"           env:"XMTPD_DB_FORCE_OVERRIDE"           description:"override nodeId in database. Use during development only"`
 }
 
 // MetricsOptions are settings used to start a prometheus server

--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -122,3 +122,10 @@ FROM
 WHERE
 	originator_node_id = @originator_node_id;
 
+-- name: UpdateNodeInfo :execrows
+UPDATE
+    node_info
+SET
+    node_id = @new_node_id
+WHERE
+    node_id = @node_id;

--- a/pkg/db/queries/queries.sql.go
+++ b/pkg/db/queries/queries.sql.go
@@ -380,3 +380,25 @@ func (q *Queries) SelectVectorClock(ctx context.Context) ([]SelectVectorClockRow
 	}
 	return items, nil
 }
+
+const updateNodeInfo = `-- name: UpdateNodeInfo :execrows
+UPDATE
+    node_info
+SET
+    node_id = $1
+WHERE
+    node_id = $2
+`
+
+type UpdateNodeInfoParams struct {
+	NewNodeID int32
+	NodeID    int32
+}
+
+func (q *Queries) UpdateNodeInfo(ctx context.Context, arg UpdateNodeInfoParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNodeInfo, arg.NewNodeID, arg.NodeID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/pkg/registrant/registrant.go
+++ b/pkg/registrant/registrant.go
@@ -146,18 +146,14 @@ func ensureDatabaseMatches(
 		if nodeInfo.NodeID != int32(record.NodeID) {
 			if !overrideNodeId {
 				return fmt.Errorf(
-					fmt.Sprintf(
-						"registry node ID (%d) does not match ID in database (%d)",
-						record.NodeID,
-						nodeInfo.NodeID,
-					),
+					"registry node ID (%d) does not match ID in database (%d)",
+					record.NodeID,
+					nodeInfo.NodeID,
 				)
 			}
 
 			log.Warn(
-				fmt.Sprintf(
-					"WARNING: enabled --db.force-override and a mismatching nodeID was detected. Attempting to update DB...",
-				),
+				"WARNING: enabled --db.force-override and a mismatching nodeID was detected. Attempting to update DB...",
 			)
 			numRows, err = db.UpdateNodeInfo(
 				ctx,

--- a/pkg/registrant/registrant_test.go
+++ b/pkg/registrant/registrant_test.go
@@ -69,6 +69,7 @@ func setupWithRegistrant(t *testing.T) (deps, *registrant.Registrant, func()) {
 		deps.db,
 		deps.registry,
 		deps.privKey1Str,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -85,6 +86,7 @@ func TestNewRegistrantBadPrivateKey(t *testing.T) {
 		deps.db,
 		deps.registry,
 		"badkey",
+		false,
 	)
 	require.ErrorContains(t, err, "parse")
 }
@@ -104,6 +106,7 @@ func TestNewRegistrantNotInRegistry(t *testing.T) {
 		deps.db,
 		deps.registry,
 		deps.privKey1Str,
+		false,
 	)
 	require.ErrorContains(t, err, "registry")
 }
@@ -124,6 +127,7 @@ func TestNewRegistrantNewDatabase(t *testing.T) {
 		deps.db,
 		deps.registry,
 		deps.privKey1Str,
+		false,
 	)
 	require.NoError(t, err)
 }
@@ -151,6 +155,7 @@ func TestNewRegistrantExistingDatabase(t *testing.T) {
 		deps.db,
 		deps.registry,
 		deps.privKey1Str,
+		false,
 	)
 	require.NoError(t, err)
 }
@@ -178,6 +183,7 @@ func TestNewRegistrantMismatchingDatabaseNodeId(t *testing.T) {
 		deps.db,
 		deps.registry,
 		deps.privKey1Str,
+		false,
 	)
 	require.ErrorContains(t, err, "does not match")
 }
@@ -205,6 +211,7 @@ func TestNewRegistrantMismatchingDatabasePublicKey(t *testing.T) {
 		deps.db,
 		deps.registry,
 		deps.privKey1Str,
+		false,
 	)
 	require.ErrorContains(t, err, "does not match")
 }
@@ -223,6 +230,7 @@ func TestNewRegistrantPrivateKeyNo0x(t *testing.T) {
 		deps.db,
 		deps.registry,
 		utils.HexEncode(crypto.FromECDSA(deps.privKey1)),
+		false,
 	)
 	require.NoError(t, err)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -83,6 +83,7 @@ func NewReplicationServer(
 		queries.New(s.writerDB),
 		nodeRegistry,
 		options.Signer.PrivateKey,
+		options.DB.ForceOverride,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -52,7 +52,14 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, func()) {
 	mockRegistry.EXPECT().GetNodes().Return([]registry.Node{
 		{NodeID: 1, SigningKey: &privKey.PublicKey},
 	}, nil)
-	registrant, err := registrant.NewRegistrant(ctx, log, queries.New(db), mockRegistry, privKeyStr)
+	registrant, err := registrant.NewRegistrant(
+		ctx,
+		log,
+		queries.New(db),
+		mockRegistry,
+		privKeyStr,
+		false,
+	)
 	require.NoError(t, err)
 	mockMessagePublsiher := blockchain.NewMockIBlockchainPublisher(t)
 


### PR DESCRIPTION
During development it seems to be pretty common to change the nodeId from one to another. We have to nuke the DB to fix this.

Can we simply change the NodeId in the DB without catastrophic consequences?