### PR TITLE
A bunch of improvements

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
@@ -137,7 +138,7 @@ func main() {
 			log.Fatal("initializing server", zap.Error(err))
 		}
 
-		s.WaitForShutdown()
+		s.WaitForShutdown(10 * time.Second)
 		doneC <- true
 	})
 	<-doneC

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -146,10 +146,14 @@ func (s *ApiServer) gracefulShutdown(timeout time.Duration) {
 	<-ctx.Done()
 }
 
-func (s *ApiServer) Close() {
+func (s *ApiServer) Close(timeout time.Duration) {
 	s.log.Debug("closing")
 	if s.grpcServer != nil {
-		s.gracefulShutdown(10 * time.Second)
+		if timeout != 0 {
+			s.gracefulShutdown(timeout)
+		} else {
+			s.grpcServer.Stop()
+		}
 	}
 	if s.grpcListener != nil {
 		if err := s.grpcListener.Close(); err != nil && !isErrUseOfClosedConnection(err) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/prometheus/client_golang/prometheus"
@@ -260,14 +261,14 @@ func (s *ReplicationServer) Addr() net.Addr {
 	return s.apiServer.Addr()
 }
 
-func (s *ReplicationServer) WaitForShutdown() {
+func (s *ReplicationServer) WaitForShutdown(timeout time.Duration) {
 	termChannel := make(chan os.Signal, 1)
 	signal.Notify(termChannel, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 	<-termChannel
-	s.Shutdown()
+	s.Shutdown(timeout)
 }
 
-func (s *ReplicationServer) Shutdown() {
+func (s *ReplicationServer) Shutdown(timeout time.Duration) {
 	if s.metrics != nil {
 		s.metrics.Close()
 	}
@@ -284,7 +285,7 @@ func (s *ReplicationServer) Shutdown() {
 		s.indx.Close()
 	}
 	if s.apiServer != nil {
-		s.apiServer.Close()
+		s.apiServer.Close(timeout)
 	}
 
 	s.cancel()

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -191,12 +191,14 @@ func (s *syncWorker) subscribeToNodeRegistration(
 				backoff = time.Second
 			}
 
-			conn, err := s.connectToNode(*node)
+			var conn *grpc.ClientConn
+			conn, err = s.connectToNode(*node)
 			if err != nil {
 				continue
 			}
 
-			stream, err := s.setupStream(registration.ctx, *node, conn)
+			var stream *originatorStream
+			stream, err = s.setupStream(registration.ctx, *node, conn)
 			if err != nil {
 				_ = conn.Close()
 				continue

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -164,7 +164,7 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks, fu
 
 	return svr, db, allMocks, func() {
 		cancel()
-		svr.Close()
+		svr.Close(0)
 		dbCleanup()
 	}
 }


### PR DESCRIPTION
Hard to break these apart as they are all kinda entangled.

1) We know that `TestReadOwnWritesGuarantee` occasionally fails (#478) but the output of that test is mangled with the output from the previous test.
The mangling is caused by unclean shutdown. As those resources get cleaned up, the output gets printed all over the place.
In tests, we don't need soft shutdown, so this PR introduces a hard shutdown to speed up tests.

2) The sync worker was leaking connections

3) Recv() is blocking and does not listen to ctx Done. A separate mechanism has to be introduced to handle shutdowns cleanly. This is the same pattern that we use in `nodeCursorTracker`

4) Create DBs with the name of the test in them. Makes SQL debugging easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Configurable timeout settings now enable a graceful shutdown process to ensure active operations complete reliably.
- **Refactor**
	- Enhanced shutdown logic with timeout parameters for improved control over server shutdown processes.
	- Optimized background processing with non-blocking error handling for improved responsiveness.
- **Tests**
	- Enhanced testing utilities with refined resource cleanup and dynamic naming to bolster test robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->