### PR TITLE
Add CLI tool for adding rates to the contract

### DIFF
--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -16,6 +16,14 @@ type MigrateNodesOptions struct {
 	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to administer the node"`
 }
 
+type AddRatesOptions struct {
+	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to administer the node"`
+	MessageFee      uint64 `long:"message-fee"       description:"Message fee"`
+	StorageFee      uint64 `long:"storage-fee"       description:"Storage fee"`
+	CongestionFee   uint64 `long:"congestion-fee"    description:"Congestion fee"`
+	DelayDays       uint   `long:"delay-days"        description:"Delay the rates going into effect for N days"    default:"0"`
+}
+
 type UpdateHealthOptions struct {
 	AdminPrivateKey string `long:"admin-private-key" description:"Private key of the admin to administer the node"`
 	NodeId          int64  `long:"node-id"           description:"NodeId to update"`


### PR DESCRIPTION
### TL;DR
Added a new CLI command `add-rates` to manage fee rates for the XMTP network.

### What changed?
- Added new `add-rates` command to the CLI with options for message, storage, and congestion fees
- Implemented ability to set a delay period for when rates take effect

### How to test?
1. Run the CLI with the new `add-rates` command:
```bash
./cli add-rates \
  --admin-private-key <private-key> \
  --message-fee <fee> \
  --storage-fee <fee> \
  --congestion-fee <fee> \
  --delay-days <days>
```
2. Verify the rates were properly set by checking the blockchain
3. If delay was set, confirm rates take effect after the specified period

### Why make this change?
To provide administrators with a straightforward way to manage network fees through the CLI, allowing for better control over message, storage, and congestion costs in the XMTP network. The delay feature enables planned fee changes to be scheduled in advance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the new "add-rates" command in the CLI, enabling users to add and configure rate settings.
	- Users can specify parameters such as message fees, storage fees, congestion fees, and the effective start delay for the rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->