### PR TITLE
API Mock Improvements

### DIFF
--- a/pkg/api/message/subscribe_test.go
+++ b/pkg/api/message/subscribe_test.go
@@ -25,7 +25,9 @@ var (
 )
 var allRows []queries.InsertGatewayEnvelopeParams
 
-func setupTest(t *testing.T) (message_api.ReplicationApiClient, *sql.DB, func()) {
+func setupTest(
+	t *testing.T,
+) (message_api.ReplicationApiClient, *sql.DB, testUtilsApi.ApiServerMocks, func()) {
 	allRows = []queries.InsertGatewayEnvelopeParams{
 		// Initial rows
 		{
@@ -115,7 +117,7 @@ func validateUpdates(
 }
 
 func TestSubscribeEnvelopesAll(t *testing.T) {
-	client, db, cleanup := setupTest(t)
+	client, db, _, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, db)
 
@@ -136,7 +138,7 @@ func TestSubscribeEnvelopesAll(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesByTopic(t *testing.T) {
-	client, store, cleanup := setupTest(t)
+	client, store, _, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, store)
 
@@ -158,7 +160,7 @@ func TestSubscribeEnvelopesByTopic(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesByOriginator(t *testing.T) {
-	client, db, cleanup := setupTest(t)
+	client, db, _, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, db)
 
@@ -180,7 +182,7 @@ func TestSubscribeEnvelopesByOriginator(t *testing.T) {
 }
 
 func TestSimultaneousSubscriptions(t *testing.T) {
-	client, store, cleanup := setupTest(t)
+	client, store, _, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, store)
 
@@ -223,7 +225,7 @@ func TestSimultaneousSubscriptions(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesFromCursor(t *testing.T) {
-	client, store, cleanup := setupTest(t)
+	client, store, _, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, store)
 
@@ -245,7 +247,7 @@ func TestSubscribeEnvelopesFromCursor(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesFromEmptyCursor(t *testing.T) {
-	client, store, cleanup := setupTest(t)
+	client, store, _, cleanup := setupTest(t)
 	defer cleanup()
 	insertInitialRows(t, store)
 
@@ -267,7 +269,7 @@ func TestSubscribeEnvelopesFromEmptyCursor(t *testing.T) {
 }
 
 func TestSubscribeEnvelopesInvalidRequest(t *testing.T) {
-	client, _, cleanup := setupTest(t)
+	client, _, _, cleanup := setupTest(t)
 	defer cleanup()
 
 	stream, err := client.SubscribeEnvelopes(

--- a/pkg/api/payer/clientManager_test.go
+++ b/pkg/api/payer/clientManager_test.go
@@ -20,9 +20,9 @@ func formatAddress(addr string) string {
 }
 
 func TestClientManager(t *testing.T) {
-	server1, _, cleanup1 := apiTestUtils.NewTestAPIServer(t)
+	server1, _, _, cleanup1 := apiTestUtils.NewTestAPIServer(t)
 	defer cleanup1()
-	server2, _, cleanup2 := apiTestUtils.NewTestAPIServer(t)
+	server2, _, _, cleanup2 := apiTestUtils.NewTestAPIServer(t)
 	defer cleanup2()
 
 	nodeRegistry := registry.NewFixedNodeRegistry([]registry.Node{

--- a/pkg/api/payer/publish_test.go
+++ b/pkg/api/payer/publish_test.go
@@ -106,7 +106,7 @@ func TestPublishIdentityUpdate(t *testing.T) {
 }
 
 func TestPublishToNodes(t *testing.T) {
-	originatorServer, _, originatorCleanup := apiTestUtils.NewTestAPIServer(t)
+	originatorServer, _, _, originatorCleanup := apiTestUtils.NewTestAPIServer(t)
 	defer originatorCleanup()
 
 	ctx := context.Background()

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -75,7 +75,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 }
 
 func TestQueryAllEnvelopes(t *testing.T) {
-	api, db, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, db, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, db)
 
@@ -91,7 +91,7 @@ func TestQueryAllEnvelopes(t *testing.T) {
 }
 
 func TestQueryPagedEnvelopes(t *testing.T) {
-	api, db, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, db, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, db)
 
@@ -107,7 +107,7 @@ func TestQueryPagedEnvelopes(t *testing.T) {
 }
 
 func TestQueryEnvelopesByOriginator(t *testing.T) {
-	api, db, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, db, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, db)
 
@@ -126,7 +126,7 @@ func TestQueryEnvelopesByOriginator(t *testing.T) {
 }
 
 func TestQueryEnvelopesByTopic(t *testing.T) {
-	api, store, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, store, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, store)
 
@@ -145,7 +145,7 @@ func TestQueryEnvelopesByTopic(t *testing.T) {
 }
 
 func TestQueryEnvelopesFromLastSeen(t *testing.T) {
-	api, db, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, db, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, db)
 
@@ -163,7 +163,7 @@ func TestQueryEnvelopesFromLastSeen(t *testing.T) {
 }
 
 func TestQueryTopicFromLastSeen(t *testing.T) {
-	api, store, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, store, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, store)
 
@@ -184,7 +184,7 @@ func TestQueryTopicFromLastSeen(t *testing.T) {
 }
 
 func TestQueryMultipleTopicsFromLastSeen(t *testing.T) {
-	api, store, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, store, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, store)
 
@@ -205,7 +205,7 @@ func TestQueryMultipleTopicsFromLastSeen(t *testing.T) {
 }
 
 func TestQueryMultipleOriginatorsFromLastSeen(t *testing.T) {
-	api, store, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, store, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, store)
 
@@ -226,7 +226,7 @@ func TestQueryMultipleOriginatorsFromLastSeen(t *testing.T) {
 }
 
 func TestQueryEnvelopesWithEmptyResult(t *testing.T) {
-	api, store, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, store, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	db_rows := setupQueryTest(t, store)
 
@@ -244,7 +244,7 @@ func TestQueryEnvelopesWithEmptyResult(t *testing.T) {
 }
 
 func TestInvalidQuery(t *testing.T) {
-	api, store, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	api, store, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
 	defer cleanup()
 	_ = setupQueryTest(t, store)
 


### PR DESCRIPTION
### TL;DR
Added key package validation to the message publishing flow tests and updated test infrastructure to pass mocks to the caller.

## Closes
https://github.com/xmtp/xmtpd/issues/360

### What changed?
- Added new test cases for key package validation success and failure scenarios
- Introduced `ApiServerMocks` structure to handle validation service mocking
- Updated test utility functions to return mock instances
- Added validation service expectations in test cases

### How to test?
1. Run the test suite with `go test ./pkg/api/message/...`
2. Verify key package validation tests pass
3. Confirm both success and failure scenarios are properly handled
4. Check that mock expectations are met during test execution

### Why make this change?
To ensure key packages are properly validated before being published to the network, preventing invalid or malformed key packages from entering the system. This adds an important security layer to the message publishing flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test coverage for key package validation in publishing process
	- Updated test setup functions to include additional mock server functionality
	- Improved test utility functions to return more comprehensive mock objects

- **Refactor**
	- Introduced `ApiServerMocks` struct to group related mock dependencies
	- Modified function signatures in test utility methods to support more detailed mock returns

The changes primarily focus on improving test infrastructure and mock management across various API test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->