### PR TITLE
Fix GRPC TLS

### DIFF
--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -164,7 +164,7 @@ func (s *syncWorker) listenToStream(
 }
 
 func (s *syncWorker) insertEnvelope(env *message_api.OriginatorEnvelope) {
-	s.log.Info(fmt.Sprintf("Replication server received envelope %s", env))
+	s.log.Debug("Replication server received envelope", zap.Any("envelope", env))
 	// TODO(nm) Validation logic - share code with API service and publish worker
 	originatorBytes, err := proto.Marshal(env)
 	if err != nil {

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/registrant"
@@ -165,18 +164,18 @@ func (s *syncWorker) listenToStream(
 }
 
 func (s *syncWorker) insertEnvelope(env *message_api.OriginatorEnvelope) {
-	log.Info(fmt.Sprintf("Replication server received envelope %s", env))
+	s.log.Info(fmt.Sprintf("Replication server received envelope %s", env))
 	// TODO(nm) Validation logic - share code with API service and publish worker
 	originatorBytes, err := proto.Marshal(env)
 	if err != nil {
-		log.Error("Failed to marshal originator envelope", zap.Error(err))
+		s.log.Error("Failed to marshal originator envelope", zap.Error(err))
 		return
 	}
 
 	unsignedEnvelope := &message_api.UnsignedOriginatorEnvelope{}
 	err = proto.Unmarshal(env.GetUnsignedOriginatorEnvelope(), unsignedEnvelope)
 	if err != nil {
-		log.Error(
+		s.log.Error(
 			"Failed to unmarshal unsigned originator envelope",
 			zap.Error(err),
 		)
@@ -189,7 +188,7 @@ func (s *syncWorker) insertEnvelope(env *message_api.OriginatorEnvelope) {
 		clientEnvelope,
 	)
 	if err != nil {
-		log.Error(
+		s.log.Error(
 			"Failed to unmarshal client envelope",
 			zap.Error(err),
 		)
@@ -210,11 +209,11 @@ func (s *syncWorker) insertEnvelope(env *message_api.OriginatorEnvelope) {
 		},
 	)
 	if err != nil {
-		log.Error("Failed to insert gateway envelope", zap.Error(err))
+		s.log.Error("Failed to insert gateway envelope", zap.Error(err))
 		return
 	} else if inserted == 0 {
 		// Envelope was already inserted by another worker
-		log.Warn("Envelope already inserted")
+		s.log.Warn("Envelope already inserted")
 		return
 	}
 }

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -1,22 +1,55 @@
 package utils
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"net/url"
-	"strings"
 )
 
 // / Maps from a URL, as defined in https://pkg.go.dev/net/url#URL, to a gRPC target,
 // / as defined in https://github.com/grpc/grpc/blob/master/doc/naming.md
-func HttpAddressToGrpcTarget(httpAddress string) (string, error) {
+func HttpAddressToGrpcTarget(httpAddress string) (string, bool, error) {
 	url, err := url.Parse(httpAddress)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
-	if strings.ToLower(url.Hostname()) == "localhost" {
-		return fmt.Sprintf("passthrough://localhost/[::]:%s", url.Port()), nil
+	var isTLS bool
+	if url.Scheme == "https" {
+		isTLS = true
+	} else if url.Scheme == "http" || url.Scheme == "" {
+		isTLS = false
+	} else {
+		return "", false, fmt.Errorf("Unknown connection schema %s", url.Scheme)
+	}
+	if url.Port() != "" {
+		return fmt.Sprintf("%s:%s", url.Hostname(), url.Port()), isTLS, nil
 	}
 
-	// TODO(rich): Handle SSL properly
-	return fmt.Sprintf("dns:%s:%s", url.Hostname(), url.Port()), nil
+	return fmt.Sprintf("%s", url.Hostname()), isTLS, nil
+}
+
+func GetCredentialsForAddress(
+	isTLS bool,
+) (credentials.TransportCredentials, error) {
+	if !isTLS {
+		return insecure.NewCredentials(), nil
+	}
+
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system CA certificates: %v", err)
+	}
+	if certPool == nil {
+		return nil, fmt.Errorf("no system CA certificates available")
+	}
+
+	// Create a credentials object with the loaded client certificate and system's CA cert pool
+	creds := credentials.NewTLS(&tls.Config{
+		RootCAs: certPool, // System CA pool
+	})
+
+	return creds, nil
 }

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -28,7 +28,7 @@ func HttpAddressToGrpcTarget(httpAddress string) (string, bool, error) {
 		return fmt.Sprintf("%s:%s", url.Hostname(), url.Port()), isTLS, nil
 	}
 
-	return fmt.Sprintf("%s", url.Hostname()), isTLS, nil
+	return url.Hostname(), isTLS, nil
 }
 
 func GetCredentialsForAddress(

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -46,7 +46,6 @@ func GetCredentialsForAddress(
 		return nil, fmt.Errorf("no system CA certificates available")
 	}
 
-	// Create a credentials object with the loaded client certificate and system's CA cert pool
 	creds := credentials.NewTLS(&tls.Config{
 		RootCAs: certPool, // System CA pool
 	})


### PR DESCRIPTION
Load TLS certs from host machine if possible.
Determine whether TLS should be used based on HTTPS scheme.
`passthrough` and `dns` are technically not required.

All tests still pass. A local node can now connect to `testnet`. Local nodes can peer.