### PR TITLE
cli: prefix node arguments

### DIFF
--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -23,9 +23,9 @@ func TestRegisterNodeArgParse(t *testing.T) {
 			httpAddress,
 			"--admin-private-key",
 			adminPrivateKey,
-			"--owner-address",
+			"--node-owner-address",
 			ownerAddress.Hex(),
-			"--signing-key-pub",
+			"--node-signing-key-pub",
 			signingKeyPub,
 		},
 	)
@@ -41,7 +41,7 @@ func TestRegisterNodeArgParse(t *testing.T) {
 	require.Equal(
 		t,
 		err.Error(),
-		"Could not parse options: the required flags `--admin-private-key', `--http-address', `--owner-address' and `--signing-key-pub' were not specified",
+		"Could not parse options: the required flags `--admin-private-key', `--http-address', `--node-owner-address' and `--node-signing-key-pub' were not specified",
 	)
 }
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -5,9 +5,10 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"github.com/xmtp/xmtpd/pkg/config"
 	"log"
 	"os"
+
+	"github.com/xmtp/xmtpd/pkg/config"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
@@ -145,7 +146,7 @@ func registerNode(logger *zap.Logger, options *CLI) {
 	}
 	logger.Info(
 		"successfully added node",
-		zap.String("owner-address", options.RegisterNode.OwnerAddress),
+		zap.String("node-owner-address", options.RegisterNode.OwnerAddress),
 		zap.String("node-http-address", options.RegisterNode.HttpAddress),
 		zap.String("node-signing-key-pub", utils.EcdsaPublicKeyToString(signingKeyPub)),
 	)
@@ -303,5 +304,4 @@ func main() {
 		updateAddress(logger, options)
 		return
 	}
-
 }

--- a/dev/register-local-node
+++ b/dev/register-local-node
@@ -8,6 +8,6 @@ export NODE_ADDRESS=$ANVIL_ACC_1_ADDRESS
 
 dev/cli register-node \
     --http-address=http://localhost:5050 \
-    --owner-address=$NODE_ADDRESS \
+    --node-owner-address=$NODE_ADDRESS \
     --admin-private-key=$PRIVATE_KEY \
-    --signing-key-pub=$XMTPD_SIGNER_PUBLIC_KEY
+    --node-signing-key-pub=$XMTPD_SIGNER_PUBLIC_KEY

--- a/dev/register-local-node-2
+++ b/dev/register-local-node-2
@@ -9,6 +9,6 @@ export NODE_ADDRESS=$ANVIL_ACC_2_ADDRESS
 
 dev/cli register-node \
     --http-address=http://localhost:5051 \
-    --owner-address=$NODE_ADDRESS \
+    --node-owner-address=$NODE_ADDRESS \
     --admin-private-key=$PRIVATE_KEY \
-    --signing-key-pub=$XMTPD_SIGNER_PUBLIC_KEY
+    --node-signing-key-pub=$XMTPD_SIGNER_PUBLIC_KEY

--- a/dev/up
+++ b/dev/up
@@ -13,7 +13,7 @@ if ! which sqlc &> /dev/null; then go install github.com/sqlc-dev/sqlc/cmd/sqlc;
 if ! which buf &> /dev/null; then go install github.com/bufbuild/buf/cmd/buf; fi
 if ! which golines &>/dev/null; then go install github.com/segmentio/golines@latest; fi
 if ! which abigen &>/dev/null; then go install github.com/ethereum/go-ethereum/cmd/abigen; fi
-
+if ! which jq &>/dev/null; then brew install jq; fi
 
 dev/docker/up
 dev/contracts/deploy-local 

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -26,9 +26,9 @@ export PRIVATE_KEY=<secret>
 
 dev/cli register-node \
     --http-address=<node DNS> \
-    --owner-address=0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0 \
+    --node-owner-address=0xd27FDB90A393Ce0E390120aeB58b326AbA910BE0 \
     --admin-private-key=$PRIVATE_KEY \
-    --signing-key-pub=<node pub key>
+    --node-signing-key-pub=<node pub key>
 ```
 
 You need to register all (both) nodes with their correct DNS entries and public keys.

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -48,9 +48,9 @@ export PRIVATE_KEY=<secret>
 
 dev/cli register-node \
     --http-address=<node DNS> \
-    --owner-address=<node address> \
+    --node-owner-address=<node address> \
     --admin-private-key=$PRIVATE_KEY \
-    --signing-key-pub=<node pub-key>
+    --node-signing-key-pub=<node pub-key>
 ```
 
 ## Step 4) Start the node

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -25,8 +25,8 @@ type GetPubKeyOptions struct {
 }
 
 type RegisterNodeOptions struct {
-	HttpAddress     string `long:"http-address"      description:"HTTP address to register for the node"                            required:"true"`
-	OwnerAddress    string `long:"owner-address"     description:"Blockchain address of the intended owner of the registration NFT" required:"true"`
-	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to register the node"                    required:"true"`
-	SigningKeyPub   string `long:"signing-key-pub"   description:"Signing key of the node to register"                              required:"true"`
+	HttpAddress     string `long:"http-address"         description:"HTTP address to register for the node"                            required:"true"`
+	OwnerAddress    string `long:"node-owner-address"   description:"Blockchain address of the intended owner of the registration NFT" required:"true"`
+	AdminPrivateKey string `long:"admin-private-key"    description:"Private key of the admin to register the node"                    required:"true"`
+	SigningKeyPub   string `long:"node-signing-key-pub" description:"Signing key of the node to register"                              required:"true"`
 }


### PR DESCRIPTION
Summary
--
- Prefix node arguments with `node-`
- Include `jq` as a dependency in `dev/up`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated command-line arguments for node registration to enhance clarity.
  
- **Bug Fixes**
	- Improved error messages for missing command-line options.

- **Documentation**
	- Revised deployment and onboarding documents to reflect updated command-line options.

- **Chores**
	- Added a check for the `jq` command-line tool installation in scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->