### PR TITLE
Auto-enable metadata API

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -9,6 +9,5 @@ export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
 export XMTPD_SYNC_ENABLE=true
 export XMTPD_INDEXER_ENABLE=true
-export XMTPD_METADATA_ENABLE=true
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -51,10 +51,6 @@ type SyncOptions struct {
 	Enable bool `long:"enable" env:"XMTPD_SYNC_ENABLE" description:"Enable the sync server"`
 }
 
-type MetadataOptions struct {
-	Enable bool `long:"enable" env:"XMTPD_METADATA_ENABLE" description:"Enable the metadata API"`
-}
-
 type MlsValidationOptions struct {
 	GrpcAddress string `long:"grpc-address" env:"XMTPD_MLS_VALIDATION_GRPC_ADDRESS" description:"Address of the MLS validation service"`
 }
@@ -84,7 +80,6 @@ type ServerOptions struct {
 	DB            DbOptions            `group:"Database Options"       namespace:"db"`
 	Log           LogOptions           `group:"Log Options"            namespace:"log"`
 	Indexer       IndexerOptions       `group:"Indexer Options"        namespace:"indexer"`
-	Metadata      MetadataOptions      `group:"Metadata Options"       namespace:"metadata"`
 	Metrics       MetricsOptions       `group:"Metrics Options"        namespace:"metrics"`
 	MlsValidation MlsValidationOptions `group:"MLS Validation Options" namespace:"mls-validation"`
 	Payer         PayerOptions         `group:"Payer Options"          namespace:"payer"`

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -59,12 +59,6 @@ func ValidateServerOptions(options ServerOptions) error {
 		}
 	}
 
-	if options.Metadata.Enable {
-		if options.DB.WriterConnectionString == "" {
-			missingSet["--DB.WriterConnectionString"] = struct{}{}
-		}
-	}
-
 	if options.Indexer.Enable {
 		if options.DB.WriterConnectionString == "" {
 			missingSet["--DB.WriterConnectionString"] = struct{}{}


### PR DESCRIPTION
Remove the option to start the metadata API.

Automatically start it if the replication API is enabled.