### PR TITLE
Fix the nonce starting point debug log

### DIFF
--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -65,11 +66,14 @@ func NewBlockchainPublisher(
 
 	// The nonce is the next ID to be used, not the current highest
 	// The nonce member variable represents the last recenty used, so it is pending-1
-	if nonce > 0 {
-		nonce--
-	}
+	// If the nonce is 0, it will underflow to 18446744073709551615, which at +1 generates the correct next nonce of 0
+	nonce--
 
-	logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", nonce))
+	if nonce == math.MaxUint64 {
+		logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", -1))
+	} else {
+		logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", nonce))
+	}
 
 	return &BlockchainPublisher{
 		signer: signer,

--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -64,16 +63,12 @@ func NewBlockchainPublisher(
 		return nil, err
 	}
 
+	logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", nonce))
+
 	// The nonce is the next ID to be used, not the current highest
 	// The nonce member variable represents the last recenty used, so it is pending-1
 	// If the nonce is 0, it will underflow to 18446744073709551615, which at +1 generates the correct next nonce of 0
 	nonce--
-
-	if nonce == math.MaxUint64 {
-		logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", -1))
-	} else {
-		logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", nonce))
-	}
 
 	return &BlockchainPublisher{
 		signer: signer,

--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -65,7 +65,9 @@ func NewBlockchainPublisher(
 
 	// The nonce is the next ID to be used, not the current highest
 	// The nonce member variable represents the last recenty used, so it is pending-1
-	nonce = max(nonce-1, uint64(0))
+	if nonce > 0 {
+		nonce--
+	}
 
 	logger.Info(fmt.Sprintf("Starting server with blockchain nonce: %d", nonce))
 


### PR DESCRIPTION
I saw this log
```
$ docker logs libxmtp-repnode-1
2025-01-13T19:00:47.094Z        INFO    replication     Version: v0.1.3-38-g0a896ad
2025-01-13T19:00:47.190Z        INFO    replication     Starting server with blockchain nonce: 18446744073709551615
2025-01-13T19:00:47.192Z        INFO    replication     Registrant identified   {"nodeId": 100}
```

and realized that we are printing the nonce is a bit of a confusing fashion.

The issue with the code lies in attempting to decrement a uint64 value (nonce) and ensuring it doesn't underflow. Since uint64 is an unsigned integer, it cannot hold negative values. If nonce is already 0, decrementing it would result in an underflow, wrapping around to its maximum value (18446744073709551615).

The resulting behavior is exactly the same, but the log no longer looks like an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified nonce handling logic in blockchain publisher
	- Updated logging for server startup with blockchain nonce
	- Refined nonce initialization process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->