### PR TITLE
Calculate congestion from last 5 minutes of data

### DIFF
--- a/pkg/fees/congestion.go
+++ b/pkg/fees/congestion.go
@@ -1,0 +1,79 @@
+package fees
+
+import "math"
+
+const (
+	// At this point, always return congestion as 100%
+	MAX_CONGESTION_RATIO = 1.5
+)
+
+/*
+*
+The algorithm for calculating congestion is as follows:
+
+1) Compute the average number of messages per minute, excluding the current minute which may be incomplete
+2) Take the greater of: the current minute's rate, the previous minute's rate, or the preceding 4 minute average
+3) Compute the ratio of the max rate to the target rate
+4) If the ratio is less than or equal to 1, return 0
+5) If the ratio is greater than MAX_CONGESTION_RATIO, return 100
+6) Otherwise, return the congestion as an exponential function of the ratio
+*
+*/
+func CalculateCongestion(last5Minutes [5]int64, targetRatePerMinute int64) int64 {
+	// If the target rate is 0, return 0
+	if targetRatePerMinute == 0 {
+		return 0
+	}
+
+	currentMinute := last5Minutes[0]
+	prevMinute := last5Minutes[1]
+
+	// 1) Compute the average congestion, excluding the current minute which may be incomplete
+	fourMinuteAverage := calculateFourMinuteAverage(last5Minutes)
+
+	// 2) Determine if congestion must be 0:
+	//    Congestion is 0 only if both the current and previous minute
+	//    are not above target AND the 4-minute average is not above target.
+	if currentMinute <= targetRatePerMinute && prevMinute <= targetRatePerMinute &&
+		fourMinuteAverage <= targetRatePerMinute {
+		return 0
+	}
+
+	// 3) Compute the ratio = max(current, previous, 4-min avg) / T
+	ratio := math.Max(
+		float64(currentMinute),
+		math.Max(float64(prevMinute), float64(fourMinuteAverage)),
+	) / float64(
+		targetRatePerMinute,
+	)
+
+	// 4) If ratio <= 1, effectively no excess above T
+	//    (In practice, if we reached here, ratio should be >= 1.)
+	if ratio <= 1 {
+		return 0
+	}
+
+	// 5) If ratio >= MAX_CONGESTION_RATIO => congestion = 100
+	if ratio >= MAX_CONGESTION_RATIO {
+		return 100
+	}
+
+	// 6) Exponential mapping for 1 < ratio < MAX_CONGESTION_RATIO
+	//    - ratio=1   => 0
+	//    - ratio=MAX_CONGESTION_RATIO => 100
+	//    - Grows exponentially in between
+	k := 4.0 // Adjust k to tune how fast congestion rises
+	numerator := math.Exp(k*(ratio-1.0)) - 1.0
+	denominator := math.Exp(k*(MAX_CONGESTION_RATIO-1.0)) - 1.0
+	congestion := 100.0 * (numerator / denominator)
+
+	return int64(congestion)
+}
+
+func calculateFourMinuteAverage(last5Minutes [5]int64) int64 {
+	// Apply weights that decrease with recency (index 1 is most recent, index 4 is oldest)
+	// Weight distribution: 40%, 30%, 20%, 10%
+	weightedSum := last5Minutes[1]*4 + last5Minutes[2]*3 + last5Minutes[3]*2 + last5Minutes[4]*1
+	totalWeight := int64(10) // sum of weights: 4+3+2+1
+	return weightedSum / totalWeight
+}

--- a/pkg/fees/congestion_test.go
+++ b/pkg/fees/congestion_test.go
@@ -1,0 +1,56 @@
+package fees
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const EXPECTED_CONGESTION_FOR_125 = int64(26)
+
+func TestCalculateAverageCongestion(t *testing.T) {
+	rates := [5]int64{125, 100, 100, 100, 100}
+	targetRate := int64(100)
+
+	congestion := CalculateCongestion(rates, targetRate)
+	assert.Equal(t, EXPECTED_CONGESTION_FOR_125, congestion)
+}
+
+func TestCurrentMinuteCongestion(t *testing.T) {
+	rates := [5]int64{125, 0, 0, 0, 0}
+	targetRate := int64(100)
+
+	congestion := CalculateCongestion(rates, targetRate)
+	assert.Equal(t, EXPECTED_CONGESTION_FOR_125, congestion)
+}
+
+func TestPreviousMinuteCongestion(t *testing.T) {
+	rates := [5]int64{0, 125, 0, 0, 0}
+	targetRate := int64(100)
+
+	congestion := CalculateCongestion(rates, targetRate)
+	assert.Equal(t, EXPECTED_CONGESTION_FOR_125, congestion)
+}
+
+func TestFourMinuteAverageCongestion(t *testing.T) {
+	rates := [5]int64{0, 0, 400, 0, 0}
+	targetRate := int64(100)
+
+	congestion := CalculateCongestion(rates, targetRate)
+	assert.Equal(t, int64(19), congestion)
+}
+
+func TestTargetRateZero(t *testing.T) {
+	rates := [5]int64{100, 100, 100, 100, 100}
+	targetRate := int64(0)
+
+	congestion := CalculateCongestion(rates, targetRate)
+	assert.Equal(t, int64(0), congestion)
+}
+
+func TestWeightedAverage(t *testing.T) {
+	rates := [5]int64{100, 100, 100, 100, 200}
+
+	average := calculateFourMinuteAverage(rates)
+	assert.Equal(t, int64(110), average)
+}


### PR DESCRIPTION
### TL;DR
Introduces a new congestion calculation package that determines system congestion based on request rates over time.

### What changed?
- Added new `congestion` package with core calculation logic
- Implemented exponential mapping algorithm for congestion calculation between 0-100%
- Added comprehensive test coverage for various congestion scenarios
- Set maximum congestion ratio at 1.5x the target rate
- Included logic to analyze current minute, previous minute, and 4-minute average rates

### How to test?
Run the test suite which covers multiple scenarios:
- Average congestion calculation
- Current minute congestion
- Previous minute congestion
- Four-minute average congestion
- Verify expected congestion value of 26 when rate is 125% of target

### Why make this change?
To provide a standardized way of calculating system congestion that:
- Gives early warning when system load approaches critical levels
- Uses exponential scaling to reflect increasing severity of congestion
- Considers both immediate and historical load patterns
- Provides a normalized 0-100% congestion score for easier monitoring and alerting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to calculate congestion levels dynamically based on recent messaging activity and target thresholds.
- **Tests**
	- Added comprehensive tests that validate accurate congestion determinations across different message volume scenarios, including zero activity and fluctuating messaging rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->