### PR TITLE
Pin Foundry to the latest working version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,8 @@ jobs:
           submodules: recursive
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 'nightly-2044faec64f99a21f0e5f0094458a973612d0712'
       - run: forge --version
       - name: Run Forge fmt
         # only format code, we do not want to format LIB

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       - run: dev/docker/up
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 'nightly-2044faec64f99a21f0e5f0094458a973612d0712'
       - run: dev/contracts/deploy-local
       - name: Run Tests
         run: |
@@ -48,6 +50,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 'nightly-2044faec64f99a21f0e5f0094458a973612d0712'
 
       - name: Run Forge build
         working-directory: contracts


### PR DESCRIPTION
We should eventually figure out why it broke.

If we wanna keep the pin, we should set it as a variable in the GH Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows for linting and testing to specify a version for the Foundry toolchain.
	- Upgraded the checkout action version from `v3` to `v4` in the linting workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->