### PR TITLE
Fix read guarantees

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -485,6 +485,9 @@ func (s *Service) waitForGatewayPublish(
 	startTime := time.Now()
 	timeout := time.After(30 * time.Second)
 
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-timeout:
@@ -497,7 +500,7 @@ func (s *Service) waitForGatewayPublish(
 				zap.Int64("envelope_id", stagedEnv.ID),
 				zap.Int64("last_processed", s.publishWorker.lastProcessed.Load()))
 			return
-		default:
+		case <-ticker.C:
 			// Check if the last processed ID has reached or exceeded the current ID
 			if s.publishWorker.lastProcessed.Load() >= stagedEnv.ID {
 				s.log.Debug(
@@ -507,7 +510,6 @@ func (s *Service) waitForGatewayPublish(
 				)
 				return
 			}
-			time.Sleep(10 * time.Millisecond)
 		}
 	}
 }

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -485,27 +485,29 @@ func (s *Service) waitForGatewayPublish(
 	startTime := time.Now()
 	timeout := time.After(30 * time.Second)
 
-	select {
-	case <-timeout:
-		s.log.Warn("Timeout waiting for publisher",
-			zap.Int64("envelope_id", stagedEnv.ID),
-			zap.Int64("last_processed", s.publishWorker.lastProcessed.Load()))
-		return
-	case <-ctx.Done():
-		s.log.Warn("Context cancelled while waiting for publisher",
-			zap.Int64("envelope_id", stagedEnv.ID),
-			zap.Int64("last_processed", s.publishWorker.lastProcessed.Load()))
-		return
-	default:
-		// Check if the last processed ID has reached or exceeded the current ID
-		if s.publishWorker.lastProcessed.Load() >= stagedEnv.ID {
-			s.log.Debug(
-				"Finished waiting for publisher",
+	for {
+		select {
+		case <-timeout:
+			s.log.Warn("Timeout waiting for publisher",
 				zap.Int64("envelope_id", stagedEnv.ID),
-				zap.Int64("wait_time", time.Since(startTime).Milliseconds()),
-			)
+				zap.Int64("last_processed", s.publishWorker.lastProcessed.Load()))
 			return
+		case <-ctx.Done():
+			s.log.Warn("Context cancelled while waiting for publisher",
+				zap.Int64("envelope_id", stagedEnv.ID),
+				zap.Int64("last_processed", s.publishWorker.lastProcessed.Load()))
+			return
+		default:
+			// Check if the last processed ID has reached or exceeded the current ID
+			if s.publishWorker.lastProcessed.Load() >= stagedEnv.ID {
+				s.log.Debug(
+					"Finished waiting for publisher",
+					zap.Int64("envelope_id", stagedEnv.ID),
+					zap.Int64("wait_time", time.Since(startTime).Milliseconds()),
+				)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
I have no idea how this happened. But the waitFunction never actually waited. After a single iteration, it would just continue as normal...

I guess in most cases the 10ms sleep was sufficient, but not in CI as we see in #478

I am dumbstruck...

Followup to #415 and https://github.com/xmtp/xmtpd/issues/358

Fixes https://github.com/xmtp/xmtpd/issues/478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Optimized the internal message processing logic to boost responsiveness and provide enhanced timing insights during operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->