### PR TITLE
Normalize contract deployment keys

### DIFF
--- a/contracts/dev/lib/common
+++ b/contracts/dev/lib/common
@@ -116,8 +116,7 @@ function forge_verify_contract() {
         return
     fi
 
-    impl_key="$(echo ${contract_name:0:1} | tr '[:upper:]' '[:lower:]')${contract_name:1}Impl"
-    deployed_address="$(jq -r ".addresses.$impl_key" config/${chain_name}/${contract_name}.json)"
+    deployed_address="$(jq -r ".addresses.implementation" config/${chain_name}/${contract_name}.json)"
     if [ -z "$deployed_address" ]; then
         echo "Failed to get deployed address for $contract_name"
         exit 1

--- a/contracts/script/DeployGroupMessages.s.sol
+++ b/contracts/script/DeployGroupMessages.s.sol
@@ -45,10 +45,10 @@ contract DeployGroupMessages is Script, Utils, Environment {
 
         string memory addressesOutput;
 
-        addressesOutput = vm.serializeAddress(addresses, "groupMessagesDeployer", deployer);
-        addressesOutput = vm.serializeAddress(addresses, "groupMessagesProxyAdmin", admin);
-        addressesOutput = vm.serializeAddress(addresses, "groupMessagesProxy", address(proxy));
-        addressesOutput = vm.serializeAddress(addresses, "groupMessagesImpl", address(groupMessagesImpl));
+        addressesOutput = vm.serializeAddress(addresses, "deployer", deployer);
+        addressesOutput = vm.serializeAddress(addresses, "proxyAdmin", admin);
+        addressesOutput = vm.serializeAddress(addresses, "proxy", address(proxy));
+        addressesOutput = vm.serializeAddress(addresses, "implementation", address(groupMessagesImpl));
 
         string memory finalJson;
         finalJson = vm.serializeString(parent_object, addresses, addressesOutput);

--- a/contracts/script/DeployIdentityUpdates.s.sol
+++ b/contracts/script/DeployIdentityUpdates.s.sol
@@ -44,10 +44,10 @@ contract DeployIdentityUpdates is Script, Utils, Environment {
 
         string memory addressesOutput;
 
-        addressesOutput = vm.serializeAddress(addresses, "identityUpdatesDeployer", deployer);
-        addressesOutput = vm.serializeAddress(addresses, "identityUpdatesProxyAdmin", admin);
-        addressesOutput = vm.serializeAddress(addresses, "identityUpdatesProxy", address(proxy));
-        addressesOutput = vm.serializeAddress(addresses, "identityUpdatesImpl", address(idUpdatesImpl));
+        addressesOutput = vm.serializeAddress(addresses, "deployer", deployer);
+        addressesOutput = vm.serializeAddress(addresses, "proxyAdmin", admin);
+        addressesOutput = vm.serializeAddress(addresses, "proxy", address(proxy));
+        addressesOutput = vm.serializeAddress(addresses, "implementation", address(idUpdatesImpl));
 
         string memory finalJson;
         finalJson = vm.serializeString(parent_object, addresses, addressesOutput);

--- a/contracts/script/DeployNodeRegistry.s.sol
+++ b/contracts/script/DeployNodeRegistry.s.sol
@@ -34,15 +34,17 @@ contract DeployXMTPNodeRegistry is Script, Environment, Utils {
     function _serializeDeploymentData() internal {
         string memory parent_object = "parent object";
         string memory addresses = "addresses";
+        string memory constructorArgs = "constructorArgs";
 
         string memory addressesOutput;
+        addressesOutput = vm.serializeAddress(addresses, "deployer", deployer);
+        addressesOutput = vm.serializeAddress(addresses, "implementation", address(nodes));
 
-        addressesOutput = vm.serializeAddress(addresses, "XMTPNodeRegistryDeployer", deployer);
-        addressesOutput = vm.serializeAddress(addresses, "XMTPNodeRegistryInitialAdmin", admin);
-        addressesOutput = vm.serializeAddress(addresses, "XMTPNodeRegistry", address(nodes));
+        string memory constructorArgsOutput = vm.serializeAddress(constructorArgs, "initialAdmin", admin);
 
         string memory finalJson;
         finalJson = vm.serializeString(parent_object, addresses, addressesOutput);
+        finalJson = vm.serializeString(parent_object, constructorArgs, constructorArgsOutput);
         finalJson = vm.serializeUint(parent_object, "deploymentBlock", block.number);
         finalJson = vm.serializeUint(parent_object, "latestUpgradeBlock", block.number);
 

--- a/contracts/script/DeployNodeRegistry.s.sol
+++ b/contracts/script/DeployNodeRegistry.s.sol
@@ -46,7 +46,6 @@ contract DeployXMTPNodeRegistry is Script, Environment, Utils {
         finalJson = vm.serializeString(parent_object, addresses, addressesOutput);
         finalJson = vm.serializeString(parent_object, constructorArgs, constructorArgsOutput);
         finalJson = vm.serializeUint(parent_object, "deploymentBlock", block.number);
-        finalJson = vm.serializeUint(parent_object, "latestUpgradeBlock", block.number);
 
         writeOutput(finalJson, XMTP_NODE_REGISTRY_OUTPUT_JSON);
     }

--- a/contracts/script/DeployRatesManager.s.sol
+++ b/contracts/script/DeployRatesManager.s.sol
@@ -45,10 +45,10 @@ contract DeployRatesManager is Script, Utils, Environment {
 
         string memory addressesOutput;
 
-        addressesOutput = vm.serializeAddress(addresses, "ratesManagerDeployer", deployer);
-        addressesOutput = vm.serializeAddress(addresses, "ratesManagerProxyAdmin", admin);
-        addressesOutput = vm.serializeAddress(addresses, "ratesManagerProxy", address(proxy));
-        addressesOutput = vm.serializeAddress(addresses, "ratesManagerImpl", address(ratesManagerImpl));
+        addressesOutput = vm.serializeAddress(addresses, "deployer", deployer);
+        addressesOutput = vm.serializeAddress(addresses, "proxyAdmin", admin);
+        addressesOutput = vm.serializeAddress(addresses, "proxy", address(proxy));
+        addressesOutput = vm.serializeAddress(addresses, "implementation", address(ratesManagerImpl));
 
         string memory finalJson;
         finalJson = vm.serializeString(parent_object, addresses, addressesOutput);

--- a/contracts/script/upgrades/UpgradeGroupMessages.s.sol
+++ b/contracts/script/upgrades/UpgradeGroupMessages.s.sol
@@ -36,7 +36,7 @@ contract UpgradeGroupMessages is Script, Utils, Environment {
 
     function _initializeProxy() internal {
         string memory fileContent = readOutput(XMTP_GROUP_MESSAGES_OUTPUT_JSON);
-        proxy = GroupMessages(stdJson.readAddress(fileContent, ".addresses.groupMessagesProxy"));
+        proxy = GroupMessages(stdJson.readAddress(fileContent, ".addresses.proxy"));
         require(address(proxy) != address(0), "proxy address not set");
         require(proxy.hasRole(proxy.DEFAULT_ADMIN_ROLE(), upgrader), "Upgrader must have admin role");
     }
@@ -45,7 +45,7 @@ contract UpgradeGroupMessages is Script, Utils, Environment {
         vm.writeJson(
             vm.toString(address(newImplementation)),
             getOutputPath(XMTP_GROUP_MESSAGES_OUTPUT_JSON),
-            ".addresses.groupMessagesImpl"
+            ".addresses.implementation"
         );
         vm.writeJson(vm.toString(block.number), getOutputPath(XMTP_GROUP_MESSAGES_OUTPUT_JSON), ".latestUpgradeBlock");
     }

--- a/contracts/script/upgrades/UpgradeIdentityUpdates.s.sol
+++ b/contracts/script/upgrades/UpgradeIdentityUpdates.s.sol
@@ -36,7 +36,7 @@ contract UpgradeIdentityUpdates is Script, Utils, Environment {
 
     function _initializeProxy() internal {
         string memory fileContent = readOutput(XMTP_IDENTITY_UPDATES_OUTPUT_JSON);
-        proxy = IdentityUpdates(stdJson.readAddress(fileContent, ".addresses.identityUpdatesProxy"));
+        proxy = IdentityUpdates(stdJson.readAddress(fileContent, ".addresses.proxy"));
         require(address(proxy) != address(0), "proxy address not set");
         require(proxy.hasRole(proxy.DEFAULT_ADMIN_ROLE(), upgrader), "Upgrader must have admin role");
     }
@@ -45,7 +45,7 @@ contract UpgradeIdentityUpdates is Script, Utils, Environment {
         vm.writeJson(
             vm.toString(address(newImplementation)),
             getOutputPath(XMTP_IDENTITY_UPDATES_OUTPUT_JSON),
-            ".addresses.identityUpdatesImpl"
+            ".addresses.implementation"
         );
         vm.writeJson(vm.toString(block.number), getOutputPath(XMTP_IDENTITY_UPDATES_OUTPUT_JSON), ".latestUpgradeBlock");
     }

--- a/dev/baked/Dockerfile
+++ b/dev/baked/Dockerfile
@@ -29,9 +29,9 @@ RUN set -euo pipefail; \
     echo "Stopping anvil process..."; pkill -f anvil || { echo "⚠️ Warning: pkill anvil failed, continuing..."; }; \
     echo "Sleeping for 5 seconds..."; sleep 5
 
-RUN echo "export XMTPD_CONTRACTS_NODES_ADDRESS="$(jq -r '.addresses.XMTPNodeRegistry' contracts/config/anvil_localnet/XMTPNodeRegistry.json)"" >> contracts.env && \
-    echo "export XMTPD_CONTRACTS_MESSAGES_ADDRESS="$(jq -r '.addresses.groupMessagesProxy' contracts/config/anvil_localnet/GroupMessages.json)""  >> contracts.env && \
-    echo "export XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS="$(jq -r '.addresses.identityUpdatesProxy' contracts/config/anvil_localnet/IdentityUpdates.json)""  >> contracts.env
+RUN echo "export XMTPD_CONTRACTS_NODES_ADDRESS="$(jq -r '.addresses.implementation' contracts/config/anvil_localnet/XMTPNodeRegistry.json)"" >> contracts.env && \
+    echo "export XMTPD_CONTRACTS_MESSAGES_ADDRESS="$(jq -r '.addresses.proxy' contracts/config/anvil_localnet/GroupMessages.json)""  >> contracts.env && \
+    echo "export XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS="$(jq -r '.addresses.proxy' contracts/config/anvil_localnet/IdentityUpdates.json)""  >> contracts.env
 
 # ACTUAL IMAGE -------------------------------------------------------
 

--- a/dev/local.env
+++ b/dev/local.env
@@ -12,11 +12,11 @@ export XMTPD_DB_WRITER_CONNECTION_STRING="postgres://postgres:xmtp@localhost:876
 
 # Contract Options
 export XMTPD_CONTRACTS_RPC_URL=$RPC_URL  # From contracts/dev/lib/env
-XMTPD_CONTRACTS_NODES_ADDRESS="$(jq -r '.addresses.XMTPNodeRegistry' ${ANVIL_SCRIPTS_OUTPUT}/XMTPNodeRegistry.json)" # Built by contracts/dev/deploy local
+XMTPD_CONTRACTS_NODES_ADDRESS="$(jq -r '.addresses.implementation' ${ANVIL_SCRIPTS_OUTPUT}/XMTPNodeRegistry.json)" # Built by contracts/dev/deploy local
 export XMTPD_CONTRACTS_NODES_ADDRESS
-XMTPD_CONTRACTS_MESSAGES_ADDRESS="$(jq -r '.addresses.groupMessagesProxy' ${ANVIL_SCRIPTS_OUTPUT}/GroupMessages.json)" # Built by contracts/dev/deploy local
+XMTPD_CONTRACTS_MESSAGES_ADDRESS="$(jq -r '.addresses.proxy' ${ANVIL_SCRIPTS_OUTPUT}/GroupMessages.json)" # Built by contracts/dev/deploy local
 export XMTPD_CONTRACTS_MESSAGES_ADDRESS
-XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS="$(jq -r '.addresses.identityUpdatesProxy' ${ANVIL_SCRIPTS_OUTPUT}/IdentityUpdates.json)" # Built by contracts/dev/deploy local
+XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS="$(jq -r '.addresses.proxy' ${ANVIL_SCRIPTS_OUTPUT}/IdentityUpdates.json)" # Built by contracts/dev/deploy local
 export XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS
 
 export ANVIL_ACC_1_PRIVATE_KEY="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -44,27 +43,16 @@ func rootPath(t *testing.T) string {
 
 /*
 *
-Parse the JSON file at this location to get the deployed contract proxy address
+Parse the JSON file at this location to get the deployed contract address.
 *
 */
-func getContractAddress(t *testing.T, fileName string) string {
+func getContractAddress(t *testing.T, fileName string, key string) string {
 	data, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("Failed to read json: %v", err)
 	}
 
-	switch {
-	case strings.Contains(fileName, "GroupMessages.json"):
-		return fastjson.GetString(data, "addresses", "groupMessagesProxy")
-	case strings.Contains(fileName, "IdentityUpdates.json"):
-		return fastjson.GetString(data, "addresses", "identityUpdatesProxy")
-	case strings.Contains(fileName, "XMTPNodeRegistry.json"):
-		return fastjson.GetString(data, "addresses", "XMTPNodeRegistry")
-	case strings.Contains(fileName, "RatesManager.json"):
-		return fastjson.GetString(data, "addresses", "ratesManagerProxy")
-	default:
-		return ""
-	}
+	return fastjson.GetString(data, "addresses", key)
 }
 
 func GetContractsOptions(t *testing.T) config.ContractsOptions {
@@ -75,18 +63,22 @@ func GetContractsOptions(t *testing.T) config.ContractsOptions {
 		MessagesContractAddress: getContractAddress(
 			t,
 			path.Join(rootDir, "./contracts/config/anvil_localnet/GroupMessages.json"),
+			"proxy",
 		),
 		NodesContractAddress: getContractAddress(
 			t,
 			path.Join(rootDir, "./contracts/config/anvil_localnet/XMTPNodeRegistry.json"),
+			"implementation",
 		),
 		IdentityUpdatesContractAddress: getContractAddress(
 			t,
 			path.Join(rootDir, "./contracts/config/anvil_localnet/IdentityUpdates.json"),
+			"proxy",
 		),
 		RatesManagerContractAddress: getContractAddress(
 			t,
 			path.Join(rootDir, "./contracts/config/anvil_localnet/RatesManager.json"),
+			"proxy",
 		),
 		RegistryRefreshInterval: 100 * time.Millisecond,
 		RatesRefreshInterval:    100 * time.Millisecond,


### PR DESCRIPTION
Use standard naming for contract deployment JSON files.
Start using constructorArgs section for contracts that requires constructor args.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**  
  - Standardized naming in serialized output for addresses across deployments and upgrades, ensuring a more consistent structure.

- **Chore**  
  - Updated environment configurations and address retrieval processes to streamline deployment and integration workflows.  
  - Adjusted extraction of contract addresses in environment files to reference updated JSON fields.  
  - Simplified address retrieval methods in testing utilities for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->