### PR TITLE
Don't use pointer to interface

### DIFF
--- a/pkg/api/payer/publish_test.go
+++ b/pkg/api/payer/publish_test.go
@@ -75,17 +75,15 @@ func buildPayerService(
 	mockMessagePublisher := blockchainMocks.NewMockIBlockchainPublisher(t)
 
 	metaMocks := metadataMocks.NewMockMetadataApiClient(t)
-	metadataConstructor := &FixedMetadataApiClientConstructor{
-		mockClient: metaMocks,
-	}
-	var interf payer.MetadataApiClientConstructor = metadataConstructor
 	payerService, err := payer.NewPayerApiService(
 		ctx,
 		log,
 		mockRegistry,
 		privKey,
 		mockMessagePublisher,
-		&interf,
+		&FixedMetadataApiClientConstructor{
+			mockClient: metaMocks,
+		},
 	)
 	require.NoError(t, err)
 

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -41,14 +41,14 @@ func NewPayerApiService(
 	registry registry.NodeRegistry,
 	payerPrivateKey *ecdsa.PrivateKey,
 	blockchainPublisher blockchain.IBlockchainPublisher,
-	metadataApiClient *MetadataApiClientConstructor,
+	metadataApiClient MetadataApiClientConstructor,
 ) (*Service, error) {
 	var metadataClient MetadataApiClientConstructor
 	clientManager := NewClientManager(log, registry)
 	if metadataApiClient == nil {
 		metadataClient = &DefaultMetadataApiClientConstructor{clientManager: clientManager}
 	} else {
-		metadataClient = *metadataApiClient
+		metadataClient = metadataApiClient
 	}
 	return &Service{
 		ctx:                 ctx,


### PR DESCRIPTION
Minor fix. Interfaces can be nil, so there is no need for the extra pointer to interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the backend service initialization by streamlining how internal parameters are handled, enhancing maintainability while keeping the same functionality.
	- Simplified the instantiation of the service by removing an intermediate variable, resulting in cleaner code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->