### PR TITLE
Use v5 for caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,10 @@ jobs:
           submodules: recursive
           fetch-tags: true
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: "**/*.sum"
       - run: dev/docker/up
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
Speeds up builds by about 30-50 sec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the automated testing workflow to improve dependency caching, resulting in faster and more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->