### PR TITLE
Recover signer from payer envelopes

### DIFF
--- a/pkg/authn/signingMethod.go
+++ b/pkg/authn/signingMethod.go
@@ -7,14 +7,14 @@ import (
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/xmtp/xmtpd/pkg/utils"
 )
 
 const (
-	ALGORITHM               = "ES256K"
-	SIG_LENGTH              = 65
-	R_LENGTH                = 32
-	S_LENGTH                = 32
-	DOMAIN_SEPARATION_LABEL = "jwt"
+	ALGORITHM  = "ES256K"
+	SIG_LENGTH = 65
+	R_LENGTH   = 32
+	S_LENGTH   = 32
 )
 
 var (
@@ -36,7 +36,7 @@ func (sm *SigningMethodSecp256k1) Verify(signingString string, sig []byte, key i
 		return ErrWrongKeyFormat
 	}
 
-	hashedString := hashStringWithDomainSeparation(signingString)
+	hashedString := utils.HashJWTSignatureInput([]byte(signingString))
 
 	if len(sig) != SIG_LENGTH {
 		return ErrBadSignature
@@ -58,7 +58,7 @@ func (sm *SigningMethodSecp256k1) Sign(signingString string, key interface{}) ([
 		return nil, ErrWrongKeyFormat
 	}
 
-	hashedString := hashStringWithDomainSeparation(signingString)
+	hashedString := utils.HashJWTSignatureInput([]byte(signingString))
 
 	sig, err := ethcrypto.Sign(hashedString, priv)
 	if err != nil {
@@ -74,10 +74,6 @@ func (sm *SigningMethodSecp256k1) Sign(signingString string, key interface{}) ([
 
 func (sm *SigningMethodSecp256k1) Alg() string {
 	return ALGORITHM
-}
-
-func hashStringWithDomainSeparation(signingString string) []byte {
-	return ethcrypto.Keccak256([]byte(DOMAIN_SEPARATION_LABEL + signingString))
 }
 
 func init() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	JWT_DOMAIN_SEPARATION_LABEL   = "jwt|"
+	PAYER_DOMAIN_SEPARATION_LABEL = "payer|"
+)

--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/xmtp/xmtpd/pkg/constants"
+)
+
+func HashPayerSignatureInput(unsignedClientEnvelope []byte) []byte {
+	return ethcrypto.Keccak256(
+		[]byte(constants.PAYER_DOMAIN_SEPARATION_LABEL),
+		unsignedClientEnvelope,
+	)
+}
+
+func HashJWTSignatureInput(textToSign []byte) []byte {
+	return ethcrypto.Keccak256(
+		[]byte(constants.JWT_DOMAIN_SEPARATION_LABEL),
+		textToSign,
+	)
+}

--- a/pkg/utils/signature.go
+++ b/pkg/utils/signature.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"crypto/ecdsa"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func SignPayerEnvelope(
+	unsignedClientEnvelope []byte,
+	payerPrivateKey *ecdsa.PrivateKey,
+) ([]byte, error) {
+	hash := HashPayerSignatureInput(unsignedClientEnvelope)
+	signature, err := ethcrypto.Sign(hash, payerPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return signature, nil
+}


### PR DESCRIPTION
## tl;dr

- Adds method to recover the signer from payer envelopes (https://github.com/xmtp/xmtpd/issues/232)
- Refactors domain separation for jwt's and payer envelopes

### AI Assisted Summary

Introduced domain separation for payer signatures, and added functionality to recover signer addresses from payer envelopes.

### What changed?

- Created a new `constants` package with domain separation labels for JWT and payer signatures.
- Updated the JWT signing method to use the new constant for domain separation.
- Implemented a `RecoverSigner` method for `PayerEnvelope` to extract the signer's address.
- Added utility functions for hashing and signing payer envelopes.
- Expanded test coverage for envelope signer recovery.

### Why make this change?

This change enhances security and consistency by introducing domain separation for signatures. It also adds the ability to recover signer addresses from payer envelopes, which is crucial for verifying the authenticity of messages and implementing payer-based features in the system.