### PR TITLE
Fix CLI version print

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var Commit string = "unknown"
+var Version string = "unknown"
 
 type CLI struct {
 	config.GlobalOptions
@@ -264,7 +264,7 @@ func updateAddress(logger *zap.Logger, options *CLI) {
 func main() {
 	for _, arg := range os.Args[1:] {
 		if arg == "-v" || arg == "--version" {
-			fmt.Printf("Version: %s\n", Commit)
+			fmt.Printf("Version: %s\n", Version)
 			return
 		}
 	}


### PR DESCRIPTION
There was a slight drift and it was printing:
```
martinkysel@mac xmtpd (main) $ ./dev/cli --version
Version: unknown
```

```
martinkysel@mac xmtpd (main) $ ./dev/cli --version
Version: v0.2.0-0-g8ffc98e

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the command-line interface to display version information using a more standardized label for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->