### PR TITLE
Fix foundry version check

### DIFF
--- a/dev/up
+++ b/dev/up
@@ -2,7 +2,7 @@
 set -e
 
 if ! which forge &>/dev/null; then echo "ERROR: Missing foundry binaries. Run 'curl -L https://foundry.paradigm.xyz | bash' and follow the instructions to install foundry 1.0.0" && exit 1; fi
-if ! forge --version | grep -q "v1.0.0"; then echo "ERROR: Foundry version is not 1.0.0. Please install the correct version." && exit 1; fi
+if ! forge --version | grep -q "1.0.0"; then echo "ERROR: Foundry version is not 1.0.0. Please install the correct version." && exit 1; fi
 if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
 if ! which jq &>/dev/null; then brew install jq; fi
 


### PR DESCRIPTION
## tl;dr

Foundry seems to have updated the way they display versions from `v1.0.0` to `1.0.0-stable`, which breaks our Foundry check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the version verification logic for a key dependency to ensure compatibility, so users receive the correct prompt if the required version isn’t installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->