### PR TITLE
Improve Grammar and Clarity in Documentation

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -42,7 +42,7 @@ Additionally, it uses `slither` for static analysis.
 
 ### Install
 
-As the project uses `soldeer`, update the dependencies by running:
+As the project uses `foundry`, update the dependencies by running:
 
 ```shell
 forge soldeer update

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -55,4 +55,4 @@ dev/cli register-node \
 
 ## Step 4) Start the node
 
-This step might differ for every operator. A good starting point is our [Deploy Doc](deploy.md)
+This step might differ for every operator. A good starting point is our [Deployment Guide](deploy.md)

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -2,7 +2,7 @@
 
 **⚠️ Experimental:** warning, this file might be out of date!
 
-It is important that both `public key` and `address` are correct as they are immutable and can not be changed in the future.
+It is important that both `public key` and `address` are correct as they are immutable and cannot be changed in the future.
 
 ## Step 1) Get All Keys
 


### PR DESCRIPTION
Consistency in Dependency Management Description
File: Documentation (e.g., README.md)

Before: "As the project uses soldeer, update the dependencies by running:"
After: "As the project uses foundry, update the dependencies by running:"
Reason: Foundry is the actual framework used. soldeer is a package manager within Foundry, so this phrasing better reflects the project's build process.
2. Correction of "can not" → "cannot"
File: Documentation (e.g., onboarding.md)

Before: "It is important that both public key and address are correct as they are immutable and can not be changed in the future."
After: "It is important that both public key and address are correct as they are immutable and cannot be changed in the future."
Reason: "Cannot" is the correct single-word form, whereas "can not" is rarely used in this context. This correction ensures proper grammar.
3. Improved Terminology in Deployment Guide Reference
File: Documentation (e.g., onboarding.md)

Before: "A good starting point is our [Deploy Doc](https://github.com/xmtp/xmtpd/compare/deploy.md)"
After: "A good starting point is our [Deployment Guide](https://github.com/xmtp/xmtpd/compare/deploy.md)"
Reason: "Deploy Doc" is an informal phrasing. "Deployment Guide" is more professional and standard for technical documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions to reference the new dependency management tool.
	- Refined wording and formatting in the user guide for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->