### PR TITLE
Add curl to Docker image

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -25,6 +25,8 @@ ENV GOLOG_LOG_FMT=nocolor
 
 EXPOSE 5050
 
+RUN apk add --no-cache curl
+
 COPY --from=builder /app/bin/xmtpd /usr/bin/
 
 ENTRYPOINT ["/usr/bin/xmtpd"]


### PR DESCRIPTION
### TL;DR

Added curl to the Docker image so we can use it in container health checks

### What changed?

Added `curl` package installation to the Dockerfile using Alpine's package manager (`apk add --no-cache curl`)

### Why make this change?

Curl is a necessary dependency for health checks and debugging network connectivity issues within containers. Including it in the base image ensures these diagnostic tools are readily available in production environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Dockerfile to include the installation of the `curl` package for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->