### PR TITLE
Configure indexer reorg check interval

### DIFF
--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -228,17 +228,21 @@ func indexLogs(
 	blockTracker IBlockTracker,
 	reorgHandler ChainReorgHandler,
 ) {
+	// L3 Orbit works with Arbitrum Elastic Block Time, which under maximum load produces a block every 0.25s.
+	// With a maximum throughput of 7M gas per second and a median transaction size of roughly 200k gas,
+	// checking for a reorg every 60 blocks (15 seconds) means that, theoretically, a maximum of 495 messages could be affected.
+	const reorgCheckInterval = 60
+
 	var (
-		errStorage         storer.LogStorageError
-		storedBlockNumber  uint64
-		storedBlockHash    []byte
-		lastBlockSeen      uint64
-		reorgCheckInterval uint64 = 10 // TODO(borja): Adapt based on blocks per batch
-		reorgCheckAt       uint64
-		reorgDetectedAt    uint64
-		reorgBeginsAt      uint64
-		reorgFinishesAt    uint64
-		reorgInProgress    bool
+		errStorage        storer.LogStorageError
+		storedBlockNumber uint64
+		storedBlockHash   []byte
+		lastBlockSeen     uint64
+		reorgCheckAt      uint64
+		reorgDetectedAt   uint64
+		reorgBeginsAt     uint64
+		reorgFinishesAt   uint64
+		reorgInProgress   bool
 	)
 
 	// We don't need to listen for the ctx.Done() here, since the eventChannel will be closed when the parent context is canceled

--- a/pkg/indexer/reorgHandler.go
+++ b/pkg/indexer/reorgHandler.go
@@ -27,8 +27,11 @@ var (
 	ErrGetBlock      = errors.New("failed to get block")
 )
 
-// TODO(borja): Make this configurable?
-const BLOCK_RANGE_SIZE uint64 = 1000
+// The indexer performs a reorg check every 60 blocks.
+// Setting BLOCK_RANGE_SIZE to 600 (10 cycles of 60 blocks)
+// allows us to retrieve a single page of blocks from the database,
+// which will likely contain the reorg point.
+const BLOCK_RANGE_SIZE uint64 = 600
 
 func NewChainReorgHandler(
 	ctx context.Context,
@@ -42,7 +45,8 @@ func NewChainReorgHandler(
 	}
 }
 
-// TODO(borja): When reorg range has been calculated, alert clients (TBD)
+// TODO(borja): When reorg range has been calculated, alert clients.
+// Tracked in https://github.com/xmtp/xmtpd/issues/437
 func (r *ReorgHandler) FindReorgPoint(detectedAt uint64) (uint64, []byte, error) {
 	startBlock, endBlock := blockRange(detectedAt)
 

--- a/pkg/indexer/reorgHandler_test.go
+++ b/pkg/indexer/reorgHandler_test.go
@@ -15,9 +15,9 @@ func Test_blockRange(t *testing.T) {
 	}{
 		{
 			name:           "block range with subtraction",
-			from:           1001,
+			from:           601,
 			wantStartBlock: 1,
-			wantEndBlock:   1001,
+			wantEndBlock:   601,
 		},
 		{
 			name:           "block range without subtraction",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Adjusted the system’s blockchain reorganization checks for improved reliability and performance by updating the reorg check interval.
  - Updated the block range configuration to streamline data retrieval during reorganization events, allowing checks every 60 blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->