### PR TITLE
IPayerReport interface

### DIFF
--- a/contracts/src/interfaces/IPayer.sol
+++ b/contracts/src/interfaces/IPayer.sol
@@ -266,17 +266,15 @@ interface IPayer {
     *
     * @param originatorNode The node that submitted the report.
     * @param reportIndex The index of the report.
-    * @param offset The starting index of the batch in the report's data.
     * @param payers A contiguous array of payer addresses.
     * @param amounts A contiguous array of usage amounts corresponding to each payer.
     */
     function settleUsage(
         address originatorNode,
         uint256 reportIndex,
-        uint256 offset,
         address[] calldata payers,
         uint256[] calldata amounts
-    ) external;
+    ) external /* onlyPayerReport */ ;
 
     /**
      * @notice Retrieves the total pending fees that have not yet been transferred

--- a/contracts/src/interfaces/IPayer.sol
+++ b/contracts/src/interfaces/IPayer.sol
@@ -261,27 +261,21 @@ interface IPayer {
     //==============================================================
 
     /**
-     * @notice Settles a contiguous batch of usage data from a PayerReport.
-     * Uses an aggregated Merkle proof to verify that the provided batch of
-     * (payer, amount) entries is included in the report’s committed Merkle root.
-     *
-     * @param originatorNode The node that submitted the report.
-     * @param reportIndex The index of the report.
-     * @param offset The starting index in the list of (payer, amount) entries.
-     * @param payers A contiguous array of payer addresses.
-     * @param amounts A contiguous array of usage amounts corresponding to each payer.
-     * @param proof An array of branch hashes for the aggregated Merkle proof.
-     *
-     * The contract computes the aggregated hash for the batch and, along with the
-     * provided proof and offset, reconstructs the Merkle path to verify inclusion.
-     */
+    * @notice Settles usage for a contiguous batch of (payer, amount) entries.
+    * Assumes that the PayerReport contract has already verified the aggregated Merkle proof.
+    *
+    * @param originatorNode The node that submitted the report.
+    * @param reportIndex The index of the report.
+    * @param offset The starting index of the batch in the report's data.
+    * @param payers A contiguous array of payer addresses.
+    * @param amounts A contiguous array of usage amounts corresponding to each payer.
+    */
     function settleUsage(
         address originatorNode,
         uint256 reportIndex,
         uint256 offset,
         address[] calldata payers,
-        uint256[] calldata amounts,
-        bytes32[] calldata proof
+        uint256[] calldata amounts
     ) external;
 
     /**

--- a/contracts/src/interfaces/IPayer.sol
+++ b/contracts/src/interfaces/IPayer.sol
@@ -68,13 +68,13 @@ interface IPayer {
     event WithdrawalFinalized(address indexed payer, uint256 amountReturned);
 
     /// @dev Emitted when usage is settled and fees are calculated.
-    event UsageSettled(uint256 fees, address indexed payer, uint256 indexed nodeId, uint256 timestamp);
+    event UsageSettled(uint256 fees, address indexed payer, uint256 indexed originatorNode, uint256 timestamp);
 
-    /// @dev Emitted when fees are transferred to the rewards contract.
+    /// @dev Emitted when fees are transferred to the distribution contract.
     event FeesTransferred(uint256 amount);
 
-    /// @dev Emitted when the rewards contract address is updated.
-    event RewardsContractUpdated(address indexed newRewardsContract);
+    /// @dev Emitted when the distribution contract address is updated.
+    event DistributionContractUpdated(address indexed newDistributionContract);
 
     /// @dev Emitted when the nodes contract address is updated.
     event NodesContractUpdated(address indexed newNodesContract);
@@ -95,8 +95,8 @@ interface IPayer {
     /// @dev Error thrown when caller is not an authorized node operator.
     error UnauthorizedNodeOperator();
 
-    /// @dev Error thrown when caller is not the rewards contract.
-    error NotRewardsContract();
+    /// @dev Error thrown when caller is not the distribution contract.
+    error NotDistributionContract();
 
     /// @dev Error thrown when an address is invalid (usually zero address).
     error InvalidAddress();
@@ -286,19 +286,18 @@ interface IPayer {
 
     /**
      * @notice Retrieves the total pending fees that have not yet been transferred
-     *         to the rewards contract.
+     *         to the distribution contract.
      * @return pending The total pending fees in USDC.
      */
     function getPendingFees() external view returns (uint256 pending);
 
     /**
-     * @notice Transfers all pending fees to the designated rewards contract for
-     *         distribution using EIP-2200 optimizations.
+     * @notice Transfers all pending fees to the designated distribution contract.
      * @dev Uses a single storage write for updating accumulated fees.
      *
      * Emits `FeesTransferred`.
      */
-    function transferFeesToRewards() external;
+    function transferFeesToDistribution() external;
 
     /**
      * @notice Returns the maximum allowed time difference for backdated settlements.
@@ -366,12 +365,12 @@ interface IPayer {
     //==============================================================
 
     /**
-     * @notice Sets the address of the rewards contract.
-     * @param _rewardsContract The address of the new rewards contract.
+     * @notice Sets the address of the distribution contract.
+     * @param _distributionContract The address of the new distribution contract.
      *
-     * Emits `RewardsContractUpdated`.
+     * Emits `DistributionContractUpdated`.
      */
-    function setRewardsContract(address _rewardsContract) external;
+    function setDistributionContract(address _distributionContract) external;
 
     /**
      * @notice Sets the address of the nodes contract for operator verification.
@@ -382,16 +381,16 @@ interface IPayer {
     function setNodesContract(address _nodesContract) external;
 
     /**
-     * @notice Retrieves the address of the current rewards contract.
-     * @return The address of the rewards contract.
+     * @notice Retrieves the address of the current distribution contract.
+     * @return distributionContract The address of the distribution contract.
      */
-    function getRewardsContract() external view returns (address);
+    function getDistributionContract() external view returns (address distributionContract);
 
     /**
      * @notice Retrieves the address of the current nodes contract.
-     * @return The address of the nodes contract.
+     * @return nodesContract The address of the nodes contract.
      */
-    function getNodesContract() external view returns (address);
+    function getNodesContract() external view returns (address nodesContract);
 
     /**
      * @notice Pauses the contract functions in case of emergency.

--- a/contracts/src/interfaces/IPayerReport.sol
+++ b/contracts/src/interfaces/IPayerReport.sol
@@ -10,6 +10,15 @@ interface IPayerReport {
     //                             STRUCTS
     //==============================================================
 
+    /// @notice A struct containing the usage report details.
+    /// @param originatorNode The address of the originator node.
+    /// @param startingSequenceID The starting sequence ID of the report.
+    /// @param endingSequenceID The ending sequence ID of the report.
+    /// @param lastMessageTimestamp The timestamp of the last message in the report.
+    /// @param reportTimestamp The timestamp of the report.
+    /// @param reportMerkleRoot The Merkle root of the report.
+    /// @param leafCount The number of leaves in the report.
+    /// A leaf is a single (payer, amount) pair.
     struct PayerReport {
         address originatorNode;
         uint256 startingSequenceID;
@@ -17,7 +26,7 @@ interface IPayerReport {
         uint256 lastMessageTimestamp;
         uint256 reportTimestamp;
         bytes32 reportMerkleRoot;
-        uint16 batches;
+        uint16 leafCount;
     }
 
     //==============================================================
@@ -38,7 +47,7 @@ interface IPayerReport {
         uint256 endingSequenceID,
         uint256 lastMessageTimestamp,
         uint256 reportTimestamp,
-        uint16 batches
+        uint16 leafCount
     );
 
     /**

--- a/contracts/src/interfaces/IPayerReport.sol
+++ b/contracts/src/interfaces/IPayerReport.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title IPayerReport
+ * @notice Updated interface for a Rewards (PayerReport) contract that:
+ *  1) Accepts fee transfers from the Payer contract.
+ *  2) Stores 12-hour usage reports submitted by originator nodes. Each report
+ *     now includes a commitment (Merkle root) to the detailed (payer, amount)
+ *     data that can be verified later.
+ *  3) Allows nodes to attest to the report’s correctness.
+ *  4) Finalizes reports upon majority attestation, triggering settlement of usage.
+ *  5) Enables batch settlement of usage via aggregated Merkle proofs.
+ *  6) Periodically distributes accumulated rewards to active node operators.
+ *
+ * "Active slots" data is retrieved from the Auction contract (not shown here).
+ */
+interface IPayerReport {
+
+    //==============================================================
+    //                          EVENTS
+    //==============================================================
+
+    /**
+     * @dev Emitted when an originator node submits a usage report.
+     * The report includes the Merkle root of the detailed (payer, amount) data.
+     */
+    event PayerReportSubmitted(
+        address indexed originatorNode,
+        uint256 indexed reportIndex,
+        uint256 startingSequenceID,
+        uint256 endingSequenceID,
+        uint256 lastMessageTimestamp,
+        uint256 reportTimestamp,
+        bytes32 reportMerkleRoot,
+        address[] payers,
+        uint256[] amountsSpent
+    );
+
+    /**
+     * @dev Emitted when a node attests to the correctness of a report.
+     */
+    event PayerReportAttested(
+        address indexed originatorNode,
+        bytes32 reportMerkleRoot
+    );
+
+    /**
+     * @dev Emitted when a usage report is confirmed.
+     */
+    event PayerReportConfirmed(
+        address indexed originatorNode,
+        bytes32 reportMerkleRoot
+    );
+
+    //==============================================================
+    //                     USAGE REPORT LOGIC
+    //==============================================================
+
+    /**
+     * @notice Submits a usage report for a node covering messages from
+     *         startingSequenceID to endingSequenceID.
+     * @param originatorNode The node’s address/ID.
+     * @param startingSequenceID The first message included in the report.
+     * @param endingSequenceID The last message included in the report.
+     * @param lastMessageTimestamp The timestamp of the last message in the report.
+     * @param reportTimestamp The time the report was generated.
+     * @param reportMerkleRoot The Merkle root of the detailed (payer, amount) data.
+     * @param payers An array of payer addresses included in this usage window.
+     * @param amountsSpent The usage cost each payer owes.
+     *
+     * Emits a PayerReportSubmitted event.
+     */
+    function submitPayerReport(
+        address originatorNode,
+        uint256 startingSequenceID,
+        uint256 endingSequenceID,
+        uint256 lastMessageTimestamp,
+        uint256 reportTimestamp,
+        bytes32 reportMerkleRoot,
+        address[] calldata payers,
+        uint256[] calldata amountsSpent
+    ) external;
+
+    /**
+     * @notice Allows nodes to attest to the correctness of a submitted usage report.
+     * @param originatorNode The node that submitted the report.
+     * @param reportIndex The index of the report.
+     *
+     * Emits a PayerReportAttested event.
+     */
+    function attestPayerReport(address originatorNode, uint256 reportIndex) external;
+
+    /**
+     * @notice Finalizes a usage report once majority attestation is reached.
+     * Settlement happens in batches, by calling the settleUsage function in Payer contract.
+     * Emits a PayerReportConfirmed event.
+     * @param originatorNode The node that submitted the report.
+     * @param reportIndex The index of the report to confirm.
+     */
+    function confirmPayerReport(
+        address originatorNode,
+        uint256 reportIndex
+    ) external;
+
+    /**
+     * @notice Returns a list of all payer reports for a given originator node.
+     * @param originatorNode The address of the originator node.
+     * @return startingSequenceID The first sequence ID in the report.
+     * @return reportsMerkleRoot The Merkle root for the detailed usage data.
+     */
+    function listPayerReports(address originatorNode) external view returns (uint256[] memory startingSequenceID, bytes32[] memory reportsMerkleRoot);
+
+    /**
+     * @notice Returns summary info about a specific usage report.
+     * @param originatorNode The node that submitted the report.
+     * @param reportIndex The report's index.
+     * @return startingSequenceID The first sequence ID in the report.
+     * @return endingSequenceID The last sequence ID in the report.
+     * @return lastMessageTimestamp The timestamp of the last message in the report.
+     * @return reportTimestamp The time the report was generated.
+     * @return attestationCount The number of attestations received.
+     * @return isConfirmed Whether the report is finalized.
+     * @return reportMerkleRoot The Merkle root for the detailed usage data.
+     */
+    function getPayerReport(
+        address originatorNode,
+        uint256 reportIndex
+    )
+        external
+        view
+        returns (
+            uint256 startingSequenceID,
+            uint256 endingSequenceID,
+            uint256 lastMessageTimestamp,
+            uint256 reportTimestamp,
+            uint256 attestationCount,
+            bool isConfirmed,
+            bytes32 reportMerkleRoot
+        );
+}

--- a/contracts/src/interfaces/IPayerReport.sol
+++ b/contracts/src/interfaces/IPayerReport.sol
@@ -125,18 +125,20 @@ interface IPayerReport {
     ) external view returns (UsageReport memory payerReport);
 
     /**
-     * @notice Settles a contiguous batch of usage data from a confirmed report.
-     * This function calls the settleUsage function in the Payer contract.
-     * 
-     * @param originatorNode The node that submitted the report.
-     * @param reportIndex The index of the report.
-     * @param offset The starting index of the batch in the report's data (managed offchain).
-     * @param payers A contiguous array of payer addresses.
-     * @param amounts A contiguous array of usage amounts corresponding to each payer.
-     * @param proof An aggregated Merkle proof containing branch hashes.
-     *
-     * Emits a UsageSettled event.
-     */
+    * @notice Settles a contiguous batch of usage data from a confirmed report.
+    * Verifies an aggregated Merkle proof that the provided (payer, amount)
+    * batch is included in the report's committed Merkle root, then calls the
+    * settleUsage function in the Payer contract.
+    * 
+    * @param originatorNode The node that submitted the report.
+    * @param reportIndex The index of the report.
+    * @param offset The starting index of the batch in the report's data (managed offchain).
+    * @param payers A contiguous array of payer addresses.
+    * @param amounts A contiguous array of usage amounts corresponding to each payer.
+    * @param proof An aggregated Merkle proof containing branch hashes.
+    *
+    * Emits a UsageSettled event.
+    */
     function settleUsageBatch(
         address originatorNode,
         uint256 reportIndex,

--- a/contracts/src/interfaces/IPayerReport.sol
+++ b/contracts/src/interfaces/IPayerReport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.28;
 
 /**
  * @title IPayerReport


### PR DESCRIPTION
Context around Merkle Trees in https://github.com/xmtp/xmtpd/issues/563
Closes https://github.com/xmtp/xmtpd/issues/470?issue=xmtp%7Cxmtpd%7C499

The following is the expected sequence of events:
- A node generates and submits a `PayerReport`.
- All the other nodes call `attestPayerReport` if they can confirm its validity.
- Nodes in the network listen for attestations and tracks them. Upon reaching majority, the `confirmPayerReport` can be called.
- When a `PayerReport` is confirmed, any node can submit batches to `settleUsageBatch`. The `PayerReport` contract is expected to track batches submissions to prevent duplicates.
- `settleUsageBatch` verifies the provided payers and amounts leafs are included in the PayerReport Merkle tree. If verified, the Payer.settleUsage is called with the list of payers and amounts to settle the usage. 

Nodes attest to PayerReports, and once majority has been reached `confirmPayerReport` can be called for settlement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the usage settlement process to handle batches more efficiently with improved verification.
  - Introduced a new reporting interface enabling users to submit, attest, and confirm usage data reports.
  - Added events for tracking report submissions, attestations, and confirmations.
  - Updated terminology for contracts related to distribution to better reflect current functionality.
- **Bug Fixes**
  - Clarified documentation for events to accurately represent their context and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->