### PR TITLE
Upgrade tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Ignore Git files
+.git
+.gitignore
+.github
+
+# Ignore IDE/editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Ignore Go test executables and other compiled files
+*.test
+*.out
+*.exe
+*.o
+*.a
+*.so
+
+# Ignore build directories
+build/
+bin/
+
+# Ignore all test files
+**/*_test.go
+
+dev/
+!dev/docker
+
+contracts/
+!contracts/pkg
+
+doc/
+
+LICENSE
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,12 +24,6 @@ bin/
 # Ignore all test files
 **/*_test.go
 
-dev/
-!dev/docker
-
-contracts/
-!contracts/pkg
-
 doc/
 
 LICENSE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,12 @@ jobs:
           export GOPATH="${HOME}/go/"
           export PATH="${PATH}:${GOPATH}/bin"
           go test -v ./... -race
+      - name: Run Upgrade Tests
+        run: |
+          export GOPATH="${HOME}/go/"
+          export PATH="${PATH}:${GOPATH}/bin"
+          export ENABLE_UPGRADE_TESTS=1
+          go test github.com/xmtp/xmtpd/pkg/upgrade -v
       - uses: datadog/junit-upload-github-action@v1
         with:
           api-key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: "nightly-ac81a53d1d5823919ffbadd3c65f081927aa11f2"
       - run: contracts/dev/deploy-local
+      - run: dev/register-local-node
       - name: Run Tests
         run: |
           export GOPATH="${HOME}/go/"

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 # Build the final node binary
 ARG VERSION=unknown
-RUN go build -ldflags="-X 'main.Version=$VERSION'" -o bin/xmtpd cmd/replication/main.go
+RUN go build -ldflags="-X 'main.Version=$VERSION'"g -o bin/xmtpd cmd/replication/main.go
 
 # ACTUAL IMAGE -------------------------------------------------------
 

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -6,11 +6,16 @@ FROM golang:${GO_VERSION}-alpine AS builder
 RUN apk add --no-cache build-base
 
 WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
 COPY . .
 
 # Build the final node binary
 ARG VERSION=unknown
-RUN go build -ldflags="-X 'main.Version=$VERSION'"g -o bin/xmtpd cmd/replication/main.go
+RUN go build -ldflags="-X 'main.Version=$VERSION'" -o bin/xmtpd cmd/replication/main.go
 
 # ACTUAL IMAGE -------------------------------------------------------
 

--- a/dev/docker/Dockerfile-cli
+++ b/dev/docker/Dockerfile-cli
@@ -6,6 +6,11 @@ FROM golang:${GO_VERSION}-alpine AS builder
 RUN apk add --no-cache build-base
 
 WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
 COPY . .
 
 # Build the final node binary

--- a/dev/docker/build
+++ b/dev/docker/build
@@ -2,7 +2,7 @@
 set -e
 
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
-DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/xmtpd}"
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-ghcr.io/xmtp/xmtpd}"
 VERSION="$(git describe HEAD --tags --long)"
 
 docker buildx build \

--- a/dev/docker/build
+++ b/dev/docker/build
@@ -1,5 +1,20 @@
-#!/usr/bin/env sh
-set -e
+#!/bin/bash
+
+set -euo pipefail
+
+error() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+# Get the directory where the script is located
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+TOP_LEVEL_DIR=$(realpath "${SCRIPT_DIR}/../.." 2>/dev/null) || error "Failed to resolve top-level directory"
+
+[ -d "$TOP_LEVEL_DIR" ] || error "Top level directory not found: $TOP_LEVEL_DIR"
+
+cd "$TOP_LEVEL_DIR" || error "Failed to change to top level directory"
 
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
 DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-ghcr.io/xmtp/xmtpd}"

--- a/dev/docker/down
+++ b/dev/docker/down
@@ -3,4 +3,4 @@ set -e
 
 . dev/docker/env
 
-docker_compose down
+docker_compose down --remove-orphans --volumes

--- a/pkg/testutils/store.go
+++ b/pkg/testutils/store.go
@@ -20,7 +20,7 @@ const (
 	LocalTestDBDSNSuffix = "?sslmode=disable"
 )
 
-func getCallerName(depth int) string {
+func GetCallerName(depth int) string {
 	pc, _, _, ok := runtime.Caller(depth)
 	if !ok {
 		return "unknown"
@@ -46,7 +46,7 @@ func newCtlDB(t testing.TB) (*sql.DB, string, func()) {
 }
 
 func newInstanceDB(t testing.TB, ctx context.Context, ctlDB *sql.DB) (*sql.DB, string, func()) {
-	dbName := "test_" + getCallerName(3) + "_" + RandomStringLower(12)
+	dbName := "test_" + GetCallerName(3) + "_" + RandomStringLower(12)
 	t.Logf("creating database %s ...", dbName)
 	_, err := ctlDB.Exec("CREATE DATABASE " + dbName)
 	require.NoError(t, err)

--- a/pkg/upgrade/docker_utils_test.go
+++ b/pkg/upgrade/docker_utils_test.go
@@ -1,0 +1,236 @@
+package upgrade_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testFlag = "ENABLE_UPGRADE_TESTS"
+
+func skipIfNotEnabled() {
+	if _, isSet := os.LookupEnv(testFlag); !isSet {
+		fmt.Printf("Skipping upgrade test. %s is not set\n", testFlag)
+		os.Exit(0)
+	}
+}
+
+func getScriptPath(scriptName string) string {
+	_, filename, _, _ := runtime.Caller(0)
+	baseDir := filepath.Dir(filename)
+	return filepath.Join(baseDir, scriptName)
+}
+
+func loadEnvFromShell() (map[string]string, error) {
+	scriptPath := getScriptPath("./scripts/load_env.sh")
+	cmd := exec.Command(scriptPath)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error loading env via shell script: %v\nError: %s",
+			err,
+			errBuf.String(),
+		)
+	}
+
+	envMap := make(map[string]string)
+	scanner := bufio.NewScanner(&outBuf)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	return envMap, nil
+}
+
+func expandVars(vars map[string]string) {
+	vars["XMTPD_REPLICATION_ENABLE"] = "true"
+	vars["XMTPD_INDEXER_ENABLE"] = "true"
+
+	dbName := testutils.GetCallerName(3) + "_" + testutils.RandomStringLower(6)
+
+	vars["XMTPD_DB_NAME_OVERRIDE"] = dbName
+}
+
+func convertLocalhost(vars map[string]string) {
+	for varKey, varValue := range vars {
+		if strings.Contains(varValue, "localhost") {
+			vars[varKey] = strings.Replace(varValue, "localhost", "host.docker.internal", -1)
+		}
+	}
+}
+
+func dockerRmc(containerName string) error {
+	killCmd := exec.Command("docker", "rm", containerName)
+	return killCmd.Run()
+}
+
+func dockerKill(containerName string) error {
+	killCmd := exec.Command("docker", "kill", containerName)
+	return killCmd.Run()
+}
+
+func constructVariables(t *testing.T) map[string]string {
+	envVars, err := loadEnvFromShell()
+	require.NoError(t, err)
+	expandVars(envVars)
+	convertLocalhost(envVars)
+
+	return envVars
+}
+
+func streamDockerLogs(containerName string) (chan string, func(), error) {
+	logsCmd := exec.Command("docker", "logs", "-f", containerName)
+	stdoutPipe, err := logsCmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = logsCmd.Start()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	logChan := make(chan string)
+	go func() {
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			logChan <- scanner.Text()
+		}
+		close(logChan)
+	}()
+
+	cancelFunc := func() {
+		_ = logsCmd.Process.Kill()
+	}
+
+	return logChan, cancelFunc, nil
+}
+
+func runContainer(
+	t *testing.T,
+	containerName string,
+	imageName string,
+	envVars map[string]string,
+) {
+	var dockerEnvArgs []string
+	for key, value := range envVars {
+		dockerEnvArgs = append(dockerEnvArgs, "-e", fmt.Sprintf("%s=%s", key, value))
+	}
+
+	_ = dockerRmc(containerName)
+
+	dockerCmd := []string{"run", "-d"}
+	if runtime.GOOS == "linux" {
+		dockerCmd = append(dockerCmd, "--add-host=host.docker.internal:host-gateway")
+	}
+
+	dockerCmd = append(dockerCmd, dockerEnvArgs...)
+	dockerCmd = append(dockerCmd, "--name", containerName, imageName)
+
+	cmd := exec.Command("docker", dockerCmd...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	require.NoError(t, err, "Error: %s", errBuf.String())
+
+	defer func() {
+		_ = dockerKill(containerName)
+	}()
+
+	logChan, cancel, err := streamDockerLogs(containerName)
+	require.NoError(t, err, "Failed to start log streaming")
+	defer cancel()
+
+	timeout := time.After(5 * time.Second)
+
+	for {
+		select {
+		case line, ok := <-logChan:
+			if !ok {
+				t.Fatalf("Log stream closed before finding target log")
+			}
+			t.Log(line)
+			if strings.Contains(line, "replication.api\tserving grpc") {
+				t.Logf("Service started successfully")
+				return
+			}
+		case <-timeout:
+			t.Fatalf("Timeout: 'replication.api\tserving grpc' not found in logs within 5 seconds")
+		}
+	}
+}
+
+func buildDevImage() error {
+	scriptPath := getScriptPath("../../dev/docker/build")
+
+	// Set a 5-minute timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, scriptPath)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	// Run the command and check for errors
+	if err := cmd.Run(); err != nil {
+		// Handle timeout separately
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("build process timed out after 5 minutes")
+		} else {
+			return fmt.Errorf("build process failed: %s\n", errBuf.String())
+		}
+	}
+
+	return nil
+}
+
+func dockerPull(imageName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "pull", imageName)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("timeout exceeded while pulling image %s", imageName)
+	}
+
+	if err != nil {
+		return fmt.Errorf(
+			"error pulling image %s: %v\nError: %s",
+			imageName,
+			err,
+			errBuf.String(),
+		)
+	}
+
+	return nil
+}

--- a/pkg/upgrade/main_test.go
+++ b/pkg/upgrade/main_test.go
@@ -1,0 +1,47 @@
+package upgrade_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func setup() {
+	start := time.Now() // Start tracking time
+	fmt.Println("=== SETUP UpgradeTestSetup")
+	fmt.Println("    Setting up before all tests...")
+
+	// Measure time for building dev image
+	fmt.Println("    Building dev image... This may take a while.")
+	imageStart := time.Now()
+	err := buildDevImage()
+	if err != nil {
+		fmt.Printf("    Error building dev image: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("    ✅ Dev image built in %v\n", time.Since(imageStart))
+
+	// Measure time for pulling old images
+	fmt.Println("    Pulling old images...")
+	pullStart := time.Now()
+	for _, image := range upgradeToLatest {
+		err := dockerPull(image)
+		if err != nil {
+			fmt.Printf("    ❌ Error pulling image %s: %v\n", image, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("    ✅ All images pulled in %v\n", time.Since(pullStart))
+
+	// Print total setup time
+	fmt.Printf("=== SETUP COMPLETE (%v)\n", time.Since(start))
+}
+
+// TestMain runs once for the whole test suite
+func TestMain(m *testing.M) {
+	skipIfNotEnabled()
+	setup()
+	code := m.Run()
+	os.Exit(code)
+}

--- a/pkg/upgrade/main_test.go
+++ b/pkg/upgrade/main_test.go
@@ -13,17 +13,17 @@ func setup() {
 	fmt.Println("    Setting up before all tests...")
 
 	// Measure time for building dev image
-	fmt.Println("    Building dev image... This may take a while.")
+	fmt.Println("    ⧖ Building dev image... This may take a while.")
 	imageStart := time.Now()
 	err := buildDevImage()
 	if err != nil {
 		fmt.Printf("    Error building dev image: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Printf("    ✅ Dev image built in %v\n", time.Since(imageStart))
+	fmt.Printf("    ✔ Dev image built in %v\n", time.Since(imageStart))
 
 	// Measure time for pulling old images
-	fmt.Println("    Pulling old images...")
+	fmt.Println("    ⧖ Pulling old images...")
 	pullStart := time.Now()
 	for _, image := range upgradeToLatest {
 		err := dockerPull(image)
@@ -32,7 +32,7 @@ func setup() {
 			os.Exit(1)
 		}
 	}
-	fmt.Printf("    ✅ All images pulled in %v\n", time.Since(pullStart))
+	fmt.Printf("    ✔ All images pulled in %v\n", time.Since(pullStart))
 
 	// Print total setup time
 	fmt.Printf("=== SETUP COMPLETE (%v)\n", time.Since(start))

--- a/pkg/upgrade/scripts/load_env.sh
+++ b/pkg/upgrade/scripts/load_env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+# Get the directory where the script is located
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+# Navigate to the top-level directory
+TOP_LEVEL_DIR=$(realpath "$SCRIPT_DIR/../../..")
+
+cd $TOP_LEVEL_DIR
+
+. ./dev/local.env
+
+env | grep XMTPD

--- a/pkg/upgrade/scripts/load_env.sh
+++ b/pkg/upgrade/scripts/load_env.sh
@@ -1,15 +1,37 @@
 #!/bin/bash
 
-set -eu
+set -euo pipefail
+
+error() {
+  echo "Error: $1" >&2
+  exit 1
+}
 
 # Get the directory where the script is located
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
-# Navigate to the top-level directory
-TOP_LEVEL_DIR=$(realpath "$SCRIPT_DIR/../../..")
+TOP_LEVEL_DIR=$(realpath "${SCRIPT_DIR}/../../.." 2>/dev/null) || error "Failed to resolve top-level directory"
 
-cd $TOP_LEVEL_DIR
+[ -d "$TOP_LEVEL_DIR" ] || error "Top level directory not found: $TOP_LEVEL_DIR"
 
-. ./dev/local.env
+cd "$TOP_LEVEL_DIR" || error "Failed to change to top level directory"
 
-env | grep XMTPD
+ENV_FILE="./dev/local.env"
+[ -f "$ENV_FILE" ] || error "Environment file not found: $ENV_FILE"
+[ -r "$ENV_FILE" ] || error "Environment file not readable: $ENV_FILE"
+. "$ENV_FILE"
+
+# a subset of all of them
+REQUIRED_VARS=(
+  "XMTPD_SIGNER_PRIVATE_KEY"
+  "XMTPD_DB_WRITER_CONNECTION_STRING"
+  "XMTPD_CONTRACTS_RPC_URL"
+)
+
+for var in "${REQUIRED_VARS[@]}"; do
+  [ -n "${!var:-}" ] || error "Required environment variable not set: $var"
+done
+
+# Display and validate XMTPD variables
+XMTPD_VARS=$(env | grep XMTPD) || error "No XMTPD environment variables found"
+echo "$XMTPD_VARS"

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -85,17 +85,6 @@ func dockerKill(containerName string) error {
 	return killCmd.Run()
 }
 
-func dockerLogs(containerName string) (string, error) {
-	logsCmd := exec.Command("docker", "logs", containerName)
-	var outBuf bytes.Buffer
-	logsCmd.Stdout = &outBuf
-	err := logsCmd.Run()
-	if err != nil {
-		return "", err
-	}
-	return outBuf.String(), nil
-}
-
 func constructVariables(t *testing.T) map[string]string {
 	envVars, err := loadEnvFromShell()
 	require.NoError(t, err)
@@ -174,7 +163,7 @@ func runContainer(
 			if !ok {
 				t.Fatalf("Log stream closed before finding target log")
 			}
-			t.Logf(line)
+			t.Log(line)
 			if strings.Contains(line, "replication.api\tserving grpc") {
 				t.Logf("Service started successfully")
 				return

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/testutils"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,14 @@ import (
 	"testing"
 	"time"
 )
+
+const testFlag = "ENABLE_UPGRADE_TESTS"
+
+func skipIfNotEnabled(t *testing.T) {
+	if _, isSet := os.LookupEnv(testFlag); !isSet {
+		t.Skip("Skipping upgrade test")
+	}
+}
 
 func getScriptPath(scriptName string) string {
 	_, filename, _, _ := runtime.Caller(0)
@@ -176,7 +185,7 @@ func runContainer(
 }
 
 func TestUpgradeFrom014(t *testing.T) {
-
+	skipIfNotEnabled(t)
 	envVars := constructVariables(t)
 	t.Logf("Starting old container")
 	runContainer(t, "xmtpd_test_014", "ghcr.io/xmtp/xmtpd:0.1.4", envVars)

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1,0 +1,122 @@
+package upgrade_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func getScriptPath(scriptName string) string {
+	_, filename, _, _ := runtime.Caller(0)
+	baseDir := filepath.Dir(filename)
+	return filepath.Join(baseDir, scriptName)
+}
+
+func loadEnvFromShell() (map[string]string, error) {
+	scriptPath := getScriptPath("./scripts/load_env.sh")
+	cmd := exec.Command(scriptPath)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error loading env via shell script: %v\nError: %s",
+			err,
+			errBuf.String(),
+		)
+	}
+
+	envMap := make(map[string]string)
+	scanner := bufio.NewScanner(&outBuf)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	return envMap, nil
+}
+
+func expandVars(vars map[string]string) {
+	vars["XMTPD_REFLECTION_ENABLE"] = "true"
+	vars["XMTPD_PAYER_ENABLE"] = "true"
+	vars["XMTPD_REPLICATION_ENABLE"] = "true"
+	vars["XMTPD_SYNC_ENABLE"] = "true"
+	vars["XMTPD_INDEXER_ENABLE"] = "true"
+}
+
+func convertLocalhost(vars map[string]string) {
+	for varKey, varValue := range vars {
+		if strings.Contains(varValue, "localhost") {
+			vars[varKey] = strings.Replace(varValue, "localhost", "host.docker.internal", -1)
+		}
+	}
+}
+
+func TestLoadEnvAndPassToDocker(t *testing.T) {
+	envVars, err := loadEnvFromShell()
+	if err != nil {
+		t.Fatalf("Failed to load environment variables: %v", err)
+	}
+	expandVars(envVars)
+	convertLocalhost(envVars)
+
+	var dockerEnvArgs []string
+	for key, value := range envVars {
+		dockerEnvArgs = append(dockerEnvArgs, "-e", fmt.Sprintf("%s=%s", key, value))
+	}
+	containerName := "xmtpd_test_env"
+
+	dockerCmd := append([]string{"run"}, dockerEnvArgs...)
+	dockerCmd = append(dockerCmd, "--name", containerName, "ghcr.io/xmtp/xmtpd:0.1.3")
+
+	t.Logf("Running docker command: %v", dockerCmd)
+	cmd := exec.Command("docker", dockerCmd...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf(
+			"Docker run failed: %v\nOutput: %s\nError: %s",
+			err,
+			outBuf.String(),
+			errBuf.String(),
+		)
+	}
+
+	// Wait for 5 seconds
+	time.Sleep(5 * time.Second)
+
+	// Collect logs
+	logsCmd := exec.Command("docker", "logs", containerName)
+	var logsBuf bytes.Buffer
+	logsCmd.Stdout = &logsBuf
+	logsCmd.Stderr = &errBuf
+
+	err = logsCmd.Run()
+	if err != nil {
+		t.Fatalf("Failed to collect logs: %v\nError: %s", err, errBuf.String())
+	}
+
+	// Kill the container
+	killCmd := exec.Command("docker", "kill", containerName)
+	err = killCmd.Run()
+	if err != nil {
+		t.Fatalf("Failed to kill Docker container: %v", err)
+	}
+
+	t.Logf("Logs:\n%s", logsBuf.String())
+
+}

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1,217 +1,25 @@
 package upgrade_test
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/xmtp/xmtpd/pkg/testutils"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
-	"time"
 )
 
-const testFlag = "ENABLE_UPGRADE_TESTS"
-
-func skipIfNotEnabled() {
-	if _, isSet := os.LookupEnv(testFlag); !isSet {
-		fmt.Printf("Skipping upgrade test. %s is not set\n", testFlag)
-		os.Exit(0)
-	}
+var upgradeToLatest = map[string]string{
+	"0.1.4": "ghcr.io/xmtp/xmtpd:0.1.4",
 }
 
-func getScriptPath(scriptName string) string {
-	_, filename, _, _ := runtime.Caller(0)
-	baseDir := filepath.Dir(filename)
-	return filepath.Join(baseDir, scriptName)
-}
+func TestUpgradeToLatest(t *testing.T) {
+	for version, image := range upgradeToLatest {
+		t.Run(version, func(t *testing.T) {
 
-func loadEnvFromShell() (map[string]string, error) {
-	scriptPath := getScriptPath("./scripts/load_env.sh")
-	cmd := exec.Command(scriptPath)
-	var outBuf, errBuf bytes.Buffer
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
+			envVars := constructVariables(t)
+			t.Logf("Starting old container")
+			runContainer(t, fmt.Sprintf("xmtpd_test_%s", version), image, envVars)
 
-	err := cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error loading env via shell script: %v\nError: %s",
-			err,
-			errBuf.String(),
-		)
+			t.Logf("Starting new container")
+			runContainer(t, "xmtpd_test_dev", "ghcr.io/xmtp/xmtpd:dev", envVars)
+		})
 	}
 
-	envMap := make(map[string]string)
-	scanner := bufio.NewScanner(&outBuf)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			envMap[parts[0]] = parts[1]
-		}
-	}
-	return envMap, nil
-}
-
-func expandVars(vars map[string]string) {
-	vars["XMTPD_REPLICATION_ENABLE"] = "true"
-	vars["XMTPD_INDEXER_ENABLE"] = "true"
-
-	dbName := testutils.GetCallerName(3) + "_" + testutils.RandomStringLower(6)
-
-	vars["XMTPD_DB_NAME_OVERRIDE"] = dbName
-}
-
-func convertLocalhost(vars map[string]string) {
-	for varKey, varValue := range vars {
-		if strings.Contains(varValue, "localhost") {
-			vars[varKey] = strings.Replace(varValue, "localhost", "host.docker.internal", -1)
-		}
-	}
-}
-
-func dockerRmc(containerName string) error {
-	killCmd := exec.Command("docker", "rm", containerName)
-	return killCmd.Run()
-}
-
-func dockerKill(containerName string) error {
-	killCmd := exec.Command("docker", "kill", containerName)
-	return killCmd.Run()
-}
-
-func constructVariables(t *testing.T) map[string]string {
-	envVars, err := loadEnvFromShell()
-	require.NoError(t, err)
-	expandVars(envVars)
-	convertLocalhost(envVars)
-
-	return envVars
-}
-
-func streamDockerLogs(containerName string) (chan string, func(), error) {
-	logsCmd := exec.Command("docker", "logs", "-f", containerName)
-	stdoutPipe, err := logsCmd.StdoutPipe()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	err = logsCmd.Start()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logChan := make(chan string)
-	go func() {
-		scanner := bufio.NewScanner(stdoutPipe)
-		for scanner.Scan() {
-			logChan <- scanner.Text()
-		}
-		close(logChan)
-	}()
-
-	cancelFunc := func() {
-		_ = logsCmd.Process.Kill()
-	}
-
-	return logChan, cancelFunc, nil
-}
-
-func runContainer(
-	t *testing.T,
-	containerName string,
-	imageName string,
-	envVars map[string]string,
-) {
-	var dockerEnvArgs []string
-	for key, value := range envVars {
-		dockerEnvArgs = append(dockerEnvArgs, "-e", fmt.Sprintf("%s=%s", key, value))
-	}
-
-	_ = dockerRmc(containerName)
-
-	dockerCmd := []string{"run", "-d"}
-	if runtime.GOOS == "linux" {
-		dockerCmd = append(dockerCmd, "--add-host=host.docker.internal:host-gateway")
-	}
-
-	dockerCmd = append(dockerCmd, dockerEnvArgs...)
-	dockerCmd = append(dockerCmd, "--name", containerName, imageName)
-
-	cmd := exec.Command("docker", dockerCmd...)
-
-	var outBuf, errBuf bytes.Buffer
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
-
-	err := cmd.Run()
-	require.NoError(t, err, "Error: %s", errBuf.String())
-
-	defer func() {
-		_ = dockerKill(containerName)
-	}()
-
-	logChan, cancel, err := streamDockerLogs(containerName)
-	require.NoError(t, err, "Failed to start log streaming")
-	defer cancel()
-
-	timeout := time.After(5 * time.Second)
-
-	for {
-		select {
-		case line, ok := <-logChan:
-			if !ok {
-				t.Fatalf("Log stream closed before finding target log")
-			}
-			t.Log(line)
-			if strings.Contains(line, "replication.api\tserving grpc") {
-				t.Logf("Service started successfully")
-				return
-			}
-		case <-timeout:
-			t.Fatalf("Timeout: 'replication.api\tserving grpc' not found in logs within 5 seconds")
-		}
-	}
-}
-
-func buildDevImage() {
-	scriptPath := getScriptPath("../../dev/docker/build")
-	cmd := exec.Command(scriptPath)
-	var outBuf, errBuf bytes.Buffer
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
-
-	if err := cmd.Run(); err != nil {
-		fmt.Printf("Error: %s", errBuf.String())
-		os.Exit(1)
-	}
-
-}
-
-// Setup code that runs once before all tests
-func setup() {
-	fmt.Println("Setting up before all tests...")
-	buildDevImage()
-}
-
-// TestMain runs once for the whole test suite
-func TestMain(m *testing.M) {
-	skipIfNotEnabled()
-	setup()
-	code := m.Run()
-	os.Exit(code)
-}
-
-func TestUpgradeFrom014(t *testing.T) {
-	envVars := constructVariables(t)
-	t.Logf("Starting old container")
-	runContainer(t, "xmtpd_test_014", "ghcr.io/xmtp/xmtpd:0.1.4", envVars)
-
-	t.Logf("Starting new container")
-	runContainer(t, "xmtpd_test_dev", "ghcr.io/xmtp/xmtpd:dev", envVars)
 }

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -184,12 +184,28 @@ func runContainer(
 	}
 }
 
+func buildDevImage(t *testing.T) {
+	scriptPath := getScriptPath("../../dev/docker/build")
+	cmd := exec.Command(scriptPath)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+
+	require.NoError(t, err, "build failed:\n%s\n%s", errBuf.String(), outBuf.String())
+
+}
+
 func TestUpgradeFrom014(t *testing.T) {
-	skipIfNotEnabled(t)
+	//skipIfNotEnabled(t)
 	envVars := constructVariables(t)
+
+	buildDevImage(t)
+
 	t.Logf("Starting old container")
 	runContainer(t, "xmtpd_test_014", "ghcr.io/xmtp/xmtpd:0.1.4", envVars)
 
 	t.Logf("Starting new container")
-	runContainer(t, "xmtpd_test_dev", "xmtp/xmtpd:dev", envVars)
+	runContainer(t, "xmtpd_test_dev", "ghcr.io/xmtp/xmtpd:dev", envVars)
 }

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -135,7 +135,12 @@ func runContainer(
 
 	_ = dockerRmc(containerName)
 
-	dockerCmd := append([]string{"run", "-d"}, dockerEnvArgs...)
+	dockerCmd := []string{"run", "-d"}
+	if runtime.GOOS == "linux" {
+		dockerCmd = append(dockerCmd, "--add-host=host.docker.internal:host-gateway")
+	}
+
+	dockerCmd = append(dockerCmd, dockerEnvArgs...)
 	dockerCmd = append(dockerCmd, "--name", containerName, imageName)
 
 	cmd := exec.Command("docker", dockerCmd...)


### PR DESCRIPTION
Poor mans upgrade tests.

The tests are behind a protected env variable so they don't run all the time. If you want to run them set `ENABLE_UPGRADE_TESTS=1`

The upgrade test will always attempt to build the local docker image, which can be somewhat slow. Hence the improvements to dockerignore. We were always rebuilding the image.

These steps are required:

- [x] merge #482 
- [x] backport into 0.1.3 stream
- [x] release new 0.1.3+ version
- [x] make sure `:dev` exists. Probably by executing the test using a dockerfile
- [x] get CI passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced Docker environment shutdown now performs comprehensive cleanup by removing orphaned containers and unused volumes.
	- Introduced an environment configuration tool that validates required settings prior to launching the application.
	- New test suite added to facilitate testing of the upgrade process for the application.
	- Added a new step in the GitHub Actions workflow to run upgrade tests.
	- New utility functions for managing Docker-related functionalities in tests.

- **Bug Fixes**
	- Corrected the Docker build command to ensure proper execution without errors.

- **Chores**
	- Updated default Docker image name to use the GitHub Container Registry.
	- Added Go module management to Dockerfiles to ensure dependencies are handled correctly.
	- Introduced a `.dockerignore` file to optimize Docker build processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->