### PR TITLE
Read your own group writes

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -481,7 +481,7 @@ func (s *Service) waitForGatewayPublish(
 				zap.Int64("envelope_id", stagedEnv.ID),
 				zap.Int64("wait_time", time.Since(startTime).Milliseconds()),
 			)
-			break
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}


### PR DESCRIPTION
This does not solve all possible cases of read-your-own-writes, but it makes things a little bit easier.

This guarantees that when a node confirms a payer write, future reads will return the data.

This does not guarantee:
- the same for blockchain writes
- a different node will have the data

I added the debug log so we can see how long the delay is. In general, it is usually one busy-wait cycle. But could be more on busy systems. It is rarely 0 cycles.

Relates to #358 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added tracking of last processed envelope ID in publish worker
	- Implemented wait mechanism for gateway publish completion
	- Enhanced server test infrastructure with dynamic port allocation

- **Tests**
	- Added new test to verify server's ability to read its own writes immediately after publishing

- **Chores**
	- Improved test configuration by dynamically assigning ports and populating mock configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->