### PR TITLE
Break down ENABLE apis

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -22,15 +22,17 @@ var Commit string = "unknown"
 var options config.ServerOptions
 
 func main() {
-	if _, err := flags.Parse(&options); err != nil {
-		if err, ok := err.(*flags.Error); !ok || err.Type != flags.ErrHelp {
-			fatal("Could not parse options: %s", err)
-		}
-		return
-	}
+	_, err := flags.Parse(&options)
 
 	if options.Version {
 		fmt.Printf("Version: %s\n", Commit)
+		return
+	}
+
+	if err != nil {
+		if err, ok := err.(*flags.Error); !ok || err.Type != flags.ErrHelp {
+			fatal("Could not parse options: %s", err)
+		}
 		return
 	}
 

--- a/dev/run
+++ b/dev/run
@@ -4,4 +4,8 @@ set -eu
 
 . dev/local.env
 
+export XMTPD_PAYER_ENABLE=true
+export XMTPD_REPLICATION_ENABLE=true
+export XMTPD_SYNC_ENABLE=true
+
 go run -ldflags="-X main.Commit=$(git rev-parse HEAD)" cmd/replication/main.go "$@"

--- a/dev/run-2
+++ b/dev/run-2
@@ -8,4 +8,8 @@ export XMTPD_SIGNER_PRIVATE_KEY=$ANVIL_ACC_2_PRIVATE_KEY
 export XMTPD_PAYER_PRIVATE_KEY=$XMTPD_SIGNER_PRIVATE_KEY
 export XMTPD_DB_WRITER_CONNECTION_STRING="postgres://postgres:xmtp@localhost:8766/postgres?sslmode=disable"
 
+export XMTPD_PAYER_ENABLE=true
+export XMTPD_REPLICATION_ENABLE=true
+export XMTPD_SYNC_ENABLE=true
+
 go run -ldflags="-X main.Commit=$(git rev-parse HEAD)" cmd/replication/main.go -p 5051 "$@"

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -36,7 +36,15 @@ type MetricsOptions struct {
 
 type PayerOptions struct {
 	PrivateKey string `long:"private-key" env:"XMTPD_PAYER_PRIVATE_KEY" description:"Private key used to sign blockchain transactions" required:"true"`
-	EnableAPI  bool   `long:"enable-api"  env:"XMTPD_PAYER_ENABLE_API"  description:"Enable the payer API"`
+	Enable     bool   `long:"enable"      env:"XMTPD_PAYER_ENABLE"      description:"Enable the payer API"`
+}
+
+type ReplicationOptions struct {
+	Enable bool `long:"enable" env:"XMTPD_REPLICATION_ENABLE" description:"Enable the replication API"`
+}
+
+type SyncOptions struct {
+	Enable bool `long:"enable" env:"XMTPD_SYNC_ENABLE" description:"Enable the sync server"`
 }
 
 type MlsValidationOptions struct {
@@ -90,14 +98,16 @@ type RegisterNodeOptions struct {
 
 type ServerOptions struct {
 	API           ApiOptions           `group:"API Options"            namespace:"api"`
-	DB            DbOptions            `group:"Database Options"       namespace:"db"`
 	Contracts     ContractsOptions     `group:"Contracts Options"      namespace:"contracts"`
+	DB            DbOptions            `group:"Database Options"       namespace:"db"`
+	Log           LogOptions           `group:"Log Options"            namespace:"log"`
 	Metrics       MetricsOptions       `group:"Metrics Options"        namespace:"metrics"`
+	MlsValidation MlsValidationOptions `group:"MLS Validation Options" namespace:"mls-validation"`
 	Payer         PayerOptions         `group:"Payer Options"          namespace:"payer"`
 	Reflection    ReflectionOptions    `group:"Reflection Options"     namespace:"reflection"`
-	Tracing       TracingOptions       `group:"DD APM Tracing Options" namespace:"tracing"`
-	MlsValidation MlsValidationOptions `group:"MLS Validation Options" namespace:"mls-validation"`
-	Log           LogOptions           `group:"Log Options"            namespace:"log"`
+	Replication   ReplicationOptions   `group:"Replication Options"    namespace:"replication"`
 	Signer        SignerOptions        `group:"Signer Options"         namespace:"signer"`
+	Sync          SyncOptions          `group:"Sync Options"           namespace:"sync"`
+	Tracing       TracingOptions       `group:"DD APM Tracing Options" namespace:"tracing"`
 	Version       bool                 `                                                          short:"v" long:"version" description:"Output binary version and exit"`
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -54,6 +54,16 @@ func NewTestServer(
 		API: config.ApiOptions{
 			Port: port,
 		},
+		Sync: config.SyncOptions{
+			Enable: true,
+		},
+		Replication: config.ReplicationOptions{
+			Enable: true,
+		},
+		//TODO(mkysel): this is not fully mocked yet
+		//Payer: config.PayerOptions{
+		//	Enable: true,
+		//},
 	}, registry, db, messagePublisher, fmt.Sprintf("localhost:%d", port))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This allows the caller to select which of the 3 services (replication, sync, payer) to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new environment variables to enhance configuration options: `XMTPD_PAYER_ENABLE`, `XMTPD_REPLICATION_ENABLE`, and `XMTPD_SYNC_ENABLE`.
  - Added new configuration options for replication and synchronization, improving control over server functionalities.

- **Bug Fixes**
  - Improved error handling and readability in command-line option parsing.

- **Documentation**
  - Enhanced logging for better observability during server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->