### PR TITLE
Add option to manually enable indexer

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -27,6 +27,10 @@ type DbOptions struct {
 	WaitForDB              time.Duration `long:"wait-for"                 env:"XMTPD_DB_WAIT_FOR"                 description:"wait for DB on start, up to specified duration"`
 }
 
+type IndexerOptions struct {
+	Enable bool `long:"enable" env:"XMTPD_INDEXER_ENABLE" description:"Enable the indexer"`
+}
+
 // MetricsOptions are settings used to start a prometheus server
 type MetricsOptions struct {
 	Enable  bool   `long:"enable"          env:"XMTPD_METRICS_ENABLE"          description:"Enable the metrics server"`
@@ -101,6 +105,7 @@ type ServerOptions struct {
 	Contracts     ContractsOptions     `group:"Contracts Options"      namespace:"contracts"`
 	DB            DbOptions            `group:"Database Options"       namespace:"db"`
 	Log           LogOptions           `group:"Log Options"            namespace:"log"`
+	Indexer       IndexerOptions       `group:"Indexer Options"        namespace:"indexer"`
 	Metrics       MetricsOptions       `group:"Metrics Options"        namespace:"metrics"`
 	MlsValidation MlsValidationOptions `group:"MLS Validation Options" namespace:"mls-validation"`
 	Payer         PayerOptions         `group:"Payer Options"          namespace:"payer"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -101,14 +101,17 @@ func NewReplicationServer(
 		return nil, err
 	}
 
-	s.indx = indexer.NewIndexer(ctx, log)
-	err = s.indx.StartIndexer(
-		s.writerDB,
-		options.Contracts,
-		validationService,
-	)
-	if err != nil {
-		return nil, err
+	if options.Indexer.Enable {
+		s.indx = indexer.NewIndexer(ctx, log)
+		err = s.indx.StartIndexer(
+			s.writerDB,
+			options.Contracts,
+			validationService,
+		)
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	serviceRegistrationFunc := func(grpcServer *grpc.Server) error {


### PR DESCRIPTION
## tl;dr

- Makes the blockchain indexer optional, so that we can only run it on the same instance that runs the sync worker
- This will require an infra change to set the config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to enable or disable the indexer, enhancing user control over system resources.
- **Bug Fixes**
	- Implemented conditional logic to prevent unnecessary indexer initialization, improving resource management and reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->