### PR TITLE
Change default encoding for CLI

### DIFF
--- a/dev/cli
+++ b/dev/cli
@@ -9,4 +9,6 @@ SCRIPT_DIR=$(dirname "$(realpath "$0")")
 TOP_LEVEL_DIR=$(realpath "$SCRIPT_DIR/..")
 cd "$TOP_LEVEL_DIR"
 
+export XMTPD_LOG_ENCODING=json
+
 go run -ldflags="-X main.Commit=$(git rev-parse HEAD)" cmd/cli/main.go "$@"

--- a/dev/docker/Dockerfile-cli
+++ b/dev/docker/Dockerfile-cli
@@ -23,6 +23,8 @@ LABEL description="XMTPD CLI"
 # color, nocolor, json
 ENV GOLOG_LOG_FMT=nocolor
 
+ENV XMTPD_LOG_ENCODING=json
+
 COPY --from=builder /app/bin/xmtpd-cli /usr/bin/
 
 ENTRYPOINT ["/usr/bin/xmtpd-cli"]

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -8,7 +8,7 @@ It is important that both `public key` and `address` are correct as they are imm
 
 An easy way to generate a new private key is to use our CLI:
 ```bash
-$ XMTPD_LOG_ENCODING=json ./dev/cli generate-key | jq
+./dev/cli generate-key | jq
 {
   "level": "INFO",
   "time": "2024-10-15T13:21:14.036-0400",
@@ -21,7 +21,7 @@ $ XMTPD_LOG_ENCODING=json ./dev/cli generate-key | jq
 
 If you already have a private key, you can extract the relevant public details via:
 ```bash
-$ XMTPD_LOG_ENCODING=json ./dev/cli get-pub-key --private-key 0xa9b48d687f450ea99a5faaae1be096ddb49487cb28393d3906d7359ede6ea460 | jq
+./dev/cli get-pub-key --private-key 0xa9b48d687f450ea99a5faaae1be096ddb49487cb28393d3906d7359ede6ea460 | jq
 {
   "level": "INFO",
   "time": "2024-10-15T13:21:51.276-0400",


### PR DESCRIPTION
Switch to JSON encoding since its more readable with the use of `jq`.

I thought about changing the default in the `go` code but it was a bigger surgery than expected. This works and does not require refactoring options...

I will make a follow-up PR that simplifies the docs and the user examples. New release of everything coming too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable for logging configuration in both the CLI and Dockerfile, setting the logging format to JSON.

- **Documentation**
	- Simplified command examples in the onboarding guide by removing the logging environment variable prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->