### PR TITLE
Pre-baked Anvil+XMTPD docker image

### DIFF
--- a/.github/workflows/build-pre-baked-images.yml
+++ b/.github/workflows/build-pre-baked-images.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-pre-baked-images.yml
+++ b/.github/workflows/build-pre-baked-images.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           context: .
           file: ./dev/baked/Dockerfile
-          #push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-pre-baked-images.yml
+++ b/.github/workflows/build-pre-baked-images.yml
@@ -1,0 +1,51 @@
+name: Build pre-baked images
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_METADATA_PR_HEAD_SHA: true
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/xmtp/anvil-xmtpd
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        id: push
+        with:
+          context: .
+          file: ./dev/baked/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-pre-baked-images.yml
+++ b/.github/workflows/build-pre-baked-images.yml
@@ -50,3 +50,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: "FOUNDRY_VERSION=nightly-2044faec64f99a21f0e5f0094458a973612d0712"

--- a/.github/workflows/build-pre-baked-images.yml
+++ b/.github/workflows/build-pre-baked-images.yml
@@ -36,11 +36,10 @@ jobs:
         with:
           images: ghcr.io/xmtp/anvil-xmtpd
           tags: |
-            type=schedule
             type=ref,event=branch
-            type=ref,event=tag
             type=ref,event=pr
             type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -48,6 +47,7 @@ jobs:
         with:
           context: .
           file: ./dev/baked/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          #push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -24,18 +24,14 @@ RUN dev/docker/anvil-background && \
 
 # ACTUAL IMAGE -------------------------------------------------------
 
-FROM debian:bookworm
+FROM ghcr.io/foundry-rs/foundry
 
 LABEL maintainer="engineering@xmtp.com"
 LABEL source="https://github.com/xmtp/xmtpd"
-LABEL description="XMTP Node Software"
+LABEL description="Foundry with XMTPD Node contracts and registrations"
 
-# color, nocolor, json
-ENV GOLOG_LOG_FMT=nocolor
+EXPOSE 8545
 
-EXPOSE 5050
-
-COPY --from=builder /usr/local/bin/anvil /usr/bin/
 COPY --from=builder /app/anvil-baked-state anvil-baked-state
 
-CMD ["anvil", "--state", "anvil-baked-state"]
+CMD ["anvil", "--state", "anvil-baked-state", "--host", "0.0.0.0"]

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -23,6 +23,10 @@ RUN dev/docker/anvil-background && \
     pkill -f anvil && \
     sleep 5
 
+RUN echo "export XMTPD_CONTRACTS_NODES_ADDRESS="$(jq -r '.deployedTo' build/Nodes.json)"" >> contracts.env && \
+    echo "export XMTPD_CONTRACTS_MESSAGES_ADDRESS="$(jq -r '.deployedTo' build/GroupMessages.json)""  >> contracts.env && \
+    echo "export XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS="$(jq -r '.deployedTo' build/IdentityUpdates.json)""  >> contracts.env
+
 # ACTUAL IMAGE -------------------------------------------------------
 
 FROM ghcr.io/foundry-rs/foundry
@@ -34,5 +38,6 @@ LABEL description="Foundry with XMTPD Node contracts and registrations"
 EXPOSE 8545
 
 COPY --from=builder /app/anvil-baked-state anvil-baked-state
+COPY --from=builder /app/contracts.env contracts.env
 
-CMD ["anvil", "--state", "anvil-baked-state", "--host", "0.0.0.0"]
+ENTRYPOINT ["anvil", "--state", "anvil-baked-state"]

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -20,11 +20,12 @@ RUN dev/docker/anvil-background && \
     dev/contracts/deploy-local && \
     dev/register-local-node && \
     dev/register-local-node-2 && \
+    pkill -f anvil && \
     sleep 5
 
 # ACTUAL IMAGE -------------------------------------------------------
 
-FROM ghcr.io/foundry-rs/foundry:nightly-2044faec64f99a21f0e5f0094458a973612d0712
+FROM ghcr.io/foundry-rs/foundry
 
 LABEL maintainer="engineering@xmtp.com"
 LABEL source="https://github.com/xmtp/xmtpd"

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /app
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update &&  \
-    apt-get install -y curl git jq
+    apt-get install -y curl git jq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     source ~/.bashrc && \
@@ -16,6 +18,8 @@ RUN curl -L https://foundry.paradigm.xyz | bash && \
 
 COPY . .
 
+# It seems that anvil flushes the file to disk on shutdown and it takes a few ms to be persisted
+# That gives us the pkill+sleep requirement
 RUN dev/docker/anvil-background && \
     dev/contracts/deploy-local && \
     dev/register-local-node && \

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -1,0 +1,41 @@
+# BUILD IMAGE --------------------------------------------------------
+ARG GO_VERSION=1.22
+FROM golang:${GO_VERSION}-bookworm as builder
+
+WORKDIR /app
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update &&  \
+    apt-get install -y curl git jq
+
+RUN curl -L https://foundry.paradigm.xyz | bash && \
+    source ~/.bashrc && \
+    foundryup &&  \
+    cp ~/.foundry/bin/* /usr/local/bin
+
+COPY . .
+
+RUN dev/docker/anvil-background && \
+    dev/contracts/deploy-local && \
+    dev/register-local-node && \
+    dev/register-local-node-2 && \
+    sleep 5
+
+# ACTUAL IMAGE -------------------------------------------------------
+
+FROM debian:bookworm
+
+LABEL maintainer="engineering@xmtp.com"
+LABEL source="https://github.com/xmtp/xmtpd"
+LABEL description="XMTP Node Software"
+
+# color, nocolor, json
+ENV GOLOG_LOG_FMT=nocolor
+
+EXPOSE 5050
+
+COPY --from=builder /usr/local/bin/anvil /usr/bin/
+COPY --from=builder /app/anvil-baked-state anvil-baked-state
+
+CMD ["anvil", "--state", "anvil-baked-state"]

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -1,5 +1,6 @@
 # BUILD IMAGE --------------------------------------------------------
 ARG GO_VERSION=1.22
+ARG FOUNDRY_VERSION=nightly
 FROM golang:${GO_VERSION}-bookworm as builder
 
 WORKDIR /app
@@ -13,7 +14,7 @@ RUN apt-get update &&  \
 
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     source ~/.bashrc && \
-    foundryup -v nightly-2044faec64f99a21f0e5f0094458a973612d0712 &&  \
+    foundryup -v "${FOUNDRY_VERSION}" &&  \
     cp ~/.foundry/bin/* /usr/local/bin
 
 COPY . .

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update &&  \
 
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     source ~/.bashrc && \
-    foundryup &&  \
+    foundryup -v nightly-2044faec64f99a21f0e5f0094458a973612d0712 &&  \
     cp ~/.foundry/bin/* /usr/local/bin
 
 COPY . .
@@ -24,7 +24,7 @@ RUN dev/docker/anvil-background && \
 
 # ACTUAL IMAGE -------------------------------------------------------
 
-FROM ghcr.io/foundry-rs/foundry
+FROM ghcr.io/foundry-rs/foundry:nightly-2044faec64f99a21f0e5f0094458a973612d0712
 
 LABEL maintainer="engineering@xmtp.com"
 LABEL source="https://github.com/xmtp/xmtpd"

--- a/dev/docker/anvil-background
+++ b/dev/docker/anvil-background
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+anvil -p 7545 --dump-state $PWD/anvil-baked-state &


### PR DESCRIPTION
The purpose of this image is it's usage in `libxmtp` without having to pull all the requirements.

We now automatically build a `ghcr.io/xmtp/anvil-xmtpd` image that contains 2 endpoints (localhost:5050 and localhost:5051) along with the default test keys.

If we like this pattern, I will make pre-baked images for `xmtpd` too.

Maybe we can release/tag these in sync so that no configuration is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Actions workflow to automate Docker image building and pushing.
	- Added a new Dockerfile for building an image with the Foundry framework and XMTPD Node contracts.
	- Created a shell script to run the Anvil tool in the background.

- **Documentation**
	- Updated metadata labels in the Dockerfile for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->