### PR TITLE
Wait for logs in blockchain publisher

### DIFF
--- a/pkg/blockchain/blockchainPublisher_test.go
+++ b/pkg/blockchain/blockchainPublisher_test.go
@@ -1,0 +1,142 @@
+package blockchain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+)
+
+func buildPublisher(t *testing.T) (*BlockchainPublisher, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := testutils.NewLog(t)
+	contractsOptions := testutils.GetContractsOptions(t)
+	// Set the nodes contract address to a random smart contract instead of the fixed deployment
+	contractsOptions.NodesContractAddress = testutils.DeployNodesContract(t)
+
+	signer, err := NewPrivateKeySigner(
+		testutils.GetPayerOptions(t).PrivateKey,
+		contractsOptions.ChainID,
+	)
+	require.NoError(t, err)
+
+	client, err := NewClient(ctx, contractsOptions.RpcUrl)
+	require.NoError(t, err)
+
+	publisher, err := NewBlockchainPublisher(logger, client, signer, contractsOptions)
+	require.NoError(t, err)
+
+	return publisher, func() {
+		cancel()
+		client.Close()
+	}
+}
+
+func TestPublishIdentityUpdate(t *testing.T) {
+	publisher, cleanup := buildPublisher(t)
+	defer cleanup()
+	tests := []struct {
+		name           string
+		inboxId        [32]byte
+		identityUpdate []byte
+		ctx            context.Context
+		wantErr        bool
+	}{
+		{
+			name:           "happy path",
+			inboxId:        testutils.RandomGroupID(),
+			identityUpdate: testutils.RandomBytes(100),
+			ctx:            context.Background(),
+			wantErr:        false,
+		},
+		{
+			name:           "empty update",
+			inboxId:        testutils.RandomGroupID(),
+			identityUpdate: []byte{},
+			ctx:            context.Background(),
+			wantErr:        true,
+		},
+		{
+			name:           "cancelled context",
+			inboxId:        testutils.RandomGroupID(),
+			identityUpdate: testutils.RandomBytes(100),
+			ctx:            testutils.CancelledContext(),
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			logMessage, err := publisher.PublishIdentityUpdate(
+				tt.ctx,
+				tt.inboxId,
+				tt.identityUpdate,
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, logMessage)
+			require.Equal(t, tt.inboxId, logMessage.InboxId)
+			require.Equal(t, tt.identityUpdate, logMessage.Update)
+			require.Greater(t, logMessage.SequenceId, uint64(0))
+			require.NotNil(t, logMessage.Raw.TxHash)
+		})
+	}
+}
+
+func TestPublishGroupMessage(t *testing.T) {
+	publisher, cleanup := buildPublisher(t)
+	defer cleanup()
+
+	tests := []struct {
+		name    string
+		groupID [32]byte
+		message []byte
+		ctx     context.Context
+		wantErr bool
+	}{
+		{
+			name:    "happy path",
+			groupID: testutils.RandomGroupID(),
+			message: testutils.RandomBytes(100),
+			ctx:     context.Background(),
+			wantErr: false,
+		},
+		{
+			name:    "empty message",
+			groupID: testutils.RandomGroupID(),
+			message: []byte{},
+			ctx:     context.Background(),
+			wantErr: true,
+		},
+		{
+			name:    "cancelled context",
+			groupID: testutils.RandomGroupID(),
+			message: testutils.RandomBytes(100),
+			ctx:     testutils.CancelledContext(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			logMessage, err := publisher.PublishGroupMessage(tt.ctx, tt.groupID, tt.message)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, logMessage)
+			require.Equal(t, tt.groupID, logMessage.GroupId)
+			require.Equal(t, tt.message, logMessage.Message)
+			require.Greater(t, logMessage.SequenceId, uint64(0))
+			require.NotNil(t, logMessage.Raw.TxHash)
+		})
+	}
+}

--- a/pkg/blockchain/client.go
+++ b/pkg/blockchain/client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"go.uber.org/zap"
 )
@@ -22,7 +23,7 @@ func WaitForTransaction(
 	timeout time.Duration,
 	pollSleep time.Duration,
 	hash common.Hash,
-) (common.Hash, error) {
+) (*types.Receipt, error) {
 	// Enforce the timeout with a context so that slow requests get aborted if the function has
 	// run out of time
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
@@ -33,18 +34,23 @@ func WaitForTransaction(
 	defer ticker.Stop()
 
 	for {
-		_, isPending, err := client.TransactionByHash(ctx, hash)
+		receipt, err := client.TransactionReceipt(ctx, hash)
 		if err != nil {
-			logger.Error("waiting for transaction", zap.String("hash", hash.String()))
-		} else if !isPending {
-			return hash, nil
+			if err.Error() != "not found" {
+				logger.Error("waiting for transaction", zap.String("hash", hash.String()))
+			}
+		} else if receipt != nil {
+			if receipt.Status == types.ReceiptStatusSuccessful {
+				return receipt, nil
+			}
+			return nil, fmt.Errorf("transaction failed")
 		}
+
 		select {
 		case <-ctx.Done():
-			return common.Hash{}, fmt.Errorf("timed out")
+			return nil, fmt.Errorf("timed out")
 		case <-ticker.C:
 			continue
 		}
 	}
-
 }

--- a/pkg/blockchain/interface.go
+++ b/pkg/blockchain/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/xmtp/xmtpd/pkg/abis"
 )
 
 // Construct a raw blockchain listener that can be used to listen for events across many contract event types
@@ -49,6 +50,10 @@ type IBlockchainPublisher interface {
 		ctx context.Context,
 		inboxId [32]byte,
 		identityUpdate []byte,
-	) (common.Hash, error)
-	PublishGroupMessage(ctx context.Context, groupdId [32]byte, message []byte) (common.Hash, error)
+	) (*abis.IdentityUpdatesIdentityUpdateCreated, error)
+	PublishGroupMessage(
+		ctx context.Context,
+		groupdId [32]byte,
+		message []byte,
+	) (*abis.GroupMessagesMessageSent, error)
 }

--- a/pkg/mocks/blockchain/mock_IBlockchainPublisher.go
+++ b/pkg/mocks/blockchain/mock_IBlockchainPublisher.go
@@ -3,9 +3,9 @@
 package blockchain
 
 import (
-	context "context"
+	abis "github.com/xmtp/xmtpd/pkg/abis"
 
-	common "github.com/ethereum/go-ethereum/common"
+	context "context"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -24,23 +24,23 @@ func (_m *MockIBlockchainPublisher) EXPECT() *MockIBlockchainPublisher_Expecter 
 }
 
 // PublishGroupMessage provides a mock function with given fields: ctx, groupdId, message
-func (_m *MockIBlockchainPublisher) PublishGroupMessage(ctx context.Context, groupdId [32]byte, message []byte) (common.Hash, error) {
+func (_m *MockIBlockchainPublisher) PublishGroupMessage(ctx context.Context, groupdId [32]byte, message []byte) (*abis.GroupMessagesMessageSent, error) {
 	ret := _m.Called(ctx, groupdId, message)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PublishGroupMessage")
 	}
 
-	var r0 common.Hash
+	var r0 *abis.GroupMessagesMessageSent
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) (common.Hash, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) (*abis.GroupMessagesMessageSent, error)); ok {
 		return rf(ctx, groupdId, message)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) *abis.GroupMessagesMessageSent); ok {
 		r0 = rf(ctx, groupdId, message)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(common.Hash)
+			r0 = ret.Get(0).(*abis.GroupMessagesMessageSent)
 		}
 	}
 
@@ -73,34 +73,34 @@ func (_c *MockIBlockchainPublisher_PublishGroupMessage_Call) Run(run func(ctx co
 	return _c
 }
 
-func (_c *MockIBlockchainPublisher_PublishGroupMessage_Call) Return(_a0 common.Hash, _a1 error) *MockIBlockchainPublisher_PublishGroupMessage_Call {
+func (_c *MockIBlockchainPublisher_PublishGroupMessage_Call) Return(_a0 *abis.GroupMessagesMessageSent, _a1 error) *MockIBlockchainPublisher_PublishGroupMessage_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockIBlockchainPublisher_PublishGroupMessage_Call) RunAndReturn(run func(context.Context, [32]byte, []byte) (common.Hash, error)) *MockIBlockchainPublisher_PublishGroupMessage_Call {
+func (_c *MockIBlockchainPublisher_PublishGroupMessage_Call) RunAndReturn(run func(context.Context, [32]byte, []byte) (*abis.GroupMessagesMessageSent, error)) *MockIBlockchainPublisher_PublishGroupMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // PublishIdentityUpdate provides a mock function with given fields: ctx, inboxId, identityUpdate
-func (_m *MockIBlockchainPublisher) PublishIdentityUpdate(ctx context.Context, inboxId [32]byte, identityUpdate []byte) (common.Hash, error) {
+func (_m *MockIBlockchainPublisher) PublishIdentityUpdate(ctx context.Context, inboxId [32]byte, identityUpdate []byte) (*abis.IdentityUpdatesIdentityUpdateCreated, error) {
 	ret := _m.Called(ctx, inboxId, identityUpdate)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PublishIdentityUpdate")
 	}
 
-	var r0 common.Hash
+	var r0 *abis.IdentityUpdatesIdentityUpdateCreated
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) (common.Hash, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) (*abis.IdentityUpdatesIdentityUpdateCreated, error)); ok {
 		return rf(ctx, inboxId, identityUpdate)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, [32]byte, []byte) *abis.IdentityUpdatesIdentityUpdateCreated); ok {
 		r0 = rf(ctx, inboxId, identityUpdate)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(common.Hash)
+			r0 = ret.Get(0).(*abis.IdentityUpdatesIdentityUpdateCreated)
 		}
 	}
 
@@ -133,12 +133,12 @@ func (_c *MockIBlockchainPublisher_PublishIdentityUpdate_Call) Run(run func(ctx 
 	return _c
 }
 
-func (_c *MockIBlockchainPublisher_PublishIdentityUpdate_Call) Return(_a0 common.Hash, _a1 error) *MockIBlockchainPublisher_PublishIdentityUpdate_Call {
+func (_c *MockIBlockchainPublisher_PublishIdentityUpdate_Call) Return(_a0 *abis.IdentityUpdatesIdentityUpdateCreated, _a1 error) *MockIBlockchainPublisher_PublishIdentityUpdate_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockIBlockchainPublisher_PublishIdentityUpdate_Call) RunAndReturn(run func(context.Context, [32]byte, []byte) (common.Hash, error)) *MockIBlockchainPublisher_PublishIdentityUpdate_Call {
+func (_c *MockIBlockchainPublisher_PublishIdentityUpdate_Call) RunAndReturn(run func(context.Context, [32]byte, []byte) (*abis.IdentityUpdatesIdentityUpdateCreated, error)) *MockIBlockchainPublisher_PublishIdentityUpdate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/testutils/context.go
+++ b/pkg/testutils/context.go
@@ -1,0 +1,9 @@
+package testutils
+
+import "context"
+
+func CancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}


### PR DESCRIPTION
## tl;dr

- Gets the full logs of the transaction when submitting to the blockchain, so we can construct a valid `OriginatorEnvelope` that includes the `sequence_id`

## Notes
Once this is in I will update https://github.com/xmtp/xmtpd/pull/248 to take advantage of it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced blockchain message publishing with improved error handling and structured responses.
	- Introduced new methods for parsing transaction receipts related to message sending and identity updates.
	- Added a utility function to create a cancelled context for testing purposes.

- **Bug Fixes**
	- Refined error handling in blockchain publishing methods to provide clearer error messages and logging.

- **Tests**
	- Added unit tests for `BlockchainPublisher` methods to ensure expected functionality and error handling.

- **Documentation**
	- Updated method signatures to reflect new return types for blockchain publishing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->