### PR TITLE
Fix pre-baked images builder

### DIFF
--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update &&  \
 
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     source ~/.bashrc && \
-    foundryup -v "${FOUNDRY_VERSION}" &&  \
+    foundryup -i "${FOUNDRY_VERSION}" &&  \
     cp ~/.foundry/bin/* /usr/local/bin
 
 COPY . .


### PR DESCRIPTION
For some reason foundryup changed from `-u` to `-i`...

https://github.com/foundry-rs/foundry/pull/9551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build process for the Foundry environment, modifying the installation command.
	- Retained comments for clarity on environment setup commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->