### PR TITLE
Only listen on localhost for unit tests

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -109,6 +109,7 @@ func main() {
 			chainRegistry,
 			db,
 			blockchainPublisher,
+			fmt.Sprintf("0.0.0.0:%d", options.API.Port),
 		)
 		if err != nil {
 			log.Fatal("initializing server", zap.Error(err))

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -33,11 +32,11 @@ type ApiServer struct {
 func NewAPIServer(
 	ctx context.Context,
 	log *zap.Logger,
-	port int,
+	listenAddress string,
 	enableReflection bool,
 	registrationFunc RegistrationFunc,
 ) (*ApiServer, error) {
-	grpcListener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	grpcListener, err := net.Listen("tcp", listenAddress)
 
 	if err != nil {
 		return nil, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,6 +52,7 @@ func NewReplicationServer(
 	nodeRegistry registry.NodeRegistry,
 	writerDB *sql.DB,
 	blockchainPublisher blockchain.IBlockchainPublisher,
+	listenAddress string,
 ) (*ReplicationServer, error) {
 	var err error
 
@@ -147,7 +148,7 @@ func NewReplicationServer(
 	s.apiServer, err = api.NewAPIServer(
 		s.ctx,
 		log,
-		options.API.Port,
+		listenAddress,
 		options.Reflection.Enable,
 		serviceRegistrationFunc,
 	)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -52,7 +52,7 @@ func NewTestServer(
 		API: config.ApiOptions{
 			Port: port,
 		},
-	}, registry, db, messagePublisher)
+	}, registry, db, messagePublisher, fmt.Sprintf("localhost:%d", port))
 	require.NoError(t, err)
 
 	return server

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -104,8 +104,8 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, func()) {
 	svr, err := api.NewAPIServer(
 		ctx,
 		log,
-		0,    /*port*/
-		true, /*enableReflection*/
+		"localhost:0", /*listenAddress*/
+		true,          /*enableReflection*/
 		serviceRegistrationFunc,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
The unit tests currently spin up instances of the server that accept all incoming connections, which causes a security dialog on Macs. Instead, for unit tests we only want to listen for incoming connections coming from localhost.