### PR TITLE
Sensible DB wait timeout

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -24,7 +24,7 @@ type DbOptions struct {
 	ReadTimeout            time.Duration `long:"read-timeout"             env:"XMTPD_DB_READ_TIMEOUT"             description:"Timeout for reading from the database"          default:"10s"`
 	WriteTimeout           time.Duration `long:"write-timeout"            env:"XMTPD_DB_WRITE_TIMEOUT"            description:"Timeout for writing to the database"            default:"10s"`
 	MaxOpenConns           int           `long:"max-open-conns"           env:"XMTPD_DB_MAX_OPEN_CONNS"           description:"Maximum number of open connections"             default:"80"`
-	WaitForDB              time.Duration `long:"wait-for"                 env:"XMTPD_DB_WAIT_FOR"                 description:"wait for DB on start, up to specified duration"`
+	WaitForDB              time.Duration `long:"wait-for"                 env:"XMTPD_DB_WAIT_FOR"                 description:"wait for DB on start, up to specified duration" default:"30s"`
 }
 
 type IndexerOptions struct {


### PR DESCRIPTION
In #405 I fixed the DB timeout. But not all environments override the variable.

In some cases this means that the timeout is now `0` and fails immediately. 0 does not mean "context with infinite timeout" it means "context that is already timed out"

Set it to 30s which sounds reasonable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Added a default 30-second wait time for database connection initialization when no specific duration is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->