### PR TITLE
Add migration tools for node registry

### DIFF
--- a/pkg/blockchain/migrator/migrator.go
+++ b/pkg/blockchain/migrator/migrator.go
@@ -1,0 +1,116 @@
+package migrator
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/xmtp/xmtpd/pkg/blockchain"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"go.uber.org/zap"
+)
+
+type SerializableNode struct {
+	NodeID        uint32 `json:"node_id"`
+	OwnerAddress  string `json:"owner_address"`
+	SigningKeyPub string `json:"signing_key_pub"`
+	HttpAddress   string `json:"http_address"`
+	IsHealthy     bool   `json:"is_healthy"`
+}
+
+func ReadFromRegistry(
+	chainCaller *blockchain.NodeRegistryCaller,
+) ([]SerializableNode, error) {
+	nodes, err := chainCaller.GetAllNodes(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	serializableNodes := make([]SerializableNode, len(nodes))
+	for i, node := range nodes {
+		owner, err := chainCaller.OwnerOf(context.Background(), int64(node.NodeId))
+		if err != nil {
+			return nil, err
+		}
+
+		pubKey, err := crypto.UnmarshalPubkey(node.Node.SigningKeyPub)
+		if err != nil {
+			return nil, err
+		}
+
+		serializableNodes[i] = SerializableNode{
+			NodeID:        node.NodeId,
+			OwnerAddress:  owner.Hex(),
+			SigningKeyPub: utils.EcdsaPublicKeyToString(pubKey),
+			HttpAddress:   node.Node.HttpAddress,
+			IsHealthy:     node.Node.IsHealthy,
+		}
+	}
+
+	return serializableNodes, nil
+}
+
+func DumpNodesToFile(nodes []SerializableNode, outFile string) error {
+	file, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return json.NewEncoder(file).Encode(nodes)
+}
+
+func ImportNodesFromFile(filePath string) ([]SerializableNode, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var nodes []SerializableNode
+	err = json.NewDecoder(file).Decode(&nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodes, nil
+}
+
+func WriteToRegistry(
+	logger *zap.Logger,
+	nodes []SerializableNode,
+	chainCaller *blockchain.NodeRegistryAdmin,
+) error {
+	ctx := context.Background()
+	for _, node := range nodes {
+		signingKey, err := utils.ParseEcdsaPublicKey(node.SigningKeyPub)
+		if err != nil {
+			return err
+		}
+		err = chainCaller.AddNode(
+			ctx,
+			node.OwnerAddress,
+			signingKey,
+			node.HttpAddress,
+		)
+		if err != nil {
+			return err
+		}
+
+		if !node.IsHealthy {
+			err = chainCaller.UpdateHealth(
+				ctx,
+				int64(node.NodeID),
+				false,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		logger.Info("wrote node to registry", zap.Any("node", node))
+	}
+
+	return nil
+}

--- a/pkg/blockchain/migrator/migrator_test.go
+++ b/pkg/blockchain/migrator/migrator_test.go
@@ -1,0 +1,150 @@
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/blockchain"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/utils"
+)
+
+func setupTest(
+	t *testing.T,
+) (*blockchain.NodeRegistryAdmin, *blockchain.NodeRegistryCaller, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := testutils.NewLog(t)
+	contractsOptions := testutils.GetContractsOptions(t)
+	// Set the nodes contract address to a random smart contract instead of the fixed deployment
+	contractsOptions.NodesContractAddress = testutils.DeployNodesContract(t)
+
+	signer, err := blockchain.NewPrivateKeySigner(
+		testutils.GetPayerOptions(t).PrivateKey,
+		contractsOptions.ChainID,
+	)
+	require.NoError(t, err)
+
+	client, err := blockchain.NewClient(ctx, contractsOptions.RpcUrl)
+	require.NoError(t, err)
+
+	registryAdmin, err := blockchain.NewNodeRegistryAdmin(
+		logger,
+		client,
+		signer,
+		contractsOptions,
+	)
+	require.NoError(t, err)
+
+	registryCaller, err := blockchain.NewNodeRegistryCaller(
+		logger,
+		client,
+		contractsOptions,
+	)
+	require.NoError(t, err)
+
+	return registryAdmin, registryCaller, func() {
+		cancel()
+		client.Close()
+	}
+}
+
+func registerRandomNode(
+	t *testing.T,
+	registryAdmin *blockchain.NodeRegistryAdmin,
+) SerializableNode {
+	ownerAddress := testutils.RandomAddress().Hex()
+	httpAddress := testutils.RandomString(30)
+	publicKey := testutils.RandomPrivateKey(t).PublicKey
+	require.NoError(
+		t,
+		registryAdmin.AddNode(context.Background(), ownerAddress, &publicKey, httpAddress),
+	)
+
+	return SerializableNode{
+		OwnerAddress:  ownerAddress,
+		HttpAddress:   httpAddress,
+		SigningKeyPub: utils.EcdsaPublicKeyToString(&publicKey),
+		IsHealthy:     true,
+		// We don't get the node ID here. Can live without for the tests
+	}
+}
+
+func TestRegistryRead(t *testing.T) {
+	registryAdmin, registryCaller, cleanup := setupTest(t)
+	defer cleanup()
+
+	node1 := registerRandomNode(t, registryAdmin)
+	node2 := registerRandomNode(t, registryAdmin)
+
+	nodes, err := ReadFromRegistry(registryCaller)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(nodes))
+
+	require.Equal(t, node1.OwnerAddress, nodes[0].OwnerAddress)
+	require.Equal(t, node1.HttpAddress, nodes[0].HttpAddress)
+	require.Equal(t, node1.SigningKeyPub, nodes[0].SigningKeyPub)
+	require.Equal(t, node1.IsHealthy, nodes[0].IsHealthy)
+
+	require.Equal(t, node2.OwnerAddress, nodes[1].OwnerAddress)
+	require.Equal(t, node2.HttpAddress, nodes[1].HttpAddress)
+	require.Equal(t, node2.SigningKeyPub, nodes[1].SigningKeyPub)
+	require.Equal(t, node2.IsHealthy, nodes[1].IsHealthy)
+}
+
+func TestFileDump(t *testing.T) {
+	registryAdmin, registryCaller, cleanup := setupTest(t)
+	defer cleanup()
+
+	_ = registerRandomNode(t, registryAdmin)
+
+	nodes, err := ReadFromRegistry(registryCaller)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	// Create a temporary file path for testing
+	tempDir := t.TempDir()
+	tempFilePath := filepath.Join(tempDir, fmt.Sprintf("%s.json", testutils.RandomString(12)))
+
+	err = DumpNodesToFile(nodes, tempFilePath)
+	require.NoError(t, err)
+
+	restoredNodes, err := ImportNodesFromFile(tempFilePath)
+	require.NoError(t, err)
+
+	require.Equal(t, nodes, restoredNodes)
+}
+
+func TestRegistryWrite(t *testing.T) {
+	registryAdmin, registryCaller, cleanup := setupTest(t)
+	defer cleanup()
+
+	node1 := registerRandomNode(t, registryAdmin)
+	node2 := registerRandomNode(t, registryAdmin)
+
+	nodes, err := ReadFromRegistry(registryCaller)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(nodes))
+
+	// Build a new registry admin with a different nodes contract
+	newRegistryAdmin, newRegistryCaller, newCleanup := setupTest(t)
+	defer newCleanup()
+	err = WriteToRegistry(testutils.NewLog(t), nodes, newRegistryAdmin)
+	require.NoError(t, err)
+
+	restoredNodes, err := ReadFromRegistry(newRegistryCaller)
+	require.NoError(t, err)
+	require.Equal(t, nodes, restoredNodes)
+
+	require.Equal(t, node1.OwnerAddress, restoredNodes[0].OwnerAddress)
+	require.Equal(t, node1.HttpAddress, restoredNodes[0].HttpAddress)
+	require.Equal(t, node1.SigningKeyPub, restoredNodes[0].SigningKeyPub)
+	require.Equal(t, node1.IsHealthy, restoredNodes[0].IsHealthy)
+
+	require.Equal(t, node2.OwnerAddress, restoredNodes[1].OwnerAddress)
+	require.Equal(t, node2.HttpAddress, restoredNodes[1].HttpAddress)
+	require.Equal(t, node2.SigningKeyPub, restoredNodes[1].SigningKeyPub)
+	require.Equal(t, node2.IsHealthy, restoredNodes[1].IsHealthy)
+}

--- a/pkg/blockchain/registryAdmin.go
+++ b/pkg/blockchain/registryAdmin.go
@@ -114,7 +114,7 @@ func NewNodeRegistryCaller(
 
 	return &NodeRegistryCaller{
 		client:   client,
-		logger:   logger.Named("NodeRegistryAdmin"),
+		logger:   logger.Named("NodeRegistryCaller"),
 		contract: contract,
 	}, nil
 }
@@ -126,6 +126,15 @@ func (n *NodeRegistryCaller) GetAllNodes(
 	return n.contract.AllNodes(&bind.CallOpts{
 		Context: ctx,
 	})
+}
+
+func (n *NodeRegistryCaller) OwnerOf(
+	ctx context.Context,
+	nodeId int64,
+) (common.Address, error) {
+	return n.contract.OwnerOf(&bind.CallOpts{
+		Context: ctx,
+	}, big.NewInt(nodeId))
 }
 
 func (n *NodeRegistryAdmin) UpdateHealth(

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -7,7 +7,14 @@ type GlobalOptions struct {
 
 type GenerateKeyOptions struct{}
 
-type GetAllNodesOptions struct{}
+type GetAllNodesOptions struct {
+	OutFile string `long:"out-file" description:"File to write the nodes to"`
+}
+
+type MigrateNodesOptions struct {
+	InFile          string `long:"in-file"           description:"File to read the nodes from"`
+	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to administer the node"`
+}
 
 type UpdateHealthOptions struct {
 	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to administer the node"`


### PR DESCRIPTION
## tl;dr

- Creates tools for dumping the node registry to a file, including fetching the ownerAddress of all nodes
- Creates tools for restoring the registry from a file so that we can migrate all the nodes to a new smart contract

## Notes

- Will take some massaging, but I hope we can use this to migrate all our existing nodes to the new Nodes contract @fbac is about to deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command that enables seamless node migration, allowing users to import node data from files and export node details to files.
  - Enhanced configuration settings to support file-based inputs/outputs and administrator credentials for node operations.

- **Tests**
  - Added comprehensive tests to validate node migration, ensuring reliable reading, writing, and verification of node data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->