### PR TITLE
ci(solidity): trigger only on path

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -4,10 +4,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "contracts/**"
+      - ".github/workflows/solidity.yml"
   pull_request:
     paths:
       - "contracts/**"
       - ".github/workflows/solidity.yml"
+
+permissions:
+  contents: read
+  security-events: write
 
 concurrency:
   group: ci-solidity-${{ github.ref }}
@@ -102,6 +109,7 @@ jobs:
   slither:
     needs: init
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Restore cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
Solidity CI was triggering when PR are pushed to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow configuration for Solidity to trigger based on specific path changes instead of branch-based triggering.
  - Maintained existing workflow jobs and steps without modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->