### PR TITLE
Add standard GRPC metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,10 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.66.0
 )
 
-require github.com/golang-jwt/jwt/v5 v5.2.1
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+)
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.2-20240717164558-a6c49f84cc0f.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -613,6 +613,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMNMPSVXA1yc=
 github.com/graph-gophers/graphql-go v1.5.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0 h1:CWyXh/jylQWp2dtiV33mY4iSSp6yf4lmn+c7/tN+ObI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.21.0/go.mod h1:nCLIt0w3Ept2NwF8ThLmrppXsfT07oC8k0XNDxd8sVU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=


### PR DESCRIPTION
### TL;DR

Added gRPC Prometheus metrics to the API server.

### What changed?

- Added `grpc-ecosystem/go-grpc-middleware` and `grpc-ecosystem/go-grpc-prometheus` dependencies.
- Implemented Prometheus metrics for gRPC server in the API server.
- Added unary and stream interceptors for Prometheus metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated Prometheus for monitoring gRPC server metrics, enabling performance tracking.
	- Added support for handling time histograms in the gRPC server.

- **Chores**
	- Updated dependency management in the project to include `github.com/grpc-ecosystem/go-grpc-prometheus`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->