### PR TITLE
Normalize URLs

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -71,14 +71,14 @@ func TestCreateServer(t *testing.T) {
 		{
 			NodeID:        server1NodeID,
 			SigningKey:    &privateKey1.PublicKey,
-			HttpAddress:   fmt.Sprintf("passthrough://localhost/[::]:%d", server1Port),
+			HttpAddress:   fmt.Sprintf("http://localhost:%d", server1Port),
 			IsHealthy:     true,
 			IsValidConfig: true,
 		},
 		{
 			NodeID:        server2NodeID,
 			SigningKey:    &privateKey2.PublicKey,
-			HttpAddress:   fmt.Sprintf("passthrough://localhost/[::]:%d", server2Port),
+			HttpAddress:   fmt.Sprintf("http://localhost:%d", server2Port),
 			IsHealthy:     true,
 			IsValidConfig: true,
 		},
@@ -140,7 +140,7 @@ func TestCreateServer(t *testing.T) {
 	// }, 500*time.Millisecond, 50*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		q2, err := client1.QueryEnvelopes(ctx, &message_api.QueryEnvelopesRequest{
+		q2, err := client2.QueryEnvelopes(ctx, &message_api.QueryEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
 				OriginatorNodeIds: []uint32{server1NodeID},
 				LastSeen:          &message_api.VectorClock{},

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/registrant"
 	"github.com/xmtp/xmtpd/pkg/registry"
 	"github.com/xmtp/xmtpd/pkg/tracing"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -100,8 +101,12 @@ func (s *syncWorker) subscribeToNode(node registry.Node) {
 }
 
 func (s *syncWorker) connectToNode(node registry.Node) (*grpc.ClientConn, error) {
-	addr := node.HttpAddress
-	log.Info(fmt.Sprintf("attempting to connect to %s", addr))
+	log.Info(fmt.Sprintf("Attempting to connect to %s", node.HttpAddress))
+	addr, err := utils.HttpAddressToGrpcTarget(node.HttpAddress)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to convert HTTP address to gRPC target: %v", err)
+	}
+	log.Info(fmt.Sprintf("Mapped %s to %s", node.HttpAddress, addr))
 	conn, err := grpc.NewClient(
 		addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// / Maps from a URL, as defined in https://pkg.go.dev/net/url#URL, to a gRPC target,
+// / as defined in https://github.com/grpc/grpc/blob/master/doc/naming.md
+func HttpAddressToGrpcTarget(httpAddress string) (string, error) {
+	url, err := url.Parse(httpAddress)
+	if err != nil {
+		return "", err
+	}
+	if strings.ToLower(url.Hostname()) == "localhost" {
+		return fmt.Sprintf("passthrough://localhost/[::]:%s", url.Port()), nil
+	}
+
+	// TODO(rich): Handle SSL properly
+	return fmt.Sprintf("dns:%s:%s", url.Hostname(), url.Port()), nil
+}


### PR DESCRIPTION
Quick PR to unblock node peering in our testnet. Will add more in-depth unit tests for `HttpAddressToGrpcTarget` when support for TLS is implemented.

@mkysel Feel free to merge this PR directly