### PR TITLE
make indexer handle null block hashes

### DIFF
--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -300,7 +300,8 @@ func indexLogs(
 				zap.Uint64("blockNumber", reorgCheckAt),
 			)
 
-			if !bytes.Equal(storedBlockHash, onchainBlock.Hash().Bytes()) {
+			if storedBlockHash != nil &&
+				!bytes.Equal(storedBlockHash, onchainBlock.Hash().Bytes()) {
 				logger.Warn("blockchain reorg detected",
 					zap.Uint64("storedBlockNumber", storedBlockNumber),
 					zap.String("storedBlockHash", hex.EncodeToString(storedBlockHash)),


### PR DESCRIPTION
Before the future release 0.2.0 the block_hash is not stored in database. In future releases we're using the block_hash to check for reorgs.

There's a rare corner case where the indexer tries to retrieve a block hash that happens to be null, in that case we should skip it and check for reorgs later in the chain.

In the case when a reorg happens later in the chain, and the reorg handler algorithm determines the reorg happened in a range we don't have any data about, then the indexer should simply start indexing from 0, as it's the safest option.