### PR TITLE
Fix annoying warning

### DIFF
--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -1,7 +1,7 @@
 # BUILD IMAGE --------------------------------------------------------
 ARG GO_VERSION=1.22
 ARG FOUNDRY_VERSION=nightly
-FROM golang:${GO_VERSION}-bookworm as builder
+FROM golang:${GO_VERSION}-bookworm AS builder
 
 WORKDIR /app
 

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD IMAGE --------------------------------------------------------
 ARG GO_VERSION=1.22
-FROM golang:${GO_VERSION}-alpine as builder
+FROM golang:${GO_VERSION}-alpine AS builder
 
 # Get build tools and required header files
 RUN apk add --no-cache build-base


### PR DESCRIPTION
```
 Check warning on line 1 in Dockerfile


GitHub Actions
/ docker
The 'as' keyword should match the case of the 'from' keyword

FromAsCasing: 'as' and 'FROM' keywords' casing do not match
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfile formatting for improved readability (changed `as` to `AS` for the builder alias).
	- No functional changes were made to the build process or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->