### PR TITLE
Print error on failed blockchain publish

### DIFF
--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -82,6 +82,7 @@ func (s *Service) PublishClientEnvelopes(
 		)
 		var originatorEnvelope *envelopesProto.OriginatorEnvelope
 		if originatorEnvelope, err = s.publishToBlockchain(ctx, payload.payload); err != nil {
+			s.log.Error("error publishing payer envelopes", zap.Error(err))
 			return nil, status.Errorf(codes.Internal, "error publishing group message: %v", err)
 		}
 		out[payload.originalIndex] = originatorEnvelope


### PR DESCRIPTION
I would argue that we should not leak internal errors to the client, but it is actually easier to debug for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging for blockchain publishing, enhancing visibility of encountered issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->