### PR TITLE
chore: pin abigen version

### DIFF
--- a/dev/up
+++ b/dev/up
@@ -12,8 +12,18 @@ if ! which mockery &>/dev/null; then go install github.com/vektra/mockery/v2; fi
 if ! which sqlc &> /dev/null; then go install github.com/sqlc-dev/sqlc/cmd/sqlc; fi
 if ! which buf &> /dev/null; then go install github.com/bufbuild/buf/cmd/buf; fi
 if ! which golines &>/dev/null; then go install github.com/segmentio/golines@latest; fi
-if ! which abigen &>/dev/null; then go install github.com/ethereum/go-ethereum/cmd/abigen; fi
 if ! which jq &>/dev/null; then brew install jq; fi
+
+# Pin abigen version at can introduce breaking changes between releases, rendering different ABIs.
+if ! which abigen &>/dev/null; then
+    go install github.com/ethereum/go-ethereum/cmd/abigen@v1.14.12
+fi
+
+abigen_version=$(abigen --version | awk '{print $3}')
+if [[ ${abigen_version} != "1.14.12-stable" ]]; then
+    echo "ERROR: abigen version is not 1.14.12. Please install the correct version."
+    exit 1
+fi
 
 dev/docker/up
 dev/contracts/deploy-local 

--- a/dev/update-tools
+++ b/dev/update-tools
@@ -6,6 +6,5 @@ go mod tidy
 go install github.com/vektra/mockery/v2
 go install github.com/sqlc-dev/sqlc/cmd/sqlc
 go install github.com/segmentio/golines@latest
-go install github.com/ethereum/go-ethereum/cmd/abigen
 go install github.com/golang-migrate/migrate/v4/cmd/migrate
 go install github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
Pin the abigen version, so generated golang code is deterministically generated. 
Different versions could introduce changes, and we should avoid pushing generated code with different versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced version pinning for the `abigen` tool to ensure consistent installation.
	- Added a version check for `abigen` to verify installation integrity.

- **Bug Fixes**
	- Removed the installation command for the `abigen` tool from the script, streamlining the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->