### PR TITLE
Terminate self on prolonged chain disconnect

### DIFF
--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -115,7 +115,7 @@ func (r *RpcLogStreamer) Start() {
 }
 
 func (r *RpcLogStreamer) watchContract(watcher contractConfig) {
-	fromBlock := int(watcher.fromBlock)
+	fromBlock := watcher.fromBlock
 	logger := r.logger.With(zap.String("contractAddress", watcher.contractAddress.Hex()))
 	startTime := time.Now()
 	defer close(watcher.channel)
@@ -144,6 +144,8 @@ func (r *RpcLogStreamer) watchContract(watcher contractConfig) {
 				}
 				continue
 			}
+			// reset self-termination timer
+			startTime = time.Now()
 
 			logger.Debug("Got logs", zap.Int("numLogs", len(logs)), zap.Int("fromBlock", fromBlock))
 			if len(logs) == 0 {

--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -46,11 +46,12 @@ func (c *RpcLogStreamBuilder) ListenForContractEvent(
 	fromBlock int,
 	contractAddress common.Address,
 	topics []common.Hash,
+	maxDisconnectTime time.Duration,
 ) <-chan types.Log {
 	eventChannel := make(chan types.Log, 100)
 	c.contractConfigs = append(
 		c.contractConfigs,
-		contractConfig{fromBlock, contractAddress, topics, eventChannel},
+		contractConfig{fromBlock, contractAddress, topics, eventChannel, maxDisconnectTime},
 	)
 	return eventChannel
 }
@@ -61,10 +62,11 @@ func (c *RpcLogStreamBuilder) Build() (*RpcLogStreamer, error) {
 
 // Struct defining all the information required to filter events from logs
 type contractConfig struct {
-	fromBlock       int
-	contractAddress common.Address
-	topics          []common.Hash
-	channel         chan<- types.Log
+	fromBlock         int
+	contractAddress   common.Address
+	topics            []common.Hash
+	channel           chan<- types.Log
+	maxDisconnectTime time.Duration
 }
 
 /*
@@ -115,6 +117,7 @@ func (r *RpcLogStreamer) Start() {
 func (r *RpcLogStreamer) watchContract(watcher contractConfig) {
 	fromBlock := int(watcher.fromBlock)
 	logger := r.logger.With(zap.String("contractAddress", watcher.contractAddress.Hex()))
+	startTime := time.Now()
 	defer close(watcher.channel)
 	for {
 		select {
@@ -130,6 +133,15 @@ func (r *RpcLogStreamer) watchContract(watcher contractConfig) {
 					zap.Error(err),
 				)
 				time.Sleep(ERROR_SLEEP_TIME)
+
+				if time.Since(startTime) > watcher.maxDisconnectTime {
+					logger.Error(
+						"Max disconnect time exceeded. Node might drift too far away from expected state. Shutting down...",
+					)
+					panic(
+						"Max disconnect time exceeded. Node might drift too far away from expected state",
+					)
+				}
 				continue
 			}
 

--- a/pkg/blockchain/rpcLogStreamer_test.go
+++ b/pkg/blockchain/rpcLogStreamer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	big "math/big"
 	"testing"
+	"time"
 
 	mocks "github.com/xmtp/xmtpd/pkg/mocks/blockchain"
 	"github.com/xmtp/xmtpd/pkg/testutils"
@@ -43,7 +44,7 @@ func TestBuilder(t *testing.T) {
 	listenerChannel := builder.ListenForContractEvent(
 		1,
 		testutils.RandomAddress(),
-		[]common.Hash{testutils.RandomLogTopic()},
+		[]common.Hash{testutils.RandomLogTopic()}, 5*time.Minute,
 	)
 	require.NotNil(t, listenerChannel)
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -9,12 +9,13 @@ type ApiOptions struct {
 }
 
 type ContractsOptions struct {
-	RpcUrl                         string        `long:"rpc-url"                  env:"XMTPD_CONTRACTS_RPC_URL"                  description:"Blockchain RPC URL"`
-	NodesContractAddress           string        `long:"nodes-address"            env:"XMTPD_CONTRACTS_NODES_ADDRESS"            description:"Node contract address"`
-	MessagesContractAddress        string        `long:"messages-address"         env:"XMTPD_CONTRACTS_MESSAGES_ADDRESS"         description:"Message contract address"`
-	IdentityUpdatesContractAddress string        `long:"identity-updates-address" env:"XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS" description:"Identity updates contract address"`
-	ChainID                        int           `long:"chain-id"                 env:"XMTPD_CONTRACTS_CHAIN_ID"                 description:"Chain ID for the appchain"               default:"31337"`
-	RefreshInterval                time.Duration `long:"refresh-interval"         env:"XMTPD_CONTRACTS_REFRESH_INTERVAL"         description:"Refresh interval for the nodes registry" default:"60s"`
+	RpcUrl                         string        `long:"rpc-url"                   env:"XMTPD_CONTRACTS_RPC_URL"                   description:"Blockchain RPC URL"`
+	NodesContractAddress           string        `long:"nodes-address"             env:"XMTPD_CONTRACTS_NODES_ADDRESS"             description:"Node contract address"`
+	MessagesContractAddress        string        `long:"messages-address"          env:"XMTPD_CONTRACTS_MESSAGES_ADDRESS"          description:"Message contract address"`
+	IdentityUpdatesContractAddress string        `long:"identity-updates-address"  env:"XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS"  description:"Identity updates contract address"`
+	ChainID                        int           `long:"chain-id"                  env:"XMTPD_CONTRACTS_CHAIN_ID"                  description:"Chain ID for the appchain"                                    default:"31337"`
+	RefreshInterval                time.Duration `long:"refresh-interval"          env:"XMTPD_CONTRACTS_REFRESH_INTERVAL"          description:"Refresh interval for the nodes registry"                      default:"60s"`
+	MaxChainDisconnectTime         time.Duration `long:"max-chain-disconnect-time" env:"XMTPD_CONTRACTS_MAX_CHAIN_DISCONNECT_TIME" description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
 }
 
 type DbOptions struct {

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -138,6 +138,7 @@ func configureLogStream(
 		0,
 		common.HexToAddress(cfg.MessagesContractAddress),
 		[]common.Hash{messagesTopic},
+		cfg.MaxChainDisconnectTime,
 	)
 
 	identityUpdatesTopic, err := buildIdentityUpdatesTopic()
@@ -149,6 +150,7 @@ func configureLogStream(
 		0,
 		common.HexToAddress(cfg.IdentityUpdatesContractAddress),
 		[]common.Hash{identityUpdatesTopic},
+		cfg.MaxChainDisconnectTime,
 	)
 
 	streamer, err := builder.Build()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,9 +46,6 @@ type ReplicationServer struct {
 	// Can add reader DB later if needed
 }
 
-type ShutdownHandle struct {
-}
-
 func NewReplicationServer(
 	ctx context.Context,
 	log *zap.Logger,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,6 +46,9 @@ type ReplicationServer struct {
 	// Can add reader DB later if needed
 }
 
+type ShutdownHandle struct {
+}
+
 func NewReplicationServer(
 	ctx context.Context,
 	log *zap.Logger,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -42,7 +42,8 @@ func NewTestServer(
 
 	server, err := s.NewReplicationServer(context.Background(), log, config.ServerOptions{
 		Contracts: config.ContractsOptions{
-			RpcUrl: "http://localhost:8545",
+			RpcUrl:                 "http://localhost:8545",
+			MaxChainDisconnectTime: 5 * time.Minute,
 		},
 		MlsValidation: config.MlsValidationOptions{
 			GrpcAddress: "localhost:60051",


### PR DESCRIPTION
If the chain is unreachable during startup, the node will refuse to come up since it can't determine its nodeid.
If the chain goes away (for example due to a partial network failure) the node can drift too far away from the ordered MLS messages. We can prevent that scenario from happening by shutting ourselves down.

There are generally 3 ways to shut down a node:
- cancel the main context
- signal self
- panic

I deliberately picked `panic` here as it is the most visible of the three. It will print a stack trace which usually indicates that something is not ok. Its much more "visible" than an error message and a clean shut down.

An orchestrator will restart the node but if the disconnect persists, it will not come up.

The default self termination timeout is 5 min during which we will attempt to re-connect every 100ms. A network that does not heal within 5min sounds like a larger outage.

Fixes https://github.com/xmtp/xmtpd/issues/267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for maximum allowable disconnect time in log streaming, enhancing connection stability.
  
- **Bug Fixes**
	- Improved error handling related to connection stability during log streaming sessions.

- **Documentation**
	- Updated documentation to reflect the addition of the `MaxChainDisconnectTime` parameter across various configurations and methods.

- **Tests**
	- Modified test configurations to include the new `MaxChainDisconnectTime` parameter, ensuring comprehensive testing of the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->