### PR TITLE
Generate unique nonces for concurrent blockchain txns

### DIFF
--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -3,7 +3,10 @@ package blockchain
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math/big"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -24,7 +27,8 @@ type BlockchainPublisher struct {
 	messagesContract       *abis.GroupMessages
 	identityUpdateContract *abis.IdentityUpdates
 	logger                 *zap.Logger
-	mu                     sync.Mutex
+	mutexNonce             sync.Mutex
+	nonce                  *uint64
 }
 
 func NewBlockchainPublisher(
@@ -51,7 +55,6 @@ func NewBlockchainPublisher(
 	if err != nil {
 		return nil, err
 	}
-
 	return &BlockchainPublisher{
 		signer: signer,
 		logger: logger.Named("GroupBlockchainPublisher").
@@ -71,11 +74,14 @@ func (m *BlockchainPublisher) PublishGroupMessage(
 		return nil, errors.New("message is empty")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	nonce, err := m.fetchNonce(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	tx, err := m.messagesContract.AddMessage(&bind.TransactOpts{
 		Context: ctx,
+		Nonce:   new(big.Int).SetUint64(nonce),
 		From:    m.signer.FromAddress(),
 		Signer:  m.signer.SignerFunc(),
 	}, groupID, message)
@@ -111,13 +117,15 @@ func (m *BlockchainPublisher) PublishIdentityUpdate(
 		return nil, errors.New("identity update is empty")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	nonce, err := m.fetchNonce(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	tx, err := m.identityUpdateContract.AddIdentityUpdate(&bind.TransactOpts{
-		Context: ctx,
-		From:    m.signer.FromAddress(),
-		Signer:  m.signer.SignerFunc(),
+		Nonce:  new(big.Int).SetUint64(nonce),
+		From:   m.signer.FromAddress(),
+		Signer: m.signer.SignerFunc(),
 	}, inboxId, identityUpdate)
 	if err != nil {
 		return nil, err
@@ -143,6 +151,53 @@ func (m *BlockchainPublisher) PublishIdentityUpdate(
 		m.identityUpdateContract.ParseIdentityUpdateCreated,
 		"no identity update log found",
 	)
+}
+
+func (m *BlockchainPublisher) fetchNonce(ctx context.Context) (uint64, error) {
+	// NOTE:since pendingNonce starts at 0, and we have to return that value exactly,
+	// we can't easily use Once with unsigned integers
+	if m.nonce == nil {
+		m.mutexNonce.Lock()
+		defer m.mutexNonce.Unlock()
+		if m.nonce == nil {
+			// PendingNonceAt gives the next nonce that should be used
+			// if we are the first thread to initialize the nonce, we want to return PendingNonce+0
+			nonce, err := m.client.PendingNonceAt(ctx, m.signer.FromAddress())
+			if err != nil {
+				return 0, err
+			}
+			m.nonce = &nonce
+			m.logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", *m.nonce))
+			return *m.nonce, nil
+		}
+	}
+	// Once the nonce has been initialized we can depend on Atomic to return the next value
+	next := atomic.AddUint64(m.nonce, 1)
+
+	pending, err := m.client.PendingNonceAt(ctx, m.signer.FromAddress())
+	if err != nil {
+		return 0, err
+	}
+
+	// in some cases the chain nonce jumps ahead, and we need to handle this case
+	// this won't catch all possible timing scenarios, but it should self-heal if the chain jumps
+	if next < pending {
+		m.mutexNonce.Lock()
+		defer m.mutexNonce.Unlock()
+		next = atomic.AddUint64(m.nonce, 1)
+		if next < pending {
+			m.logger.Info(
+				fmt.Sprintf(
+					"Skew detected. Bumping nonce tracker! Pending/Next:%d/%d",
+					pending,
+					next,
+				),
+			)
+			atomic.StoreUint64(m.nonce, pending)
+			return pending, nil
+		}
+	}
+	return next, nil
 }
 
 func findLog[T any](

--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -23,6 +24,7 @@ type BlockchainPublisher struct {
 	messagesContract       *abis.GroupMessages
 	identityUpdateContract *abis.IdentityUpdates
 	logger                 *zap.Logger
+	mu                     sync.Mutex
 }
 
 func NewBlockchainPublisher(
@@ -68,6 +70,10 @@ func (m *BlockchainPublisher) PublishGroupMessage(
 	if len(message) == 0 {
 		return nil, errors.New("message is empty")
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	tx, err := m.messagesContract.AddMessage(&bind.TransactOpts{
 		Context: ctx,
 		From:    m.signer.FromAddress(),
@@ -104,6 +110,10 @@ func (m *BlockchainPublisher) PublishIdentityUpdate(
 	if len(identityUpdate) == 0 {
 		return nil, errors.New("identity update is empty")
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	tx, err := m.identityUpdateContract.AddIdentityUpdate(&bind.TransactOpts{
 		Context: ctx,
 		From:    m.signer.FromAddress(),

--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -123,9 +123,10 @@ func (m *BlockchainPublisher) PublishIdentityUpdate(
 	}
 
 	tx, err := m.identityUpdateContract.AddIdentityUpdate(&bind.TransactOpts{
-		Nonce:  new(big.Int).SetUint64(nonce),
-		From:   m.signer.FromAddress(),
-		Signer: m.signer.SignerFunc(),
+		Context: ctx,
+		Nonce:   new(big.Int).SetUint64(nonce),
+		From:    m.signer.FromAddress(),
+		Signer:  m.signer.SignerFunc(),
 	}, inboxId, identityUpdate)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A single address can not publish multiple transactions to the chain concurrently. If it does, we see this:
```
$ cargo run --package xdbg -- -d -b local generate -e identity -a 5
    Finished `dev` profile [unoptimized] target(s) in 0.20s
     Running `target/debug/xdbg -d -b local generate -e identity -a 5`
Error: 
   0: API error: API client error: mls error: status: Internal, message: "error publishing group message: rpc error: code = Internal desc = error publishing identity update: nonce too low", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }
   1: API client error: mls error: status: Internal, message: "error publishing group message: rpc error: code = Internal desc = error publishing identity update: nonce too low", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }
   2: mls error: status: Internal, message: "error publishing group message: rpc error: code = Internal desc = error publishing identity update: nonce too low", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }
   3: status: Internal, message: "error publishing group message: rpc error: code = Internal desc = error publishing identity update: nonce too low", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }

```

This introduces a lock to prevent concurrent/parallel transactions.

This won't work in a HA scenario as multiple payer processes can have the same private key. The solution is to give a new key to every payer.

My understanding is that ALL transactions from a single address have to be ordered. That is why both group messages and identities use the same mutex. @fbac is that accurate?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved thread safety for publishing messages and identity updates to the blockchain.
- **New Features**
	- Introduced a nonce management system to prevent conflicts during concurrent transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->