### PR TITLE
tie xmtpd to specific proto versions

### DIFF
--- a/dev/gen-protos
+++ b/dev/gen-protos
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 rm -rf pkg/proto/**/*.pb.go pkg/proto/**/*.pb.gw.go pkg/proto/**/*.swagger.json
-if ! buf generate https://github.com/xmtp/proto.git#subdir=proto,branch=main; then
+if ! buf generate https://github.com/xmtp/proto.git#subdir=proto,ref=08c80536d56e73c6f585d80e7cd2de3db6733c8b; then
     echo "Failed to generate protobuf definitions"
     exit 1
 fi


### PR DESCRIPTION
Currently we generate the protos based on the main branch. 
Instead of doing this, and to help with reproducible deterministic build each xmtpd tag should point to the latest supported tag in xmtp/proto.

Suggestion:
- While developing in main, point to ref=latest_supported_commit
- When publishing a release, point to tag=vLatest_supported_proto_tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Adjusted the process for generating critical application definitions by using a fixed version reference, ensuring a more stable and consistent underlying build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->