### PR TITLE
Drive-by fixes to logger and fatal

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -120,7 +120,7 @@ func main() {
 			version,
 		)
 		if err != nil {
-			log.Fatal("initializing server", zap.Error(err))
+			logger.Fatal("initializing server", zap.Error(err))
 		}
 
 		s.WaitForShutdown(10 * time.Second)

--- a/pkg/authn/tokenFactory.go
+++ b/pkg/authn/tokenFactory.go
@@ -23,8 +23,8 @@ func NewTokenFactory(
 	privateKey *ecdsa.PrivateKey,
 	nodeID uint32,
 	serverVersion *semver.Version,
-) *TokenFactory {
-	return &TokenFactory{
+) TokenFactory {
+	return TokenFactory{
 		privateKey:    privateKey,
 		nodeID:        nodeID,
 		serverVersion: serverVersion,

--- a/pkg/interceptors/client/auth.go
+++ b/pkg/interceptors/client/auth.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/xmtp/xmtpd/pkg/authn"
@@ -15,19 +14,16 @@ import (
 
 // AuthInterceptor is a struct for holding the token and adding it to each request.
 type AuthInterceptor struct {
-	tokenFactory *authn.TokenFactory
+	tokenFactory authn.TokenFactory
 	targetNodeID uint32
 	currentToken *authn.Token
 }
 
 func NewAuthInterceptor(
-	tokenFactory *authn.TokenFactory,
+	tokenFactory authn.TokenFactory,
 	targetNodeID uint32,
 ) *AuthInterceptor {
-	// This should never happen
-	if tokenFactory == nil {
-		log.Fatal("tokenFactory is required")
-	}
+
 	return &AuthInterceptor{
 		tokenFactory: tokenFactory,
 		targetNodeID: targetNodeID,

--- a/pkg/registrant/registrant.go
+++ b/pkg/registrant/registrant.go
@@ -25,7 +25,7 @@ import (
 type Registrant struct {
 	record       *registry.Node
 	privateKey   *ecdsa.PrivateKey
-	tokenFactory *authn.TokenFactory
+	tokenFactory authn.TokenFactory
 }
 
 func NewRegistrant(
@@ -72,7 +72,7 @@ func (r *Registrant) NodeID() uint32 {
 	return r.record.NodeID
 }
 
-func (r *Registrant) TokenFactory() *authn.TokenFactory {
+func (r *Registrant) TokenFactory() authn.TokenFactory {
 	return r.tokenFactory
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,16 +42,17 @@ type ReplicationServer struct {
 	apiServer  *api.ApiServer
 	syncServer *sync.SyncServer
 
-	ctx               context.Context
-	cancel            context.CancelFunc
-	log               *zap.Logger
-	registrant        *registrant.Registrant
-	nodeRegistry      registry.NodeRegistry
-	indx              *indexer.Indexer
-	options           config.ServerOptions
-	metrics           *metrics.Server
-	validationService mlsvalidate.MLSValidationService
-	cursorUpdater     metadata.CursorUpdater
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	log                 *zap.Logger
+	registrant          *registrant.Registrant
+	nodeRegistry        registry.NodeRegistry
+	indx                *indexer.Indexer
+	options             config.ServerOptions
+	metrics             *metrics.Server
+	validationService   mlsvalidate.MLSValidationService
+	cursorUpdater       metadata.CursorUpdater
+	blockchainPublisher *blockchain.BlockchainPublisher
 }
 
 func NewReplicationServer(
@@ -167,7 +168,7 @@ func NewReplicationServer(
 
 func startAPIServer(
 	ctx context.Context,
-	log *zap.Logger,
+	logger *zap.Logger,
 	options config.ServerOptions,
 	s *ReplicationServer,
 	writerDB *sql.DB,
@@ -181,18 +182,18 @@ func startAPIServer(
 			if s.validationService == nil {
 				s.validationService, err = mlsvalidate.NewMlsValidationService(
 					ctx,
-					log,
+					logger,
 					options.MlsValidation,
 				)
 				if err != nil {
 					return err
 				}
 			}
-			s.cursorUpdater = metadata.NewCursorUpdater(ctx, log, writerDB)
+			s.cursorUpdater = metadata.NewCursorUpdater(ctx, logger, writerDB)
 
 			replicationService, err := message.NewReplicationApiService(
 				ctx,
-				log,
+				logger,
 				s.registrant,
 				writerDB,
 				s.validationService,
@@ -204,11 +205,11 @@ func startAPIServer(
 			}
 			message_api.RegisterReplicationApiServer(grpcServer, replicationService)
 
-			log.Info("Replication service enabled")
+			logger.Info("Replication service enabled")
 
 			metadataService, err := metadata.NewMetadataApiService(
 				ctx,
-				log,
+				logger,
 				s.cursorUpdater,
 			)
 			if err != nil {
@@ -216,7 +217,7 @@ func startAPIServer(
 			}
 			metadata_api.RegisterMetadataApiServer(grpcServer, metadataService)
 
-			log.Info("Metadata service enabled")
+			logger.Info("Metadata service enabled")
 		}
 
 		if options.Payer.Enable {
@@ -230,28 +231,28 @@ func startAPIServer(
 				options.Contracts.ChainID,
 			)
 			if err != nil {
-				log.Fatal("initializing signer", zap.Error(err))
+				logger.Fatal("initializing signer", zap.Error(err))
 			}
 
 			ethclient, err := blockchain.NewClient(ctx, options.Contracts.RpcUrl)
 			if err != nil {
-				log.Fatal("initializing blockchain client", zap.Error(err))
+				logger.Fatal("initializing blockchain client", zap.Error(err))
 			}
 
 			blockchainPublisher, err := blockchain.NewBlockchainPublisher(
 				ctx,
-				log,
+				logger,
 				ethclient,
 				signer,
 				options.Contracts,
 			)
 			if err != nil {
-				log.Fatal("initializing message publisher", zap.Error(err))
+				logger.Fatal("initializing message publisher", zap.Error(err))
 			}
 
 			payerService, err := payer.NewPayerApiService(
 				ctx,
-				log,
+				logger,
 				s.nodeRegistry,
 				payerPrivateKey,
 				blockchainPublisher,
@@ -262,7 +263,7 @@ func startAPIServer(
 			}
 			payer_api.RegisterPayerApiServer(grpcServer, payerService)
 
-			log.Info("Payer service enabled")
+			logger.Info("Payer service enabled")
 		}
 
 		return nil
@@ -283,7 +284,7 @@ func startAPIServer(
 
 	s.apiServer, err = api.NewAPIServer(
 		s.ctx,
-		log,
+		logger,
 		listenAddress,
 		options.Reflection.Enable,
 		serviceRegistrationFunc,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,17 +42,16 @@ type ReplicationServer struct {
 	apiServer  *api.ApiServer
 	syncServer *sync.SyncServer
 
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	log                 *zap.Logger
-	registrant          *registrant.Registrant
-	nodeRegistry        registry.NodeRegistry
-	indx                *indexer.Indexer
-	options             config.ServerOptions
-	metrics             *metrics.Server
-	validationService   mlsvalidate.MLSValidationService
-	cursorUpdater       metadata.CursorUpdater
-	blockchainPublisher *blockchain.BlockchainPublisher
+	ctx               context.Context
+	cancel            context.CancelFunc
+	log               *zap.Logger
+	registrant        *registrant.Registrant
+	nodeRegistry      registry.NodeRegistry
+	indx              *indexer.Indexer
+	options           config.ServerOptions
+	metrics           *metrics.Server
+	validationService mlsvalidate.MLSValidationService
+	cursorUpdater     metadata.CursorUpdater
 }
 
 func NewReplicationServer(


### PR DESCRIPTION
log.Fatal does not print in the right category. it goes to stderr and datadog does not pick it up as an error.

Using logger (zap).Fatal does the expected thing.

Also remove potential nil ptr exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced blockchain publishing support within the replication server.

- **Refactor**
  - Enhanced error logging for clearer and more consistent error reporting.
  - Streamlined authentication handling to improve token processing and overall system stability.
  - Simplified `TokenFactory` and `AuthInterceptor` instantiation by changing from pointer to value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->