### PR TITLE
Use namespace in DB

### DIFF
--- a/.github/workflows/build-pre-baked-images.yml
+++ b/.github/workflows/build-pre-baked-images.yml
@@ -50,4 +50,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: "FOUNDRY_VERSION=nightly-2044faec64f99a21f0e5f0094458a973612d0712"
+          build-args: "FOUNDRY_VERSION=nightly-ac81a53d1d5823919ffbadd3c65f081927aa11f2"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: 'nightly-2044faec64f99a21f0e5f0094458a973612d0712'
+          version: "nightly-ac81a53d1d5823919ffbadd3c65f081927aa11f2"
       - run: forge --version
       - name: Run Forge fmt
         # only format code, we do not want to format LIB

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: 'nightly-2044faec64f99a21f0e5f0094458a973612d0712'
+          version: "nightly-ac81a53d1d5823919ffbadd3c65f081927aa11f2"
       - run: dev/contracts/deploy-local
       - name: Run Tests
         run: |
@@ -51,7 +51,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: 'nightly-2044faec64f99a21f0e5f0094458a973612d0712'
+          version: "nightly-ac81a53d1d5823919ffbadd3c65f081927aa11f2"
 
       - name: Run Forge build
         working-directory: contracts

--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -57,9 +57,10 @@ func main() {
 	var wg sync.WaitGroup
 	doneC := make(chan bool, 1)
 	tracing.GoPanicWrap(ctx, &wg, "main", func(ctx context.Context) {
-		db, err := db.NewDB(
+		db, err := db.NewNamespacedDB(
 			ctx,
 			options.DB.WriterConnectionString,
+			utils.BuildNamespace(options),
 			options.DB.WaitForDB,
 			options.DB.ReadTimeout,
 		)

--- a/dev/contracts/deploy-ephemeral
+++ b/dev/contracts/deploy-ephemeral
@@ -5,4 +5,4 @@ source dev/contracts/.env
 
 cd ./contracts
 
-forge create --legacy --json --rpc-url $DOCKER_RPC_URL --private-key $PRIVATE_KEY "$1:$2"
+forge create --legacy --json --broadcast --rpc-url $DOCKER_RPC_URL --private-key $PRIVATE_KEY "$1:$2"

--- a/dev/contracts/deploy-local
+++ b/dev/contracts/deploy-local
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Deploy the smart contracts to the local anvil node
 
+set -euo pipefail
+
 source dev/contracts/.env
 
 # Make sure the build directory exists
@@ -10,7 +12,7 @@ cd ./contracts
 
 # Deploy a contract and save the output (which includes the contract address) to a JSON file to be used in tests
 function deploy_contract() {
-    forge create --legacy --json --rpc-url $DOCKER_RPC_URL --private-key $PRIVATE_KEY "$1:$2" > ../build/$2.json
+    forge create --broadcast --legacy --json --rpc-url $DOCKER_RPC_URL --private-key $PRIVATE_KEY "$1:$2" > ../build/$2.json
 }
 
 deploy_contract src/GroupMessages.sol GroupMessages

--- a/dev/contracts/deploy-testnet
+++ b/dev/contracts/deploy-testnet
@@ -8,6 +8,7 @@ cd ./contracts
 function deploy_contract() {
     forge create \
         --rpc-url $RPC_URL \
+        --broadcast \
         --chain=241320161 \
         --compiler-version=0.8.28 \
         --verify \

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/xmtp/xmtpd/pkg/config"
+)
+
+func BuildNamespace(options config.ServerOptions) string {
+	hash := ethcrypto.Keccak256(
+		[]byte(options.Signer.PrivateKey),
+		[]byte(options.Contracts.NodesContractAddress),
+	)
+
+	return HexEncode(hash)[:12]
+}


### PR DESCRIPTION
### TL;DR
Added database namespace support based on private key and contract address

### What changed?
- Introduced a new `BuildNamespace` function that generates a unique namespace using the node's private key and contract address
- Modified the replication service to use namespaced database connections
- The namespace is a 12-character hex string derived from the Keccak256 hash of the private key and contract address

### How to test?
1. Start multiple nodes with different private keys
2. Verify each node creates its database tables under a unique namespace
3. Confirm that data remains isolated between different node instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for database initialization that supports namespacing.
	- Added a function to compute a namespace based on server options.
	- Added a `--broadcast` option for contract deployment commands, enabling transaction broadcasting.

- **Bug Fixes**
	- Enhanced error handling during database and component initialization to ensure graceful application exits.
	- Improved reliability of deployment scripts with better error handling and control flow.
	- Updated deployment scripts to reflect changes in contract deployment processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->