### PR TITLE
Build CLI Docker Image

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -58,9 +58,7 @@ jobs:
       - name: Set xmtpd digest output
         if: ${{ matrix.image == 'xmtpd' }}
         id: set_xmtpd_digest
-        run: echo "digest=${{ steps.push.outputs.digest }}" >> $GITHUB_ENV
-        outputs:
-          digest: ${{ steps.push.outputs.digest }}
+        run: echo "digest=${{ steps.push.outputs.digest }}" >> $GITHUB_OUTPUT
 
 
   deploy:

--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -8,8 +8,12 @@ on:
   workflow_dispatch:
 
 jobs:
+
   push_to_registry:
-    name: Push Docker Image to GitHub Packages
+    strategy:
+      matrix:
+        image: ["xmtpd", "xmtpd-cli"]
+    name: Push Docker Images to GitHub Packages
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,7 +21,7 @@ jobs:
     env:
       DOCKER_METADATA_PR_HEAD_SHA: true
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
+      xmtpd_digest: ${{ steps.set_xmtpd_digest.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/xmtp/xmtpd
+          images: ghcr.io/xmtp/${{ matrix.image }}
           tags: |
             type=schedule
             type=ref,event=branch
@@ -51,6 +55,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "GIT_COMMIT=${{ github.event_name != 'pull_request' && github.sha || github.event.pull_request.head.sha }}"
 
+      - name: Set xmtpd digest output
+        if: ${{ matrix.image == 'xmtpd' }}
+        id: set_xmtpd_digest
+        run: echo "digest=${{ steps.push.outputs.digest }}" >> $GITHUB_ENV
+        outputs:
+          digest: ${{ steps.push.outputs.digest }}
+
+
   deploy:
     name: Deploy new images to infra
     runs-on: ubuntu-latest
@@ -68,5 +80,5 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: testnet
           variable-name: xmtpd_server_docker_image
-          variable-value: "ghcr.io/xmtp/xmtpd@${{ needs.push_to_registry.outputs.digest }}"
+          variable-value: "ghcr.io/xmtp/xmtpd@${{ needs.push_to_registry.outputs.xmtpd_digest }}"
           variable-value-required-prefix: "ghcr.io/xmtp/xmtpd@sha256:"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var Commit string = "unknown"
+
 type globalOptions struct {
 	Contracts config.ContractsOptions `group:"Contracts Options" namespace:"contracts"`
 	Log       config.LogOptions       `group:"Log Options"       namespace:"log"`
@@ -264,6 +266,13 @@ func updateAddress(logger *zap.Logger, options *CLI) {
 }
 
 func main() {
+	for _, arg := range os.Args[1:] {
+		if arg == "-v" || arg == "--version" {
+			fmt.Printf("Version: %s\n", Commit)
+			return
+		}
+	}
+
 	options, err := parseOptions(os.Args[1:])
 	if err != nil {
 		log.Fatalf("Could not parse options: %s", err)

--- a/dev/cli
+++ b/dev/cli
@@ -2,4 +2,4 @@
 
 set -eu
 
-go run cmd/cli/main.go "$@"
+go run -ldflags="-X main.Commit=$(git rev-parse HEAD)" cmd/cli/main.go "$@"

--- a/dev/docker/Dockerfile-cli
+++ b/dev/docker/Dockerfile-cli
@@ -1,0 +1,32 @@
+# BUILD IMAGE --------------------------------------------------------
+ARG GO_VERSION=1.22
+FROM golang:${GO_VERSION}-alpine AS builder
+
+# Get build tools and required header files
+RUN apk add --no-cache build-base
+
+WORKDIR /app
+COPY . .
+
+# Build the final node binary
+ARG GIT_COMMIT=unknown
+RUN go build -ldflags="-X 'main.Commit=$GIT_COMMIT'" -o bin/xmtpd-cli cmd/cli/main.go
+
+# ACTUAL IMAGE -------------------------------------------------------
+
+FROM alpine:3.12
+
+LABEL maintainer="engineering@xmtp.com"
+LABEL source="https://github.com/xmtp/xmtpd"
+LABEL description="XMTPD CLI"
+
+# color, nocolor, json
+ENV GOLOG_LOG_FMT=nocolor
+
+EXPOSE 5050
+
+RUN apk add --no-cache curl
+
+COPY --from=builder /app/bin/xmtpd-cli /usr/bin/
+
+ENTRYPOINT ["/usr/bin/xmtpd-cli"]

--- a/dev/docker/Dockerfile-cli
+++ b/dev/docker/Dockerfile-cli
@@ -23,10 +23,6 @@ LABEL description="XMTPD CLI"
 # color, nocolor, json
 ENV GOLOG_LOG_FMT=nocolor
 
-EXPOSE 5050
-
-RUN apk add --no-cache curl
-
 COPY --from=builder /app/bin/xmtpd-cli /usr/bin/
 
 ENTRYPOINT ["/usr/bin/xmtpd-cli"]


### PR DESCRIPTION
Partners might have to run the CLI to export the public key (or generate it in the first place) and provide it to Ephemera for use in the `testnet`.

It is not too convenient to download the repo, install go, just to run the CLI.

Build a docker image instead.

We will eventually need releases here in GH for easy download, and `homebrew` as well.

The important question is. How should this binary be called?

This should help @jhaaaa with docs.