### PR TITLE
Validate published envelope topics

### DIFF
--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	apiTestUtils "github.com/xmtp/xmtpd/pkg/testutils/api"
+	envelopeTestUtils "github.com/xmtp/xmtpd/pkg/testutils/envelopes"
 )
 
 func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopeParams {
@@ -21,7 +22,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			Topic:                []byte("topicA"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 1, 1),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 1, 1),
 			),
 		},
 		{
@@ -30,7 +31,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			Topic:                []byte("topicA"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 2, 1),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 2, 1),
 			),
 		},
 		{
@@ -39,7 +40,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			Topic:                []byte("topicB"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 1, 2),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 1, 2),
 			),
 		},
 		{
@@ -48,7 +49,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			Topic:                []byte("topicB"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 2, 2),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 2, 2),
 			),
 		},
 		{
@@ -57,7 +58,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			Topic:                []byte("topicA"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 1, 3),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 1, 3),
 			),
 		},
 	}

--- a/pkg/api/subscribe_test.go
+++ b/pkg/api/subscribe_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	testUtilsApi "github.com/xmtp/xmtpd/pkg/testutils/api"
+	envelopeTestUtils "github.com/xmtp/xmtpd/pkg/testutils/envelopes"
 )
 
 var allRows []queries.InsertGatewayEnvelopeParams
@@ -26,7 +27,7 @@ func setupTest(t *testing.T) (message_api.ReplicationApiClient, *sql.DB, func())
 			Topic:                []byte("topicA"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 1, 1),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 1, 1),
 			),
 		},
 		{
@@ -35,7 +36,7 @@ func setupTest(t *testing.T) (message_api.ReplicationApiClient, *sql.DB, func())
 			Topic:                []byte("topicA"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 2, 1),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 2, 1),
 			),
 		},
 		// Later rows
@@ -45,7 +46,7 @@ func setupTest(t *testing.T) (message_api.ReplicationApiClient, *sql.DB, func())
 			Topic:                []byte("topicB"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 1, 2),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 1, 2),
 			),
 		},
 		{
@@ -54,7 +55,7 @@ func setupTest(t *testing.T) (message_api.ReplicationApiClient, *sql.DB, func())
 			Topic:                []byte("topicB"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 2, 2),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 2, 2),
 			),
 		},
 		{
@@ -63,7 +64,7 @@ func setupTest(t *testing.T) (message_api.ReplicationApiClient, *sql.DB, func())
 			Topic:                []byte("topicA"),
 			OriginatorEnvelope: testutils.Marshal(
 				t,
-				testutils.CreateOriginatorEnvelope(t, 1, 3),
+				envelopeTestUtils.CreateOriginatorEnvelope(t, 1, 3),
 			),
 		},
 	}
@@ -94,7 +95,7 @@ func validateUpdates(
 		require.NoError(t, err)
 		for _, env := range envs.Envelopes {
 			expected := allRows[expectedIndices[i]]
-			actual := testutils.UnmarshalUnsignedOriginatorEnvelope(
+			actual := envelopeTestUtils.UnmarshalUnsignedOriginatorEnvelope(
 				t,
 				env.UnsignedOriginatorEnvelope,
 			)

--- a/pkg/envelopes/client.go
+++ b/pkg/envelopes/client.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"github.com/xmtp/xmtpd/pkg/topic"
 	"google.golang.org/protobuf/proto"
 )
 
 type ClientEnvelope struct {
-	proto *message_api.ClientEnvelope
+	proto       *message_api.ClientEnvelope
+	targetTopic topic.Topic
 }
 
 func NewClientEnvelope(proto *message_api.ClientEnvelope) (*ClientEnvelope, error) {
@@ -24,9 +26,12 @@ func NewClientEnvelope(proto *message_api.ClientEnvelope) (*ClientEnvelope, erro
 		return nil, errors.New("payload is missing")
 	}
 
-	// TODO:(nm) Validate topic
+	targetTopic, err := topic.ParseTopic(proto.Aad.TargetTopic)
+	if err != nil {
+		return nil, err
+	}
 
-	return &ClientEnvelope{proto: proto}, nil
+	return &ClientEnvelope{proto: proto, targetTopic: *targetTopic}, nil
 }
 
 func NewClientEnvelopeFromBytes(bytes []byte) (*ClientEnvelope, error) {
@@ -45,10 +50,37 @@ func (c *ClientEnvelope) Bytes() ([]byte, error) {
 	return bytes, nil
 }
 
+func (c *ClientEnvelope) TargetTopic() topic.Topic {
+	return c.targetTopic
+}
+
+func (c *ClientEnvelope) Payload() interface{} {
+	return c.proto.Payload
+}
+
 func (c *ClientEnvelope) Aad() *message_api.AuthenticatedData {
 	return c.proto.Aad
 }
 
 func (c *ClientEnvelope) Proto() *message_api.ClientEnvelope {
 	return c.proto
+}
+
+func (c *ClientEnvelope) TopicMatchesPayload() bool {
+	targetTopic := c.TargetTopic()
+	targetTopicKind := targetTopic.Kind()
+	payload := c.proto.Payload
+
+	switch payload.(type) {
+	case *message_api.ClientEnvelope_WelcomeMessage:
+		return targetTopicKind == topic.TOPIC_KIND_WELCOME_MESSAGES_V1
+	case *message_api.ClientEnvelope_GroupMessage:
+		return targetTopicKind == topic.TOPIC_KIND_GROUP_MESSAGES_V1
+	case *message_api.ClientEnvelope_IdentityUpdate:
+		return targetTopicKind == topic.TOPIC_KIND_IDENTITY_UPDATES_V1
+	case *message_api.ClientEnvelope_UploadKeyPackage:
+		return targetTopicKind == topic.TOPIC_KIND_KEY_PACKAGES_V1
+	default:
+		return false
+	}
 }

--- a/pkg/envelopes/payer.go
+++ b/pkg/envelopes/payer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"google.golang.org/protobuf/proto"
 )
 
 type PayerEnvelope struct {
@@ -25,4 +26,12 @@ func NewPayerEnvelope(proto *message_api.PayerEnvelope) (*PayerEnvelope, error) 
 
 func (p *PayerEnvelope) Proto() *message_api.PayerEnvelope {
 	return p.proto
+}
+
+func (p *PayerEnvelope) Bytes() ([]byte, error) {
+	bytes, err := proto.Marshal(p.proto)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,6 +19,8 @@ import (
 	s "github.com/xmtp/xmtpd/pkg/server"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	apiTestUtils "github.com/xmtp/xmtpd/pkg/testutils/api"
+	envelopeTestUtils "github.com/xmtp/xmtpd/pkg/testutils/envelopes"
+	"github.com/xmtp/xmtpd/pkg/topic"
 	"github.com/xmtp/xmtpd/pkg/utils"
 )
 
@@ -93,23 +95,26 @@ func TestCreateServer(t *testing.T) {
 	client2, cleanup2 := apiTestUtils.NewAPIClient(t, ctx, server2.Addr().String())
 	defer cleanup2()
 
+	targetTopic := topic.NewTopic(topic.TOPIC_KIND_GROUP_MESSAGES_V1, []byte{1, 2, 3}).
+		Bytes()
+
 	p1, err := client1.PublishEnvelopes(ctx, &message_api.PublishEnvelopesRequest{
-		PayerEnvelopes: []*message_api.PayerEnvelope{testutils.CreatePayerEnvelope(
+		PayerEnvelopes: []*message_api.PayerEnvelope{envelopeTestUtils.CreatePayerEnvelope(
 			t,
-			testutils.CreateClientEnvelope(&message_api.AuthenticatedData{
+			envelopeTestUtils.CreateClientEnvelope(&message_api.AuthenticatedData{
 				TargetOriginator: server1NodeID,
-				TargetTopic:      []byte{0x5},
+				TargetTopic:      targetTopic,
 				LastSeen:         &message_api.VectorClock{},
 			}),
 		)},
 	})
 	require.NoError(t, err)
 	p2, err := client2.PublishEnvelopes(ctx, &message_api.PublishEnvelopesRequest{
-		PayerEnvelopes: []*message_api.PayerEnvelope{testutils.CreatePayerEnvelope(
+		PayerEnvelopes: []*message_api.PayerEnvelope{envelopeTestUtils.CreatePayerEnvelope(
 			t,
-			testutils.CreateClientEnvelope(&message_api.AuthenticatedData{
+			envelopeTestUtils.CreateClientEnvelope(&message_api.AuthenticatedData{
 				TargetOriginator: server2NodeID,
-				TargetTopic:      []byte{0x5},
+				TargetTopic:      targetTopic,
 				LastSeen:         &message_api.VectorClock{},
 			}),
 		)},

--- a/pkg/testutils/envelopes/envelopes.go
+++ b/pkg/testutils/envelopes/envelopes.go
@@ -6,14 +6,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/proto/identity/associations"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"github.com/xmtp/xmtpd/pkg/topic"
 	"google.golang.org/protobuf/proto"
 )
-
-func Marshal(t *testing.T, msg proto.Message) []byte {
-	bytes, err := proto.Marshal(msg)
-	require.NoError(t, err)
-	return bytes
-}
 
 func UnmarshalUnsignedOriginatorEnvelope(
 	t *testing.T,
@@ -32,8 +27,9 @@ func CreateClientEnvelope(aad ...*message_api.AuthenticatedData) *message_api.Cl
 	if len(aad) == 0 {
 		aad = append(aad, &message_api.AuthenticatedData{
 			TargetOriginator: 1,
-			TargetTopic:      []byte{0x5},
-			LastSeen:         &message_api.VectorClock{},
+			TargetTopic: topic.NewTopic(topic.TOPIC_KIND_GROUP_MESSAGES_V1, []byte{1, 2, 3}).
+				Bytes(),
+			LastSeen: &message_api.VectorClock{},
 		})
 	}
 	return &message_api.ClientEnvelope{

--- a/pkg/testutils/proto.go
+++ b/pkg/testutils/proto.go
@@ -1,0 +1,14 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func Marshal(t *testing.T, msg proto.Message) []byte {
+	bytes, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return bytes
+}


### PR DESCRIPTION
## tl;dr

- Uses new `envelopes` structs to help validate publish requests
- Validates that the topic matches the payload (https://github.com/xmtp/xmtpd/issues/231)

## AI Generated Summary

Refactored envelope handling and improved validation in the API service.

### What changed?

- Moved envelope-related test utilities to a dedicated package `pkg/testutils/envelopes`.
- Enhanced `ClientEnvelope` struct with additional methods for topic handling and payload validation.
- Updated `Service.PublishEnvelopes` to use the new envelope validation logic.
- Improved error handling and messages in various API functions.
- Introduced `TopicMatchesPayload` method to ensure consistency between envelope topic and payload.

### How to test?

1. Run the existing test suite to ensure all tests pass after the refactoring.
2. Add new tests to cover the `TopicMatchesPayload` functionality in `pkg/envelopes/client.go`.
3. Verify that publishing envelopes with mismatched topics and payloads now results in appropriate error messages.

### Why make this change?

This refactoring improves code organization, enhances envelope validation, and increases the robustness of the API service. By centralizing envelope-related logic and adding stricter validation, we reduce the likelihood of processing invalid envelopes and improve overall system reliability.