### PR TITLE
Link payer to gateway envelopes

### DIFF
--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/db"
+	dbUtils "github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
@@ -23,11 +24,13 @@ var (
 )
 
 func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopeParams {
+	payerId := dbUtils.NullInt32(testutils.CreatePayer(t, db))
 	db_rows := []queries.InsertGatewayEnvelopeParams{
 		{
 			OriginatorNodeID:     1,
 			OriginatorSequenceID: 1,
 			Topic:                topicA,
+			PayerID:              payerId,
 			OriginatorEnvelope: testutils.Marshal(
 				t,
 				envelopeTestUtils.CreateOriginatorEnvelopeWithTopic(t, 1, 1, topicA),
@@ -37,6 +40,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			OriginatorNodeID:     2,
 			OriginatorSequenceID: 1,
 			Topic:                topicA,
+			PayerID:              payerId,
 			OriginatorEnvelope: testutils.Marshal(
 				t,
 				envelopeTestUtils.CreateOriginatorEnvelopeWithTopic(t, 2, 1, topicA),
@@ -46,6 +50,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			OriginatorNodeID:     1,
 			OriginatorSequenceID: 2,
 			Topic:                topicB,
+			PayerID:              payerId,
 			OriginatorEnvelope: testutils.Marshal(
 				t,
 				envelopeTestUtils.CreateOriginatorEnvelopeWithTopic(t, 1, 2, topicB),
@@ -55,6 +60,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			OriginatorNodeID:     2,
 			OriginatorSequenceID: 2,
 			Topic:                topicB,
+			PayerID:              payerId,
 			OriginatorEnvelope: testutils.Marshal(
 				t,
 				envelopeTestUtils.CreateOriginatorEnvelopeWithTopic(t, 2, 2, topicB),
@@ -64,6 +70,7 @@ func setupQueryTest(t *testing.T, db *sql.DB) []queries.InsertGatewayEnvelopePar
 			OriginatorNodeID:     1,
 			OriginatorSequenceID: 3,
 			Topic:                topicA,
+			PayerID:              payerId,
 			OriginatorEnvelope: testutils.Marshal(
 				t,
 				envelopeTestUtils.CreateOriginatorEnvelopeWithTopic(t, 1, 3, topicA),

--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -13,8 +13,8 @@ WHERE
 	singleton_id = 1;
 
 -- name: InsertGatewayEnvelope :execrows
-INSERT INTO gateway_envelopes(originator_node_id, originator_sequence_id, topic, originator_envelope)
-	VALUES (@originator_node_id, @originator_sequence_id, @topic, @originator_envelope)
+INSERT INTO gateway_envelopes(originator_node_id, originator_sequence_id, topic, originator_envelope, payer_id)
+	VALUES (@originator_node_id, @originator_sequence_id, @topic, @originator_envelope, @payer_id)
 ON CONFLICT
 	DO NOTHING;
 

--- a/pkg/db/queries/models.go
+++ b/pkg/db/queries/models.go
@@ -30,6 +30,7 @@ type GatewayEnvelope struct {
 	OriginatorSequenceID int64
 	Topic                []byte
 	OriginatorEnvelope   []byte
+	PayerID              sql.NullInt32
 }
 
 type LatestBlock struct {

--- a/pkg/db/queries/queries.sql.go
+++ b/pkg/db/queries/queries.sql.go
@@ -272,8 +272,8 @@ func (q *Queries) InsertBlockchainMessage(ctx context.Context, arg InsertBlockch
 }
 
 const insertGatewayEnvelope = `-- name: InsertGatewayEnvelope :execrows
-INSERT INTO gateway_envelopes(originator_node_id, originator_sequence_id, topic, originator_envelope)
-	VALUES ($1, $2, $3, $4)
+INSERT INTO gateway_envelopes(originator_node_id, originator_sequence_id, topic, originator_envelope, payer_id)
+	VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT
 	DO NOTHING
 `
@@ -283,6 +283,7 @@ type InsertGatewayEnvelopeParams struct {
 	OriginatorSequenceID int64
 	Topic                []byte
 	OriginatorEnvelope   []byte
+	PayerID              sql.NullInt32
 }
 
 func (q *Queries) InsertGatewayEnvelope(ctx context.Context, arg InsertGatewayEnvelopeParams) (int64, error) {
@@ -291,6 +292,7 @@ func (q *Queries) InsertGatewayEnvelope(ctx context.Context, arg InsertGatewayEn
 		arg.OriginatorSequenceID,
 		arg.Topic,
 		arg.OriginatorEnvelope,
+		arg.PayerID,
 	)
 	if err != nil {
 		return 0, err
@@ -368,7 +370,7 @@ func (q *Queries) RevokeAddressFromLog(ctx context.Context, arg RevokeAddressFro
 
 const selectGatewayEnvelopes = `-- name: SelectGatewayEnvelopes :many
 SELECT
-	gateway_time, originator_node_id, originator_sequence_id, topic, originator_envelope
+	gateway_time, originator_node_id, originator_sequence_id, topic, originator_envelope, payer_id
 FROM
 	select_gateway_envelopes($1::INT[], $2::BIGINT[], $3::BYTEA[], $4::INT[], $5::INT)
 `
@@ -402,6 +404,7 @@ func (q *Queries) SelectGatewayEnvelopes(ctx context.Context, arg SelectGatewayE
 			&i.OriginatorSequenceID,
 			&i.Topic,
 			&i.OriginatorEnvelope,
+			&i.PayerID,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/migrations/00006_link-payer-to-gateway-envelopes.down.sql
+++ b/pkg/migrations/00006_link-payer-to-gateway-envelopes.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE gateway_envelopes
+	DROP COLUMN payer_id;
+

--- a/pkg/migrations/00006_link-payer-to-gateway-envelopes.up.sql
+++ b/pkg/migrations/00006_link-payer-to-gateway-envelopes.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE gateway_envelopes
+-- Leave column nullable since blockchain originated messages won't have a payer_id
+	ADD COLUMN payer_id INT REFERENCES payers(id);
+

--- a/pkg/testutils/envelopes/envelopes.go
+++ b/pkg/testutils/envelopes/envelopes.go
@@ -1,15 +1,15 @@
 package testutils
 
 import (
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/xmtp/xmtpd/pkg/utils"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/proto/identity/associations"
 	mlsv1 "github.com/xmtp/xmtpd/pkg/proto/mls/api/v1"
 	envelopes "github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/topic"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -89,6 +89,7 @@ func CreatePayerEnvelope(
 	if len(clientEnv) == 0 {
 		clientEnv = append(clientEnv, CreateClientEnvelope())
 	}
+
 	clientEnvBytes, err := proto.Marshal(clientEnv[0])
 	require.NoError(t, err)
 

--- a/pkg/testutils/store.go
+++ b/pkg/testutils/store.go
@@ -110,3 +110,18 @@ func InsertGatewayEnvelopes(
 		}
 	}
 }
+
+func CreatePayer(t *testing.T, db *sql.DB, address ...string) int32 {
+	q := queries.New(db)
+	var payerAddress string
+	if len(address) > 0 {
+		payerAddress = address[0]
+	} else {
+		payerAddress = RandomString(42)
+	}
+
+	id, err := q.FindOrCreatePayer(context.Background(), payerAddress)
+	require.NoError(t, err)
+
+	return id
+}


### PR DESCRIPTION
### TL;DR
Added payer tracking to gateway envelopes by linking them to payer records in the database.

It's very hard to fill this link in after-the-fact, since it requires recovering the signer address from the `PayerEnvelope`, so I think it makes sense to store it on every row even if we don't have an immediate use for querying by the field.

### Issues
- https://github.com/xmtp/xmtpd/issues/527
- https://github.com/xmtp/xmtpd/issues/529

### What changed?
- Added a `payer_id` column to the `gateway_envelopes` table that references the `payers` table
- Modified the `InsertGatewayEnvelope` query to include the `payer_id` field
- Updated the publish worker and sync worker to extract payer information from envelopes and store it
- Added validation of originator envelopes before processing
- Updated tests to include payer IDs in test data

### How to test?
- Run existing test suite which has been updated to include payer tracking
- Verify that gateway envelopes are properly linked to payer records
- Confirm that invalid envelopes are rejected during validation
- Check that payer addresses are correctly recovered from signatures

### Why make this change?
This change enables tracking of message payers in the system, which is essential for:
- Monitoring message usage per payer
- Supporting future billing and rate limiting features
- Improving system accountability and auditability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced envelope processing now includes robust validation and integration of payer information, improving reliability and message tracking.

- **Chores**
  - Updated the database schema and migrations to support a new payer identifier.
  - Refined internal setups to align with the enhanced payer-data integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->