### PR TITLE
handle reorg channel closing

### DIFF
--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -135,7 +135,11 @@ func (r *RpcLogStreamer) watchContract(watcher contractConfig) {
 		case <-r.ctx.Done():
 			logger.Debug("Stopping watcher")
 			return
-		case reorgBlock := <-watcher.reorgChannel:
+		case reorgBlock, open := <-watcher.reorgChannel:
+			if !open {
+				logger.Debug("Reorg channel closed")
+				return
+			}
 			fromBlock = reorgBlock
 			logger.Info(
 				"Blockchain reorg detected, resuming from block",


### PR DESCRIPTION
Every time a channel is closed it's signaled, which turns into triggering the reorg handling logic with reorgBlock = 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of blockchain event processing by properly detecting when a background event stream stops unexpectedly, ensuring the system halts processing to maintain stable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->