### PR TITLE
Rework how we ignore changes in CI

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
     paths:
-      - ".github/workflows/lint.yml"
+      - ".github/workflows/lint-go.yml"
       - "pkg/**"
       - "cmd/**"
       - "dev/**"
@@ -17,14 +17,10 @@ permissions:
   contents: read
 jobs:
   lint:
-    name: Lint
+    name: Lint-Go
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: shellcheck
-        run: |
-          sudo apt-get -y install tree
-          dev/lint-shellcheck
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -16,7 +16,7 @@ on:
 permissions:
   contents: read
 jobs:
-  lint:
+  lint-go:
     name: Lint-Go
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-spellcheck.yml
+++ b/.github/workflows/lint-spellcheck.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint Spellcheck
 on:
   push:
     branches:

--- a/.github/workflows/lint-spellcheck.yml
+++ b/.github/workflows/lint-spellcheck.yml
@@ -1,0 +1,19 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/lint-spellcheck.yml"
+      - "dev/**"
+jobs:
+  lint-spellcheck:
+    name: Lint Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: shellcheck
+        run: |
+          sudo apt-get -y install tree
+          dev/lint-shellcheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,16 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "contracts/**"
   pull_request:
-    paths-ignore:
-      - "contracts/**"
+    paths:
+      - ".github/workflows/lint.yml"
+      - "pkg/**"
+      - "cmd/**"
+      - "dev/**"
+      - "go.mod"
+      - "go.sum"
+      - "tools.go"
+      - ".golangci.yaml"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "contracts/**"
   pull_request:
     paths:
       - "contracts/**"
+      - ".github/workflows/solidity.yml"
 
 concurrency:
   group: ci-solidity-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,15 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "contracts/**"
   pull_request:
-    paths-ignore:
-      - "contracts/**"
+    paths:
+      - ".github/workflows/test.yml"
+      - "pkg/**"
+      - "cmd/**"
+      - "dev/**"
+      - "go.mod"
+      - "go.sum"
+      - "tools.go"
 jobs:
   test:
     name: Test (Node)


### PR DESCRIPTION
This is based on how we do things in [libxmtp](https://github.com/xmtp/libxmtp/blob/main/.github/workflows/test-http-api.yml)

There are two major changes:
- always run all tests in `main`
- be more deliberate about ignoring node tests in some scenarios