### PR TITLE
Allow running without payer key

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -110,32 +110,12 @@ func main() {
 			logger.Fatal("starting smart contract registry", zap.Error(err))
 		}
 
-		signer, err := blockchain.NewPrivateKeySigner(
-			options.Payer.PrivateKey,
-			options.Contracts.ChainID,
-		)
-		if err != nil {
-			logger.Fatal("initializing signer", zap.Error(err))
-		}
-
-		blockchainPublisher, err := blockchain.NewBlockchainPublisher(
-			ctx,
-			logger,
-			ethclient,
-			signer,
-			options.Contracts,
-		)
-		if err != nil {
-			logger.Fatal("initializing message publisher", zap.Error(err))
-		}
-
 		s, err := server.NewReplicationServer(
 			ctx,
 			logger,
 			options,
 			chainRegistry,
 			dbInstance,
-			blockchainPublisher,
 			fmt.Sprintf("0.0.0.0:%d", options.API.Port),
 			version,
 		)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/config"
-	"github.com/xmtp/xmtpd/pkg/mocks/blockchain"
 	mocks "github.com/xmtp/xmtpd/pkg/mocks/registry"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
@@ -49,7 +48,6 @@ func NewTestServer(
 	privateKey *ecdsa.PrivateKey,
 ) *s.ReplicationServer {
 	log := testutils.NewLog(t)
-	messagePublisher := blockchain.NewMockIBlockchainPublisher(t)
 
 	server, err := s.NewReplicationServer(context.Background(), log, config.ServerOptions{
 		Contracts: config.ContractsOptions{
@@ -71,11 +69,7 @@ func NewTestServer(
 		Replication: config.ReplicationOptions{
 			Enable: true,
 		},
-		Payer: config.PayerOptions{
-			Enable:     true,
-			PrivateKey: hex.EncodeToString(crypto.FromECDSA(privateKey)),
-		},
-	}, registry, db, messagePublisher, fmt.Sprintf("localhost:%d", port), testutils.GetLatestVersion(t))
+	}, registry, db, fmt.Sprintf("localhost:%d", port), testutils.GetLatestVersion(t))
 	require.NoError(t, err)
 
 	return server


### PR DESCRIPTION
If you were to try to run the XMTP API/SYNC without providing the payer key, the node will crash:
```
$ ./dev/run
2025-02-24T14:01:43.485-0500    INFO    replication     Version: v0.2.0-9-g1f8192f
2025-02-24T14:01:43.495-0500    INFO    replication     Successfully connected to DB    {"namespace": "xmtpd_c04b2306614f"}
2025-02-24T14:01:43.512-0500    FATAL   replication     initializing signer     {"error": "unable to parse private key: invalid length, need 256 bits"}
exit status 1
```

The blockchain publisher is only required for the payer. If we ever need it for the node, it will have to use the node key.

I will break apart the XMTPD image and the payer image in the next few days. But I need this to get the infra code moving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined and centralized the startup processes for replication services, reducing configuration overhead and enhancing operational resilience.
  - Improved error handling during service initialization for a smoother and more reliable user experience.
  - These refinements contribute to overall system stability and maintainability.
  
- **Tests**
  - Updated test configurations to reflect the revised initialization flows by removing deprecated parameters for a cleaner testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->