### PR TITLE
Track unsettled usage

### DIFF
--- a/pkg/db/gatewayEnvelope.go
+++ b/pkg/db/gatewayEnvelope.go
@@ -1,0 +1,41 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+)
+
+// InsertGatewayEnvelopeAndIncrementUnsettledUsage inserts a gateway envelope and increments the unsettled usage for the payer.
+// It returns the number of rows inserted.
+func InsertGatewayEnvelopeAndIncrementUnsettledUsage(
+	ctx context.Context,
+	db *sql.DB,
+	insertParams queries.InsertGatewayEnvelopeParams,
+	incrementParams queries.IncrementUnsettledUsageParams,
+) (int64, error) {
+	return RunInTxWithResult(
+		ctx,
+		db,
+		&sql.TxOptions{},
+		func(ctx context.Context, txQueries *queries.Queries) (int64, error) {
+			numInserted, err := txQueries.InsertGatewayEnvelope(ctx, insertParams)
+			if err != nil {
+				return 0, err
+			}
+			// If the numInserted is 0 it means the envelope already exists
+			// and we don't need to increment the unsettled usage
+			if numInserted == 0 {
+				return 0, nil
+			}
+
+			err = txQueries.IncrementUnsettledUsage(ctx, incrementParams)
+			if err != nil {
+				return 0, err
+			}
+
+			return numInserted, nil
+		},
+	)
+}

--- a/pkg/db/gatewayEnvelope_test.go
+++ b/pkg/db/gatewayEnvelope_test.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+)
+
+func buildParams(
+	payerID int32,
+	originatorID int32,
+	sequenceID int64,
+	spendPicodollars int64,
+) (queries.InsertGatewayEnvelopeParams, queries.IncrementUnsettledUsageParams) {
+	insertParams := queries.InsertGatewayEnvelopeParams{
+		OriginatorNodeID:     originatorID,
+		OriginatorSequenceID: sequenceID,
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(100),
+		PayerID:              NullInt32(payerID),
+	}
+
+	incrementParams := queries.IncrementUnsettledUsageParams{
+		PayerID:           payerID,
+		OriginatorID:      originatorID,
+		MinutesSinceEpoch: 1,
+		SpendPicodollars:  spendPicodollars,
+	}
+
+	return insertParams, incrementParams
+}
+
+func TestInsertAndIncrement(t *testing.T) {
+	ctx := context.Background()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+
+	querier := queries.New(db)
+	// Create a payer
+	payerID := testutils.CreatePayer(t, db, testutils.RandomAddress().Hex())
+	originatorID := testutils.RandomInt32()
+	sequenceID := int64(10)
+
+	insertParams, incrementParams := buildParams(payerID, originatorID, sequenceID, 100)
+
+	numInserted, err := InsertGatewayEnvelopeAndIncrementUnsettledUsage(
+		ctx,
+		db,
+		insertParams,
+		incrementParams,
+	)
+	require.NoError(t, err)
+	require.Equal(t, numInserted, int64(1))
+
+	payerSpend, err := querier.GetPayerUnsettledUsage(
+		ctx,
+		queries.GetPayerUnsettledUsageParams{PayerID: payerID},
+	)
+	require.NoError(t, err)
+	require.Equal(t, payerSpend, int64(100))
+}
+
+func TestPayerMustExist(t *testing.T) {
+	ctx := context.Background()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+
+	payerID := testutils.RandomInt32()
+	originatorID := testutils.RandomInt32()
+	sequenceID := int64(10)
+
+	insertParams, incrementParams := buildParams(payerID, originatorID, sequenceID, 100)
+
+	_, err := InsertGatewayEnvelopeAndIncrementUnsettledUsage(
+		ctx,
+		db,
+		insertParams,
+		incrementParams,
+	)
+	require.Error(t, err)
+}
+
+func TestInsertAndIncrementParallel(t *testing.T) {
+	ctx := context.Background()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+
+	querier := queries.New(db)
+	// Create a payer
+	payerID := testutils.CreatePayer(t, db, testutils.RandomAddress().Hex())
+	originatorID := testutils.RandomInt32()
+	sequenceID := int64(10)
+	numberOfInserts := 20
+
+	insertParams, incrementParams := buildParams(payerID, originatorID, sequenceID, 100)
+
+	var wg sync.WaitGroup
+
+	totalInserted := int64(0)
+
+	attemptInsert := func() {
+		defer wg.Done()
+		numInserted, err := InsertGatewayEnvelopeAndIncrementUnsettledUsage(
+			ctx,
+			db,
+			insertParams,
+			incrementParams,
+		)
+		require.NoError(t, err)
+		atomic.AddInt64(&totalInserted, numInserted)
+	}
+
+	for range numberOfInserts {
+		wg.Add(1)
+		go attemptInsert()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, totalInserted, int64(1))
+
+	payerSpend, err := querier.GetPayerUnsettledUsage(
+		ctx,
+		queries.GetPayerUnsettledUsageParams{PayerID: payerID},
+	)
+	require.NoError(t, err)
+	require.Equal(t, payerSpend, int64(100))
+}

--- a/pkg/db/queries/models.go
+++ b/pkg/db/queries/models.go
@@ -56,3 +56,10 @@ type StagedOriginatorEnvelope struct {
 	Topic          []byte
 	PayerEnvelope  []byte
 }
+
+type UnsettledUsage struct {
+	PayerID           int32
+	OriginatorID      int32
+	MinutesSinceEpoch int32
+	SpendPicodollars  int64
+}

--- a/pkg/db/tx.go
+++ b/pkg/db/tx.go
@@ -34,3 +34,32 @@ func RunInTx(
 	done = true
 	return tx.Commit()
 }
+
+func RunInTxWithResult[T any](
+	ctx context.Context,
+	db *sql.DB,
+	opts *sql.TxOptions,
+	fn func(ctx context.Context, txQueries *queries.Queries) (T, error),
+) (result T, err error) {
+	tx, err := db.BeginTx(ctx, opts)
+	if err != nil {
+		return result, err
+	}
+
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	result, err = fn(ctx, queries.New(db).WithTx(tx))
+	if err != nil {
+		return result, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/pkg/db/unsettledUsage_test.go
+++ b/pkg/db/unsettledUsage_test.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/utils"
+)
+
+func TestIncrementUnsettledUsage(t *testing.T) {
+	ctx := context.Background()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+
+	querier := queries.New(db)
+	payerId := testutils.RandomInt32()
+	originatorId := testutils.RandomInt32()
+	minutesSinceEpoch := utils.MinutesSinceEpochNow()
+
+	require.NoError(t, querier.IncrementUnsettledUsage(ctx, queries.IncrementUnsettledUsageParams{
+		PayerID:           payerId,
+		OriginatorID:      originatorId,
+		MinutesSinceEpoch: minutesSinceEpoch,
+		SpendPicodollars:  100,
+	}))
+
+	unsettledUsage, err := querier.GetPayerUnsettledUsage(
+		ctx,
+		queries.GetPayerUnsettledUsageParams{
+			PayerID: payerId,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, unsettledUsage, int64(100))
+
+	require.NoError(t, querier.IncrementUnsettledUsage(ctx, queries.IncrementUnsettledUsageParams{
+		PayerID:           payerId,
+		OriginatorID:      originatorId,
+		MinutesSinceEpoch: minutesSinceEpoch,
+		SpendPicodollars:  100,
+	}))
+
+	unsettledUsage, err = querier.GetPayerUnsettledUsage(
+		ctx,
+		queries.GetPayerUnsettledUsageParams{
+			PayerID: payerId,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, unsettledUsage, int64(200))
+}
+
+func TestGetUnsettledUsage(t *testing.T) {
+	ctx := context.Background()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+	defer cleanup()
+
+	querier := queries.New(db)
+	payerId := testutils.RandomInt32()
+	originatorId := testutils.RandomInt32()
+
+	addUsage := func(minutesSinceEpoch int32, spendPicodollars int64) {
+		require.NoError(
+			t,
+			querier.IncrementUnsettledUsage(ctx, queries.IncrementUnsettledUsageParams{
+				PayerID:           payerId,
+				OriginatorID:      originatorId,
+				MinutesSinceEpoch: minutesSinceEpoch,
+				SpendPicodollars:  spendPicodollars,
+			}),
+		)
+	}
+
+	addUsage(1, 100)
+	addUsage(2, 200)
+	addUsage(3, 300)
+
+	unsettledUsage, err := querier.GetPayerUnsettledUsage(
+		ctx,
+		queries.GetPayerUnsettledUsageParams{
+			PayerID:             payerId,
+			MinutesSinceEpochGt: 2,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, unsettledUsage, int64(300))
+
+	unsettledUsage, err = querier.GetPayerUnsettledUsage(
+		ctx,
+		queries.GetPayerUnsettledUsageParams{
+			PayerID:             payerId,
+			MinutesSinceEpochGt: 1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, unsettledUsage, int64(500))
+}

--- a/pkg/envelopes/originator.go
+++ b/pkg/envelopes/originator.go
@@ -2,6 +2,7 @@ package envelopes
 
 import (
 	"errors"
+	"time"
 
 	envelopesProto "github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/topic"
@@ -60,6 +61,10 @@ func (o *OriginatorEnvelope) OriginatorSequenceID() uint64 {
 
 func (o *OriginatorEnvelope) OriginatorNs() int64 {
 	return o.UnsignedOriginatorEnvelope.OriginatorNs()
+}
+
+func (o *OriginatorEnvelope) OriginatorTime() time.Time {
+	return utils.NsToDate(o.OriginatorNs())
 }
 
 func (o *OriginatorEnvelope) TargetTopic() topic.Topic {

--- a/pkg/migrations/00007_unsettled-usage.down.sql
+++ b/pkg/migrations/00007_unsettled-usage.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS unsettled_usage;
+
+DROP INDEX IF EXISTS idx_unsettled_usage_payer_id;
+

--- a/pkg/migrations/00007_unsettled-usage.up.sql
+++ b/pkg/migrations/00007_unsettled-usage.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE unsettled_usage(
+	payer_id INTEGER NOT NULL,
+	originator_id INTEGER NOT NULL,
+	minutes_since_epoch INTEGER NOT NULL,
+	spend_picodollars BIGINT NOT NULL,
+	PRIMARY KEY (payer_id, originator_id, minutes_since_epoch)
+);
+
+CREATE INDEX idx_unsettled_usage_payer_id ON unsettled_usage(payer_id);

--- a/pkg/testutils/random.go
+++ b/pkg/testutils/random.go
@@ -67,3 +67,7 @@ func RandomBlockHash() common.Hash {
 	bytes := RandomBytes(32)
 	return common.BytesToHash(bytes)
 }
+
+func RandomInt32() int32 {
+	return rand.Int31()
+}

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -1,0 +1,17 @@
+package utils
+
+import "time"
+
+func MinutesSinceEpoch(timestamp time.Time) int32 {
+	durationSinceEpoch := timestamp.Sub(time.Unix(0, 0))
+
+	return int32(durationSinceEpoch.Minutes())
+}
+
+func MinutesSinceEpochNow() int32 {
+	return MinutesSinceEpoch(time.Now())
+}
+
+func NsToDate(ns int64) time.Time {
+	return time.Unix(0, ns)
+}


### PR DESCRIPTION
### TL;DR
- Added database support for tracking unsettled payer usage
- Handles usage tracking in a transaction alongside writing the gateway envelope

### What changed?
- Created new `unsettled_usage` table to track spending between payers and originators
- Added SQL queries for incrementing and retrieving unsettled usage
- Implemented `MinutesSinceEpoch` utility functions for time tracking
- Added `RunInTxWithResult` for transaction handling with return values
- Created database migration scripts for the new table structure

### How to test?
- Run the new test cases in `queries_test.go`:
  - `TestIncrementUnsettledUsage`: Verifies incremental spending updates
  - `TestGetUnsettledUsage`: Validates retrieval of usage data with time filtering
- Execute database migrations to verify table creation and index setup

### Why make this change?
This change enables tracking of real-time usage and spending between payers and originators at a granular level, which is essential for accurate billing and usage monitoring in the system. The minute-level tracking allows for precise usage accounting and settlement processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced database operations to update and retrieve unsettled usage data.
  - Added a new data structure for representing unsettled usage records.
  - Enhanced transaction handling to return query results.
  - Provided utilities for time calculations and random number generation.
  - Delivered migration scripts to create the unsettled usage table with performance improvements.
  - Integrated new methods for inserting gateway envelopes and managing unsettled usage.
  - Added a method to convert nanoseconds to a time object.

- **Tests**
  - Added automated tests to verify the functionality of unsettled usage updates and retrievals.
  - Implemented tests for inserting gateway envelopes and handling concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->