### PR TITLE
Utility to get most recent 5 minutes of congestion

### DIFF
--- a/pkg/db/congestion.go
+++ b/pkg/db/congestion.go
@@ -1,0 +1,36 @@
+package db
+
+import (
+	"context"
+
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+)
+
+// Gets the congestion for the minute specified by `endMinute` and the previous 4 minutes
+// returned in descending order with missing values filled with 0
+func Get5MinutesOfCongestion(
+	ctx context.Context,
+	querier *queries.Queries,
+	originatorID, endMinute int32,
+) (out [5]int32, err error) {
+	var congestion []queries.GetRecentOriginatorCongestionRow
+	congestion, err = querier.GetRecentOriginatorCongestion(
+		ctx,
+		queries.GetRecentOriginatorCongestionParams{
+			OriginatorID: originatorID,
+			EndMinute:    endMinute,
+			NumMinutes:   5,
+		},
+	)
+
+	if err != nil {
+		return out, err
+	}
+
+	for _, congestion := range congestion {
+		idx := endMinute - congestion.MinutesSinceEpoch
+		out[idx] = congestion.NumMessages
+	}
+
+	return out, nil
+}

--- a/pkg/db/congestion_test.go
+++ b/pkg/db/congestion_test.go
@@ -1,0 +1,89 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/db"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+)
+
+func setupTest(t *testing.T) (context.Context, *queries.Queries, func()) {
+	ctx := context.Background()
+	db, _, cleanup := testutils.NewDB(t, ctx)
+
+	querier := queries.New(db)
+
+	return ctx, querier, cleanup
+}
+
+func incrementCongestion(
+	t *testing.T,
+	ctx context.Context,
+	querier *queries.Queries,
+	originatorID, minutesSinceEpoch int32,
+) {
+	err := querier.IncrementOriginatorCongestion(ctx, queries.IncrementOriginatorCongestionParams{
+		OriginatorID:      originatorID,
+		MinutesSinceEpoch: minutesSinceEpoch,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestGet5MinutesOfCongestion(t *testing.T) {
+	ctx, querier, cleanup := setupTest(t)
+	defer cleanup()
+
+	originatorID := testutils.RandomInt32()
+	endMinute := testutils.RandomInt32()
+
+	incrementCongestion(t, ctx, querier, originatorID, endMinute-1)
+	incrementCongestion(t, ctx, querier, originatorID, endMinute-2)
+	incrementCongestion(t, ctx, querier, originatorID, endMinute-10)
+
+	congestion, err := db.Get5MinutesOfCongestion(ctx, querier, originatorID, endMinute)
+	require.NoError(t, err)
+
+	require.Equal(t, congestion[0], int32(0))
+	require.Equal(t, congestion[1], int32(1))
+	require.Equal(t, congestion[2], int32(1))
+	require.Equal(t, congestion[3], int32(0))
+	require.Equal(t, congestion[4], int32(0))
+}
+
+func TestMultipleIncrements(t *testing.T) {
+	ctx, querier, cleanup := setupTest(t)
+	defer cleanup()
+
+	originatorID := testutils.RandomInt32()
+	endMinute := testutils.RandomInt32()
+
+	incrementCongestion(t, ctx, querier, originatorID, endMinute)
+	incrementCongestion(t, ctx, querier, originatorID, endMinute)
+	incrementCongestion(t, ctx, querier, originatorID, endMinute)
+
+	congestion, err := db.Get5MinutesOfCongestion(ctx, querier, originatorID, endMinute)
+	require.NoError(t, err)
+
+	require.Equal(t, congestion[0], int32(3))
+	require.Equal(t, congestion[1], int32(0))
+	require.Equal(t, congestion[2], int32(0))
+	require.Equal(t, congestion[3], int32(0))
+	require.Equal(t, congestion[4], int32(0))
+}
+
+func TestNoCongestion(t *testing.T) {
+	ctx, querier, cleanup := setupTest(t)
+	defer cleanup()
+
+	originatorID := testutils.RandomInt32()
+	endMinute := testutils.RandomInt32()
+
+	congestion, err := db.Get5MinutesOfCongestion(ctx, querier, originatorID, endMinute)
+	require.NoError(t, err)
+
+	require.Equal(t, congestion, [5]int32{0, 0, 0, 0, 0})
+}

--- a/pkg/db/gatewayEnvelope_test.go
+++ b/pkg/db/gatewayEnvelope_test.go
@@ -66,9 +66,9 @@ func TestInsertAndIncrement(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, payerSpend, int64(100))
 
-	originatorCongestion, err := querier.GetOriginatorCongestion(
+	originatorCongestion, err := querier.SumOriginatorCongestion(
 		ctx,
-		queries.GetOriginatorCongestionParams{OriginatorID: originatorID},
+		queries.SumOriginatorCongestionParams{OriginatorID: originatorID},
 	)
 	require.NoError(t, err)
 	require.Equal(t, originatorCongestion, int64(1))
@@ -140,9 +140,9 @@ func TestInsertAndIncrementParallel(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, payerSpend, int64(100))
 
-	originatorCongestion, err := querier.GetOriginatorCongestion(
+	originatorCongestion, err := querier.SumOriginatorCongestion(
 		ctx,
-		queries.GetOriginatorCongestionParams{OriginatorID: originatorID},
+		queries.SumOriginatorCongestionParams{OriginatorID: originatorID},
 	)
 	require.NoError(t, err)
 	require.Equal(t, originatorCongestion, int64(1))

--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -238,7 +238,20 @@ ON CONFLICT (originator_id, minutes_since_epoch)
 	DO UPDATE SET
 		num_messages = originator_congestion.num_messages + 1;
 
--- name: GetOriginatorCongestion :one
+
+-- name: GetRecentOriginatorCongestion :many
+SELECT 
+	minutes_since_epoch,
+	num_messages
+FROM
+	originator_congestion
+WHERE
+	originator_id = $1
+	AND minutes_since_epoch <= sqlc.arg(end_minute)::INT
+	AND minutes_since_epoch > sqlc.arg(end_minute)::INT - sqlc.arg(num_minutes)::INT
+ORDER BY minutes_since_epoch DESC;
+
+-- name: SumOriginatorCongestion :one
 SELECT
 	COALESCE(SUM(num_messages), 0)::BIGINT AS num_messages
 FROM
@@ -249,4 +262,3 @@ WHERE
 		OR minutes_since_epoch > @minutes_since_epoch_gt::BIGINT)
 	AND (@minutes_since_epoch_lt::BIGINT = 0
 		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT);
-


### PR DESCRIPTION
## tl;dr

- Simple utility function to get the last 5 minutes of congestion for an originator in the format expected by the `CalculateCongestion` function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced congestion monitoring now provides real-time metrics covering the past five minutes, giving users clearer insights into activity levels.

- **Bug Fixes**
  - Improved handling of scenarios where no congestion is recorded, ensuring accurate reporting of zero values.

- **Refactor**
  - Streamlined data aggregation and query processing to improve the accuracy and reliability of congestion statistics.

- **Tests**
  - Expanded test coverage with new tests for recent congestion retrieval, handling multiple increments, and scenarios with no congestion, ensuring robust validation of congestion data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->