### PR TITLE
Add node connection manager

### DIFF
--- a/pkg/api/payer/clientManager.go
+++ b/pkg/api/payer/clientManager.go
@@ -1,0 +1,74 @@
+package payer
+
+import (
+	"sync"
+
+	"github.com/xmtp/xmtpd/pkg/registry"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+/*
+*
+The ClientManager contains a mapping of nodeIDs to gRPC client connections.
+
+These client connections are safe to be shared and re-used and will automatically attempt
+to reconnect if the underlying socket connection is lost.
+*
+*/
+type ClientManager struct {
+	log              *zap.Logger
+	connections      map[uint32]*grpc.ClientConn
+	connectionsMutex sync.RWMutex
+	nodeRegistry     registry.NodeRegistry
+}
+
+func NewClientManager(log *zap.Logger, nodeRegistry registry.NodeRegistry) *ClientManager {
+	return &ClientManager{
+		log:          log,
+		nodeRegistry: nodeRegistry,
+		connections:  make(map[uint32]*grpc.ClientConn),
+	}
+}
+
+func (c *ClientManager) GetClient(nodeID uint32) (*grpc.ClientConn, error) {
+	c.connectionsMutex.RLock()
+	existing, ok := c.connections[nodeID]
+	c.connectionsMutex.RUnlock()
+	if ok {
+		return existing, nil
+	}
+
+	c.connectionsMutex.Lock()
+	defer c.connectionsMutex.Unlock()
+
+	// Check again under the write lock
+	if existing, ok := c.connections[nodeID]; ok {
+		return existing, nil
+	}
+
+	conn, err := c.newClientConnection(nodeID)
+	if err != nil {
+		return nil, err
+	}
+	// Store the connection
+	c.connections[nodeID] = conn
+
+	return conn, nil
+}
+
+func (c *ClientManager) newClientConnection(
+	nodeID uint32,
+) (*grpc.ClientConn, error) {
+	c.log.Info("connecting to node", zap.Uint32("nodeID", nodeID))
+	node, err := c.nodeRegistry.GetNode(nodeID)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := node.BuildClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/pkg/api/payer/clientManager_test.go
+++ b/pkg/api/payer/clientManager_test.go
@@ -1,0 +1,60 @@
+package payer_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/api/payer"
+	"github.com/xmtp/xmtpd/pkg/registry"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	apiTestUtils "github.com/xmtp/xmtpd/pkg/testutils/api"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func formatAddress(addr string) string {
+	chunks := strings.Split(addr, ":")
+	return fmt.Sprintf("http://localhost:%s", chunks[len(chunks)-1])
+}
+
+func TestClientManager(t *testing.T) {
+	server1, _, cleanup1 := apiTestUtils.NewTestAPIServer(t)
+	defer cleanup1()
+	server2, _, cleanup2 := apiTestUtils.NewTestAPIServer(t)
+	defer cleanup2()
+
+	nodeRegistry := registry.NewFixedNodeRegistry([]registry.Node{
+		{
+			NodeID:      100,
+			HttpAddress: formatAddress(server1.Addr().String()),
+		},
+		{
+			NodeID:      200,
+			HttpAddress: formatAddress(server2.Addr().String()),
+		},
+	})
+
+	cm := payer.NewClientManager(testutils.NewLog(t), nodeRegistry)
+
+	client1, err := cm.GetClient(100)
+	require.NoError(t, err)
+	require.NotNil(t, client1)
+
+	healthClient := grpc_health_v1.NewHealthClient(client1)
+	healthResponse, err := healthClient.Check(
+		context.Background(),
+		&grpc_health_v1.HealthCheckRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, healthResponse.Status)
+
+	client2, err := cm.GetClient(200)
+	require.NoError(t, err)
+	require.NotNil(t, client2)
+
+	_, err = cm.GetClient(300)
+	require.Error(t, err)
+
+}

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api"
+	"github.com/xmtp/xmtpd/pkg/registry"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -12,14 +13,20 @@ import (
 type Service struct {
 	payer_api.UnimplementedPayerApiServer
 
-	ctx context.Context
-	log *zap.Logger
+	ctx           context.Context
+	log           *zap.Logger
+	clientManager *ClientManager
 }
 
-func NewPayerApiService(ctx context.Context, log *zap.Logger) (*Service, error) {
+func NewPayerApiService(
+	ctx context.Context,
+	log *zap.Logger,
+	registry registry.NodeRegistry,
+) (*Service, error) {
 	return &Service{
-		ctx: ctx,
-		log: log,
+		ctx:           ctx,
+		log:           log,
+		clientManager: NewClientManager(log, registry),
 	}, nil
 }
 

--- a/pkg/registry/node.go
+++ b/pkg/registry/node.go
@@ -1,6 +1,14 @@
 package registry
 
-import "crypto/ecdsa"
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"google.golang.org/grpc"
+)
+
+type DialOptionFunc func(node Node) []grpc.DialOption
 
 type Node struct {
 	NodeID        uint32
@@ -23,4 +31,34 @@ func (n *Node) Equals(other Node) bool {
 		equalsSigningKey &&
 		n.IsHealthy == other.IsHealthy &&
 		n.IsValidConfig == other.IsValidConfig
+}
+
+func (node *Node) BuildClient(
+	extraDialOpts ...grpc.DialOption,
+) (*grpc.ClientConn, error) {
+	target, isTLS, err := utils.HttpAddressToGrpcTarget(node.HttpAddress)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to convert HTTP address to gRPC target: %v", err)
+	}
+
+	creds, err := utils.GetCredentialsForAddress(isTLS)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get credentials: %v", err)
+	}
+
+	dialOpts := append([]grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultCallOptions(),
+	}, extraDialOpts...)
+
+	conn, err := grpc.NewClient(
+		target,
+		dialOpts...,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create channel at %s: %v", target, err)
+	}
+
+	return conn, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,11 +10,16 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/xmtp/xmtpd/pkg/api/message"
+	"github.com/xmtp/xmtpd/pkg/api/payer"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
 	"github.com/xmtp/xmtpd/pkg/indexer"
 	"github.com/xmtp/xmtpd/pkg/metrics"
 	"github.com/xmtp/xmtpd/pkg/mlsvalidate"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api"
 	"github.com/xmtp/xmtpd/pkg/sync"
+	"google.golang.org/grpc"
 
 	"github.com/xmtp/xmtpd/pkg/api"
 	"github.com/xmtp/xmtpd/pkg/config"
@@ -92,6 +97,7 @@ func NewReplicationServer(
 	if err != nil {
 		return nil, err
 	}
+
 	err = indexer.StartIndexer(
 		s.ctx,
 		log,
@@ -103,15 +109,35 @@ func NewReplicationServer(
 		return nil, err
 	}
 
+	serviceRegistrationFunc := func(grpcServer *grpc.Server) error {
+		replicationService, err := message.NewReplicationApiService(
+			ctx,
+			log,
+			s.registrant,
+			writerDB,
+			blockchainPublisher,
+		)
+		if err != nil {
+			return err
+		}
+		message_api.RegisterReplicationApiServer(grpcServer, replicationService)
+
+		payerService, err := payer.NewPayerApiService(ctx, log, s.nodeRegistry)
+		if err != nil {
+			return err
+		}
+		payer_api.RegisterPayerApiServer(grpcServer, payerService)
+
+		return nil
+	}
+
 	// TODO(rich): Add configuration to specify whether to run API/sync server
 	s.apiServer, err = api.NewAPIServer(
 		s.ctx,
-		s.writerDB,
 		log,
 		options.API.Port,
-		s.registrant,
 		options.Reflection.Enable,
-		blockchainPublisher,
+		serviceRegistrationFunc,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## tl;dr

- Introduces a new `ClientManager` for managing gRPC client connections
- Implements a `RegistrationFunc` callback for registering gRPC services
- Refactors `NewAPIServer` to use the `RegistrationFunc` instead of direct service creation
- Adds `BuildClient` method to `Node` struct for creating gRPC client connections
- Updates test utilities to use the new service registration approach

## Why a registration func?

Two reasons:
1. I wanted to get the dependencies and logic of building the individual services out of the `api` module and make that solely focused on creating an API server
2. Some server's will have just a payer API, some will have a message and payer API. I wanted to move that decision making up a layer in the stack.

## AI Assisted Notes

This PR introduces a `ClientManager` to handle gRPC client connections efficiently. It implements a `RegistrationFunc` callback for registering gRPC services, allowing for more flexible service configuration. The `NewAPIServer` function has been refactored to use this new `RegistrationFunc` instead of creating services directly.

A `BuildClient` method has been added to the `Node` struct, simplifying the process of creating gRPC client connections. Test utilities have been updated to reflect these changes and use the new service registration approach.

These changes improve the modularity and flexibility of the API server setup and client connection management.