### PR TITLE
Log incoming metadata of JWT verified nodes

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -7,6 +7,5 @@ set -eu
 export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
 export XMTPD_SYNC_ENABLE=true
-export XMTPD_LOG_LEVEL=debug
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/dev/run
+++ b/dev/run
@@ -7,5 +7,6 @@ set -eu
 export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
 export XMTPD_SYNC_ENABLE=true
+export XMTPD_LOG_LEVEL=debug
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/pkg/authn/claims_test.go
+++ b/pkg/authn/claims_test.go
@@ -70,7 +70,7 @@ func TestClaimsVerifierNoVersion(t *testing.T) {
 
 			token, err := tokenFactory.CreateToken(uint32(VERIFIER_NODE_ID))
 			require.NoError(t, err)
-			verificationError := verifier.Verify(token.SignedString)
+			_, verificationError := verifier.Verify(token.SignedString)
 			if tt.wantErr {
 				require.Error(t, verificationError)
 			} else {
@@ -119,7 +119,7 @@ func TestClaimsVerifier(t *testing.T) {
 
 			token, err := tokenFactory.CreateToken(uint32(VERIFIER_NODE_ID))
 			require.NoError(t, err)
-			verificationError := verifier.Verify(token.SignedString)
+			_, verificationError := verifier.Verify(token.SignedString)
 			if tt.wantErr {
 				require.Error(t, verificationError)
 			} else {

--- a/pkg/authn/interface.go
+++ b/pkg/authn/interface.go
@@ -1,5 +1,5 @@
 package authn
 
 type JWTVerifier interface {
-	Verify(tokenString string) error
+	Verify(tokenString string) (uint32, error)
 }

--- a/pkg/authn/verifier.go
+++ b/pkg/authn/verifier.go
@@ -27,7 +27,7 @@ func NewRegistryVerifier(registry registry.NodeRegistry, myNodeID uint32) *Regis
 	return &RegistryVerifier{registry: registry, myNodeID: myNodeID}
 }
 
-func (v *RegistryVerifier) Verify(tokenString string) error {
+func (v *RegistryVerifier) Verify(tokenString string) (uint32, error) {
 	var token *jwt.Token
 	var err error
 
@@ -36,21 +36,21 @@ func (v *RegistryVerifier) Verify(tokenString string) error {
 		&XmtpdClaims{},
 		v.getMatchingPublicKey,
 	); err != nil {
-		return err
+		return 0, err
 	}
 	if err = v.validateAudience(token); err != nil {
-		return err
+		return 0, err
 	}
 
 	if err = validateExpiry(token); err != nil {
-		return err
+		return 0, err
 	}
 
 	if err = v.validateClaims(token); err != nil {
-		return err
+		return 0, err
 	}
 
-	return nil
+	return getSubjectNodeId(token)
 }
 
 func (v *RegistryVerifier) getMatchingPublicKey(token *jwt.Token) (interface{}, error) {

--- a/pkg/authn/verifier_test.go
+++ b/pkg/authn/verifier_test.go
@@ -65,14 +65,14 @@ func TestVerifier(t *testing.T) {
 	token, err := tokenFactory.CreateToken(uint32(VERIFIER_NODE_ID))
 	require.NoError(t, err)
 	// This should verify correctly
-	verificationError := verifier.Verify(token.SignedString)
+	_, verificationError := verifier.Verify(token.SignedString)
 	require.NoError(t, verificationError)
 
 	// Create a token targeting a different node as the audience
 	tokenForWrongNode, err := tokenFactory.CreateToken(uint32(300))
 	require.NoError(t, err)
 	// This should not verify correctly
-	verificationError = verifier.Verify(tokenForWrongNode.SignedString)
+	_, verificationError = verifier.Verify(tokenForWrongNode.SignedString)
 	require.Error(t, verificationError)
 }
 
@@ -90,7 +90,7 @@ func TestWrongAudience(t *testing.T) {
 	tokenForWrongNode, err := tokenFactory.CreateToken(uint32(300))
 	require.NoError(t, err)
 	// This should not verify correctly
-	verificationError := verifier.Verify(tokenForWrongNode.SignedString)
+	_, verificationError := verifier.Verify(tokenForWrongNode.SignedString)
 	require.Error(t, verificationError)
 }
 
@@ -105,7 +105,7 @@ func TestUnknownNode(t *testing.T) {
 	token, err := tokenFactory.CreateToken(uint32(VERIFIER_NODE_ID))
 	require.NoError(t, err)
 
-	verificationError := verifier.Verify(token.SignedString)
+	_, verificationError := verifier.Verify(token.SignedString)
 	require.Error(t, verificationError)
 }
 
@@ -125,7 +125,7 @@ func TestWrongPublicKey(t *testing.T) {
 	token, err := tokenFactory.CreateToken(uint32(VERIFIER_NODE_ID))
 	require.NoError(t, err)
 
-	verificationError := verifier.Verify(token.SignedString)
+	_, verificationError := verifier.Verify(token.SignedString)
 	require.Error(t, verificationError)
 }
 
@@ -147,7 +147,7 @@ func TestExpiredToken(t *testing.T) {
 		time.Now().Add(-time.Hour),
 	)
 
-	verificationError := verifier.Verify(signedString)
+	_, verificationError := verifier.Verify(signedString)
 	require.Error(t, verificationError)
 }
 
@@ -169,7 +169,7 @@ func TestTokenDurationTooLong(t *testing.T) {
 		time.Now().Add(5*time.Hour),
 	)
 
-	verificationError := verifier.Verify(signedString)
+	_, verificationError := verifier.Verify(signedString)
 	require.Error(t, verificationError)
 }
 
@@ -192,7 +192,7 @@ func TestTokenClockSkew(t *testing.T) {
 		time.Now().Add(1*time.Hour),
 	)
 
-	verificationError := verifier.Verify(validToken)
+	_, verificationError := verifier.Verify(validToken)
 	require.NoError(t, verificationError)
 
 	invalidToken := buildJwt(
@@ -204,6 +204,6 @@ func TestTokenClockSkew(t *testing.T) {
 		time.Now().Add(1*time.Hour),
 	)
 
-	verificationError = verifier.Verify(invalidToken)
+	_, verificationError = verifier.Verify(invalidToken)
 	require.Error(t, verificationError)
 }

--- a/pkg/mocks/authn/mock_JWTVerifier.go
+++ b/pkg/mocks/authn/mock_JWTVerifier.go
@@ -18,7 +18,7 @@ func (_m *MockJWTVerifier) EXPECT() *MockJWTVerifier_Expecter {
 }
 
 // Verify provides a mock function with given fields: tokenString
-func (_m *MockJWTVerifier) Verify(tokenString string) error {
+func (_m *MockJWTVerifier) Verify(tokenString string) (uint32, error) {
 	ret := _m.Called(tokenString)
 
 	if len(ret) == 0 {
@@ -32,7 +32,7 @@ func (_m *MockJWTVerifier) Verify(tokenString string) error {
 		r0 = ret.Error(0)
 	}
 
-	return r0
+	return 0, r0
 }
 
 // MockJWTVerifier_Verify_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Verify'


### PR DESCRIPTION
We want to see what nodes are connected to us, so we can reason about the distributed state of the system.

We only collect metadata for nodes, not clients, to preserve their anonymity. IPs in general are considered personally identifiable information, so we do not want to collect those.

Fixes #391 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JWT verification to return node ID alongside error status
	- Added logging of incoming client address and DNS name during authentication

- **Bug Fixes**
	- Improved token verification process with more detailed error handling

- **Refactor**
	- Updated authentication-related method signatures to provide more context during verification
	- Modified mock and test implementations to support new verification approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->