### PR TITLE
Use homebrew for linter

### DIFF
--- a/dev/up
+++ b/dev/up
@@ -3,7 +3,7 @@ set -e
 
 if ! which forge &>/dev/null; then echo "ERROR: Missing foundry binaries. Run 'curl -L https://foundry.paradigm.xyz | bash' and follow the instructions" && exit 1; fi
 if ! which migrate &>/dev/null; then go install github.com/golang-migrate/migrate/v4/cmd/migrate; fi
-if ! which golangci-lint &>/dev/null; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.56.0; fi
+if ! which golangci-lint &>/dev/null; then brew install golangci-lint; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
 if ! which mockery &>/dev/null; then go install github.com/vektra/mockery/v2; fi
 if ! which sqlc &> /dev/null; then go install github.com/sqlc-dev/sqlc/cmd/sqlc; fi


### PR DESCRIPTION
Following the [official docs](https://golangci-lint.run/welcome/install/), it seems that `homebrew` is the best way to install the linter.

We do not pin the version in the CI anyway