### PR TITLE
Enable indexer on local node

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -7,5 +7,6 @@ set -eu
 export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
 export XMTPD_SYNC_ENABLE=true
+export XMTPD_INDEXER_ENABLE=true
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/dev/run-2
+++ b/dev/run-2
@@ -11,5 +11,6 @@ export XMTPD_DB_WRITER_CONNECTION_STRING="postgres://postgres:xmtp@localhost:876
 export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
 export XMTPD_SYNC_ENABLE=true
+export XMTPD_INDEXER_ENABLE=true
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go -p 5051 "$@"


### PR DESCRIPTION
I guess since November we weren't actually running the indexer service on localhost?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled XMTPD indexer functionality across development scripts by adding `XMTPD_INDEXER_ENABLE=true` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->