### PR TITLE
Add blockTracker struct

### DIFF
--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -101,3 +101,20 @@ FROM
 WHERE
 	originator_node_id = @originator_node_id;
 
+-- name: SetLatestBlock :exec
+INSERT INTO latest_block(contract_address, block_number)
+	VALUES (@contract_address, @block_number)
+ON CONFLICT (contract_address)
+	DO UPDATE SET
+		block_number = @block_number
+	WHERE
+		@block_number > latest_block.block_number;
+
+-- name: GetLatestBlock :one
+SELECT
+	block_number
+FROM
+	latest_block
+WHERE
+	contract_address = @contract_address;
+

--- a/pkg/db/queries/models.go
+++ b/pkg/db/queries/models.go
@@ -24,6 +24,11 @@ type GatewayEnvelope struct {
 	OriginatorEnvelope   []byte
 }
 
+type LatestBlock struct {
+	ContractAddress string
+	BlockNumber     int64
+}
+
 type NodeInfo struct {
 	NodeID      int32
 	PublicKey   []byte

--- a/pkg/indexer/blockTracker.go
+++ b/pkg/indexer/blockTracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -87,6 +88,14 @@ func getLatestBlock(
 			return 0, nil
 		}
 		return 0, err
+	}
+
+	if latestBlock < 0 {
+		return 0, fmt.Errorf(
+			"invalid block number %d for contract %s",
+			latestBlock,
+			contractAddress,
+		)
 	}
 
 	return uint64(latestBlock), nil

--- a/pkg/indexer/blockTracker.go
+++ b/pkg/indexer/blockTracker.go
@@ -1,0 +1,93 @@
+package indexer
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+)
+
+/*
+*
+BlockTracker keeps a database record of the latest block that has been indexed for a contract address
+and allows the user to increase the value.
+*
+*/
+type BlockTracker struct {
+	latestBlock     atomic.Uint64
+	contractAddress string
+	queries         *queries.Queries
+	mu              sync.Mutex
+}
+
+// Return a new BlockTracker initialized to the latest block from the DB
+func NewBlockTracker(
+	ctx context.Context,
+	contractAddress string,
+	queries *queries.Queries,
+) (*BlockTracker, error) {
+	bt := &BlockTracker{
+		contractAddress: contractAddress,
+		queries:         queries,
+	}
+
+	latestBlock, err := getLatestBlock(ctx, contractAddress, queries)
+	if err != nil {
+		return nil, err
+	}
+	bt.latestBlock.Store(latestBlock)
+
+	return bt, nil
+}
+
+func (bt *BlockTracker) GetLatestBlock() uint64 {
+	return bt.latestBlock.Load()
+}
+
+func (bt *BlockTracker) UpdateLatestBlock(ctx context.Context, block uint64) error {
+	// Quick check without lock
+	if block <= bt.latestBlock.Load() {
+		return nil
+	}
+
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	// Re-check after acquiring lock
+	if block <= bt.latestBlock.Load() {
+		return nil
+	}
+
+	if err := bt.updateDB(ctx, block); err != nil {
+		return err
+	}
+
+	bt.latestBlock.Store(block)
+	return nil
+}
+
+func (bt *BlockTracker) updateDB(ctx context.Context, block uint64) error {
+	return bt.queries.SetLatestBlock(ctx, queries.SetLatestBlockParams{
+		ContractAddress: bt.contractAddress,
+		BlockNumber:     int64(block),
+	})
+}
+
+func getLatestBlock(
+	ctx context.Context,
+	contractAddress string,
+	querier *queries.Queries,
+) (uint64, error) {
+	latestBlock, err := querier.GetLatestBlock(ctx, contractAddress)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	return uint64(latestBlock), nil
+}

--- a/pkg/indexer/blockTracker_test.go
+++ b/pkg/indexer/blockTracker_test.go
@@ -1,0 +1,131 @@
+package indexer
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+)
+
+const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+func TestInitialize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+	querier := queries.New(db)
+
+	tracker, err := NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
+	require.NoError(t, err)
+	require.NotNil(t, tracker)
+	require.Equal(t, uint64(0), tracker.GetLatestBlock())
+}
+
+func TestUpdateLatestBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+	querier := queries.New(db)
+
+	tracker, err := NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
+	require.NoError(t, err)
+
+	// Test updating to a higher block
+	err = tracker.UpdateLatestBlock(ctx, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), tracker.GetLatestBlock())
+
+	// Test updating to a lower block (should not update)
+	err = tracker.UpdateLatestBlock(ctx, 50)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), tracker.GetLatestBlock())
+
+	// Test updating to the same block (should not update)
+	err = tracker.UpdateLatestBlock(ctx, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), tracker.GetLatestBlock())
+
+	// Verify persistence
+	newTracker, err := NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), newTracker.GetLatestBlock())
+}
+
+func TestConcurrentUpdates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+	querier := queries.New(db)
+
+	tracker, err := NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	updatesPerGoroutine := 100
+
+	// Launch multiple goroutines to update the block number
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(startBlock int) {
+			defer wg.Done()
+			for j := 0; j < updatesPerGoroutine; j++ {
+				blockNum := uint64(startBlock + j)
+				err := tracker.UpdateLatestBlock(ctx, blockNum)
+				require.NoError(t, err)
+			}
+		}(i * updatesPerGoroutine)
+	}
+
+	wg.Wait()
+
+	// The final block number should be the highest one attempted
+	expectedFinalBlock := uint64((numGoroutines-1)*updatesPerGoroutine + (updatesPerGoroutine - 1))
+	require.Equal(t, expectedFinalBlock, tracker.GetLatestBlock())
+
+	// Verify persistence
+	newTracker, err := NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
+	require.NoError(t, err)
+	require.Equal(t, expectedFinalBlock, newTracker.GetLatestBlock())
+}
+
+func TestMultipleContractAddresses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+	querier := queries.New(db)
+
+	address1 := "0x0000000000000000000000000000000000000001"
+	address2 := "0x0000000000000000000000000000000000000002"
+
+	tracker1, err := NewBlockTracker(ctx, address1, querier)
+	require.NoError(t, err)
+	tracker2, err := NewBlockTracker(ctx, address2, querier)
+	require.NoError(t, err)
+
+	// Update trackers independently
+	err = tracker1.UpdateLatestBlock(ctx, 100)
+	require.NoError(t, err)
+	err = tracker2.UpdateLatestBlock(ctx, 200)
+	require.NoError(t, err)
+
+	// Verify different addresses maintain separate block numbers
+	require.Equal(t, uint64(100), tracker1.GetLatestBlock())
+	require.Equal(t, uint64(200), tracker2.GetLatestBlock())
+
+	// Verify persistence for both addresses
+	newTracker1, err := NewBlockTracker(ctx, address1, querier)
+	require.NoError(t, err)
+	newTracker2, err := NewBlockTracker(ctx, address2, querier)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(100), newTracker1.GetLatestBlock())
+	require.Equal(t, uint64(200), newTracker2.GetLatestBlock())
+}

--- a/pkg/migrations/00003_add-latest-block.down.sql
+++ b/pkg/migrations/00003_add-latest-block.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS latest_block;
+

--- a/pkg/migrations/00003_add-latest-block.up.sql
+++ b/pkg/migrations/00003_add-latest-block.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE latest_block(
+	contract_address TEXT NOT NULL PRIMARY KEY,
+	block_number BIGINT NOT NULL
+);
+


### PR DESCRIPTION
## TL;DR
Added a BlockTracker component to persistently track the latest processed block for each contract address.

## AI Assisted Summary

### What changed?
- Created a new `BlockTracker` type that maintains the latest processed block number for contract addresses
- Added SQL queries and database table to persist block numbers
- Implemented thread-safe block number updates with atomic operations and mutex locks
- Added comprehensive test coverage for single and concurrent operations
- Created database migration scripts for the new `latest_block` table

### How to test?
- Run the unit tests in `blockTracker_test.go`
- Tests cover:
  - Basic initialization and updates
  - Concurrent updates from multiple goroutines
  - Multiple contract address tracking
  - Persistence across tracker instances
  - Edge cases like updating to lower block numbers

### Why make this change?
This change enables reliable tracking of processed blockchain blocks per contract, preventing duplicate processing and ensuring no blocks are missed during indexing operations. The persistent storage allows the system to resume from the correct block after restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new SQL commands to manage the latest block for contract addresses, allowing for efficient retrieval and updating of block numbers.
  - Added a `BlockTracker` functionality to monitor and update the latest indexed block for specific contract addresses.

- **Bug Fixes**
  - Ensured thread safety during concurrent updates to the latest block number.

- **Tests**
  - Implemented comprehensive unit tests for the `BlockTracker` to validate its functionality and performance under various conditions.

- **Migrations**
  - Created a new database table `latest_block` to store contract addresses and their corresponding block numbers, along with a command to drop the table if it exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->