### PR TITLE
Set GRPC keep-alive

### DIFF
--- a/pkg/registrant/registrant.go
+++ b/pkg/registrant/registrant.go
@@ -49,6 +49,10 @@ func NewRegistrant(
 
 	tokenFactory := authn.NewTokenFactory(privateKey, record.NodeID)
 
+	log.Info(
+		"Registrant identified",
+		zap.Uint32("nodeId", record.NodeID),
+	)
 	return &Registrant{
 		record:       record,
 		privateKey:   privateKey,

--- a/pkg/registry/node.go
+++ b/pkg/registry/node.go
@@ -3,9 +3,11 @@ package registry
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"time"
 
 	"github.com/xmtp/xmtpd/pkg/utils"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 type DialOptionFunc func(node Node) []grpc.DialOption
@@ -49,6 +51,11 @@ func (node *Node) BuildClient(
 	dialOpts := append([]grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultCallOptions(),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	}, extraDialOpts...)
 
 	conn, err := grpc.NewClient(

--- a/pkg/registry/node.go
+++ b/pkg/registry/node.go
@@ -52,7 +52,7 @@ func (node *Node) BuildClient(
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultCallOptions(),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                10 * time.Second,
+			Time:                30 * time.Second,
 			Timeout:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),


### PR DESCRIPTION
Our sync streams are being terminated every 1 minute, possibly by the load balancer, possibly because the connection is idle. Here we set GRPC keep-alives to keep the connection active. Let's see if this fixes the issue.

Also added a log to log what a node is registered as.

More info:
- https://github.com/grpc/grpc-node/issues/1747
- https://grpc.io/docs/guides/keepalive/
- https://github.com/grpc/grpc-go/blob/master/Documentation/keepalive.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for registrant identification to improve visibility during runtime.
	- Updated gRPC client connection settings with keepalive parameters for better connection management.

- **Bug Fixes**
	- None reported.

- **Documentation**
	- None reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->