### PR TITLE
Fix nonce handling

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -106,6 +106,7 @@ func main() {
 		}
 
 		blockchainPublisher, err := blockchain.NewBlockchainPublisher(
+			ctx,
 			logger,
 			ethclient,
 			signer,

--- a/pkg/blockchain/blockchainPublisher_test.go
+++ b/pkg/blockchain/blockchainPublisher_test.go
@@ -24,7 +24,7 @@ func buildPublisher(t *testing.T) (*BlockchainPublisher, func()) {
 	client, err := NewClient(ctx, contractsOptions.RpcUrl)
 	require.NoError(t, err)
 
-	publisher, err := NewBlockchainPublisher(logger, client, signer, contractsOptions)
+	publisher, err := NewBlockchainPublisher(ctx, logger, client, signer, contractsOptions)
 	require.NoError(t, err)
 
 	return publisher, func() {

--- a/pkg/indexer/e2e_test.go
+++ b/pkg/indexer/e2e_test.go
@@ -44,6 +44,7 @@ func messagePublisher(t *testing.T, ctx context.Context) *blockchain.BlockchainP
 	require.NoError(t, err)
 
 	publisher, err := blockchain.NewBlockchainPublisher(
+		ctx,
 		testutils.NewLog(t),
 		client,
 		signer,


### PR DESCRIPTION
The access to the pointer was not thread-safe which was triggering the race tests.

I moved the initialization out of the hot section and sped things up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced nonce management in the Blockchain Publisher for improved clarity and efficiency.
	- Context parameter added to the initialization of the Blockchain Publisher, allowing better lifecycle management.

- **Bug Fixes**
	- Improved error handling during the initialization of components ensuring application stability.

- **Tests**
	- Updated test functions to include the context parameter for better management of operations and cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->