### PR TITLE
Run CLI from any directory

### DIFF
--- a/dev/cli
+++ b/dev/cli
@@ -2,4 +2,11 @@
 
 set -eu
 
+# Get the directory where the script is located
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+# Navigate to the top-level directory
+TOP_LEVEL_DIR=$(realpath "$SCRIPT_DIR/..")
+cd "$TOP_LEVEL_DIR"
+
 go run cmd/cli/main.go "$@"


### PR DESCRIPTION
You have to run the CLI from the repo root such as `./dev/cli`, but it should be runnable from anywhere.

This fixes it.

See:
```
martinkysel@Mac xmtpd (mkysel/fix-cli) $ ./dev/cli 
Please specify one command of: generate-key, get-all-nodes, get-pub-key, mark-healthy, mark-unhealthy, register-node or update-address
2024/12/04 15:52:05 Could not parse options: Could not parse options: Please specify one command of: generate-key, get-all-nodes, get-pub-key, mark-healthy, mark-unhealthy, register-node or update-address
exit status 1
martinkysel@Mac xmtpd (mkysel/fix-cli) $ cd dev/
martinkysel@Mac dev (mkysel/fix-cli) $ ./cli 
Please specify one command of: generate-key, get-all-nodes, get-pub-key, mark-healthy, mark-unhealthy, register-node or update-address
2024/12/04 15:52:12 Could not parse options: Could not parse options: Please specify one command of: generate-key, get-all-nodes, get-pub-key, mark-healthy, mark-unhealthy, register-node or update-address
exit status 1
martinkysel@Mac dev (mkysel/fix-cli) $ cd /
martinkysel@Mac / $ /Users/martinkysel/work/xmtpd/dev/cli 
Please specify one command of: generate-key, get-all-nodes, get-pub-key, mark-healthy, mark-unhealthy, register-node or update-address
2024/12/04 15:52:22 Could not parse options: Could not parse options: Please specify one command of: generate-key, get-all-nodes, get-pub-key, mark-healthy, mark-unhealthy, register-node or update-address
exit status 1
```

Noticed by @jhaaaa 