### PR TITLE
chore: update to foundry v1.0.0

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.0.0
 
       - name: Set cache key
         id: set-cache-key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "nightly-ac81a53d1d5823919ffbadd3c65f081927aa11f2"
+          version: v1.0.0
       - run: contracts/dev/deploy-local
       - run: dev/register-local-node
       - name: Run Tests

--- a/contracts/dev/generate
+++ b/contracts/dev/generate
@@ -26,7 +26,7 @@ function generate_bindings() {
     rm -f "${output_dir}/${package}"/*.go
 
     # Generate ABI and bytecode
-    if ! forge inspect "${source_artifact}:${filename}" abi > "${build_artifact}.abi.json"; then
+    if ! forge inspect "${source_artifact}:${filename}" abi --json > "${build_artifact}.abi.json"; then
         echo "ERROR: Failed to generate ABI for ${filename}" >&2
         exit 1
     fi

--- a/contracts/test/GroupMessage.t.sol
+++ b/contracts/test/GroupMessage.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 
 import "forge-std/src/Vm.sol";
-import {Test, console} from "forge-std/src/Test.sol";
+import {Test} from "forge-std/src/Test.sol";
 import {Utils} from "test/utils/Utils.sol";
 import {GroupMessages} from "src/GroupMessages.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/contracts/test/IdentityUpdates.t.sol
+++ b/contracts/test/IdentityUpdates.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 
 import "forge-std/src/Vm.sol";
-import {Test, console} from "forge-std/src/Test.sol";
+import {Test} from "forge-std/src/Test.sol";
 import {Utils} from "test/utils/Utils.sol";
 import {IdentityUpdates} from "src/IdentityUpdates.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/contracts/test/Nodes.sol
+++ b/contracts/test/Nodes.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Test, console} from "forge-std/src/Test.sol";
+import {Test} from "forge-std/src/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Nodes} from "../src/Nodes.sol";
 

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD IMAGE --------------------------------------------------------
 ARG GO_VERSION=1.24
-ARG FOUNDRY_VERSION=0.3.0
+ARG FOUNDRY_VERSION=1.0.0
 FROM golang:${GO_VERSION}-bookworm AS builder
 
 WORKDIR /app

--- a/dev/up
+++ b/dev/up
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-if ! which forge &>/dev/null; then echo "ERROR: Missing foundry binaries. Run 'curl -L https://foundry.paradigm.xyz | bash' and follow the instructions" && exit 1; fi
+if ! which forge &>/dev/null; then echo "ERROR: Missing foundry binaries. Run 'curl -L https://foundry.paradigm.xyz | bash' and follow the instructions to install foundry 1.0.0" && exit 1; fi
+if ! forge --version | grep -q "v1.0.0"; then echo "ERROR: Foundry version is not 1.0.0. Please install the correct version." && exit 1; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
 if ! which jq &>/dev/null; then brew install jq; fi
 


### PR DESCRIPTION
Update project to foundry v1.0.0:
- Pin forge versions, and require them at v1.0.0
- Minor changes to forge inspect.

Closes https://github.com/xmtp/xmtpd/issues/493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated the build and deployment workflows to require the latest Foundry (v1.0.0), ensuring consistency and clearer error messaging.
  - Enhanced the ABI generation process by providing JSON formatted outputs.
  - Updated the Dockerfile to install Foundry version 1.0.0.

- **Tests**
  - Streamlined testing by removing unnecessary debug logging for a cleaner output during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->