### PR TITLE
Add some logs

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -112,6 +112,8 @@ func NewReplicationServer(
 		if err != nil {
 			return nil, err
 		}
+
+		log.Info("Indexer service enabled")
 	}
 
 	serviceRegistrationFunc := func(grpcServer *grpc.Server) error {
@@ -181,7 +183,7 @@ func NewReplicationServer(
 			return nil, err
 		}
 
-		log.Info("Sync server started")
+		log.Info("Sync service enabled")
 	}
 
 	return s, nil


### PR DESCRIPTION
All our services print a message to `info` if they are enabled. This was not the case for the indexer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clarity of logging messages for the indexer and sync services, enhancing visibility into service status.
  
- **Documentation**
	- Updated log messages to reflect new naming conventions, providing more informative feedback during service initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->