### PR TITLE
Fix incorrect OpenZeppelin import paths

### DIFF
--- a/contracts/src/GroupMessages.sol
+++ b/contracts/src/GroupMessages.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "@openzeppelin-contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin-contracts-upgradeable/utils/PausableUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /// @title XMTP Group Messages Contract
 contract GroupMessages is Initializable, AccessControlUpgradeable, UUPSUpgradeable, PausableUpgradeable {
     /// @notice Emitted when a message is sent.
     /// @param groupId The group ID.
-    /// @param message The message in bytes. Contains the full mls group message payload.
+    /// @param message The message in bytes. Contains the full MLS group message payload.
     /// @param sequenceId The unique sequence ID of the message.
     event MessageSent(bytes32 groupId, bytes message, uint64 sequenceId);
 

--- a/contracts/src/IdentityUpdates.sol
+++ b/contracts/src/IdentityUpdates.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "@openzeppelin-contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin-contracts-upgradeable/utils/PausableUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /// @title XMTP Identity Updates Contract
 contract IdentityUpdates is Initializable, AccessControlUpgradeable, UUPSUpgradeable, PausableUpgradeable {

--- a/contracts/test/GroupMessage.t.sol
+++ b/contracts/test/GroupMessage.t.sol
@@ -7,8 +7,8 @@ import {Utils} from "test/utils/Utils.sol";
 import {GroupMessages} from "src/GroupMessages.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
-import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import {PausableUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 contract GroupMessagesTest is Test, GroupMessages, Utils {
     GroupMessages groupMessagesImpl;

--- a/contracts/test/IdentityUpdates.t.sol
+++ b/contracts/test/IdentityUpdates.t.sol
@@ -7,8 +7,8 @@ import {Utils} from "test/utils/Utils.sol";
 import {IdentityUpdates} from "src/IdentityUpdates.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
-import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import {PausableUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 contract IdentityUpdatesTest is Test, IdentityUpdates, Utils {
     IdentityUpdates identityUpdatesImpl;

--- a/contracts/test/utils/Utils.sol
+++ b/contracts/test/utils/Utils.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
-import {PausableUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 contract Utils {
     bytes32 public constant EIP1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated import paths for OpenZeppelin contracts in `GroupMessages` and `IdentityUpdates` contracts.
  - Corrected capitalization in documentation comment for `MessageSent` event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->