### PR TITLE
Allow DB override via hidden parameter

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -73,11 +73,15 @@ func main() {
 	tracing.GoPanicWrap(ctx, &wg, "main", func(ctx context.Context) {
 		var dbInstance *sql.DB
 		if options.Replication.Enable || options.Sync.Enable || options.Indexer.Enable {
+			namespace := options.DB.NameOverride
+			if namespace == "" {
+				namespace = utils.BuildNamespace(options)
+			}
 			dbInstance, err = db.NewNamespacedDB(
 				ctx,
 				logger,
 				options.DB.WriterConnectionString,
-				utils.BuildNamespace(options),
+				namespace,
 				options.DB.WaitForDB,
 				options.DB.ReadTimeout,
 			)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -25,6 +25,7 @@ type DbOptions struct {
 	WriteTimeout           time.Duration `long:"write-timeout"            env:"XMTPD_DB_WRITE_TIMEOUT"            description:"Timeout for writing to the database"            default:"10s"`
 	MaxOpenConns           int           `long:"max-open-conns"           env:"XMTPD_DB_MAX_OPEN_CONNS"           description:"Maximum number of open connections"             default:"80"`
 	WaitForDB              time.Duration `long:"wait-for"                 env:"XMTPD_DB_WAIT_FOR"                 description:"wait for DB on start, up to specified duration" default:"30s"`
+	NameOverride           string        `long:"name-override"            env:"XMTPD_DB_NAME_OVERRIDE"            description:"Override the automatically generated DB name"                 hidden:"true"`
 }
 
 type IndexerOptions struct {


### PR DESCRIPTION
This is required to upgrade testing to create a separate DB that is only being used by the test.

Will get backported into a 0.1.3 stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configuration option that allows you to override the default naming for your database setup, offering enhanced flexibility and customization of your database namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->