### PR TITLE
Use real congestion rates

### DIFF
--- a/pkg/api/message/publishWorker.go
+++ b/pkg/api/message/publishWorker.go
@@ -207,11 +207,14 @@ func (p *publishWorker) calculateFees(
 		return 0, 0, err
 	}
 
+	q := queries.New(p.store)
 	// TODO:nm: Set this to the actual congestion fee
 	// For now we are setting congestion to 0
 	congestionFee, err := p.feeCalculator.CalculateCongestionFee(
+		p.ctx,
+		q,
 		stagedEnv.OriginatorTime,
-		0,
+		p.registrant.NodeID(),
 	)
 
 	if err != nil {

--- a/pkg/fees/calculator_test.go
+++ b/pkg/fees/calculator_test.go
@@ -1,28 +1,54 @@
 package fees
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/currency"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/utils"
 )
 
 const (
-	RATE_MESSAGE_FEE    = 100
-	RATE_STORAGE_FEE    = 50
-	RATE_CONGESTION_FEE = 200
+	RATE_MESSAGE_FEE       = 100
+	RATE_STORAGE_FEE       = 50
+	RATE_CONGESTION_FEE    = 200
+	TARGET_RATE_PER_MINUTE = 4
 )
 
 func setupCalculator() *FeeCalculator {
 	rates := &Rates{
-		MessageFee:    RATE_MESSAGE_FEE,
-		StorageFee:    RATE_STORAGE_FEE,
-		CongestionFee: RATE_CONGESTION_FEE,
+		MessageFee:          RATE_MESSAGE_FEE,
+		StorageFee:          RATE_STORAGE_FEE,
+		CongestionFee:       RATE_CONGESTION_FEE,
+		TargetRatePerMinute: TARGET_RATE_PER_MINUTE,
 	}
 	ratesFetcher := NewFixedRatesFetcher(rates)
 	return NewFeeCalculator(ratesFetcher)
+}
+
+func addCongestion(
+	t *testing.T,
+	querier *queries.Queries,
+	originatorID uint32,
+	minutesSinceEpoch int32,
+	congestion int,
+) {
+	for range congestion {
+		err := querier.IncrementOriginatorCongestion(
+			context.Background(),
+			queries.IncrementOriginatorCongestionParams{
+				OriginatorID:      int32(originatorID),
+				MinutesSinceEpoch: minutesSinceEpoch,
+			},
+		)
+
+		require.NoError(t, err)
+	}
 }
 
 func TestCalculateBaseFee(t *testing.T) {
@@ -41,15 +67,25 @@ func TestCalculateBaseFee(t *testing.T) {
 
 func TestCalculateCongestionFee(t *testing.T) {
 	calculator := setupCalculator()
+	db, _, cleanup := testutils.NewDB(t, context.Background())
+	defer cleanup()
 
+	ctx := context.Background()
+	querier := queries.New(db)
+	originatorID := uint32(testutils.RandomInt32())
 	messageTime := time.Now()
-	congestionPercent := int64(50)
+	minutesSinceEpoch := utils.MinutesSinceEpoch(messageTime)
 
-	congestionFee, err := calculator.CalculateCongestionFee(messageTime, congestionPercent)
+	// Should return 0 if no congestion
+	congestionFee, err := calculator.CalculateCongestionFee(ctx, querier, messageTime, originatorID)
 	require.NoError(t, err)
+	require.Equal(t, currency.PicoDollar(0), congestionFee)
 
-	expectedFee := RATE_CONGESTION_FEE * congestionPercent
-	require.Equal(t, currency.PicoDollar(expectedFee), congestionFee)
+	// Congestion rate is 100 because this is double the max
+	addCongestion(t, querier, originatorID, minutesSinceEpoch, 8)
+	congestionFee, err = calculator.CalculateCongestionFee(ctx, querier, messageTime, originatorID)
+	require.NoError(t, err)
+	require.Equal(t, currency.PicoDollar(20000), congestionFee)
 }
 
 func TestOverflow(t *testing.T) {
@@ -68,18 +104,4 @@ func TestOverflow(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "storage fee calculation overflow")
-}
-
-func TestInvalidCongestionPercent(t *testing.T) {
-	calculator := setupCalculator()
-
-	messageTime := time.Now()
-
-	_, err := calculator.CalculateCongestionFee(messageTime, int64(101))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "congestionPercent must be between 0 and 100")
-
-	_, err = calculator.CalculateCongestionFee(messageTime, int64(-1))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "congestionPercent must be between 0 and 100")
 }

--- a/pkg/fees/congestion.go
+++ b/pkg/fees/congestion.go
@@ -19,7 +19,7 @@ The algorithm for calculating congestion is as follows:
 6) Otherwise, return the congestion as an exponential function of the ratio
 *
 */
-func CalculateCongestion(last5Minutes [5]int64, targetRatePerMinute int64) int64 {
+func CalculateCongestion(last5Minutes [5]int32, targetRatePerMinute int32) int32 {
 	// If the target rate is 0, return 0
 	if targetRatePerMinute == 0 {
 		return 0
@@ -67,13 +67,13 @@ func CalculateCongestion(last5Minutes [5]int64, targetRatePerMinute int64) int64
 	denominator := math.Exp(k*(MAX_CONGESTION_RATIO-1.0)) - 1.0
 	congestion := 100.0 * (numerator / denominator)
 
-	return int64(congestion)
+	return int32(congestion)
 }
 
-func calculateFourMinuteAverage(last5Minutes [5]int64) int64 {
+func calculateFourMinuteAverage(last5Minutes [5]int32) int32 {
 	// Apply weights that decrease with recency (index 1 is most recent, index 4 is oldest)
 	// Weight distribution: 40%, 30%, 20%, 10%
 	weightedSum := last5Minutes[1]*4 + last5Minutes[2]*3 + last5Minutes[3]*2 + last5Minutes[4]*1
-	totalWeight := int64(10) // sum of weights: 4+3+2+1
+	totalWeight := int32(10) // sum of weights: 4+3+2+1
 	return weightedSum / totalWeight
 }

--- a/pkg/fees/congestion_test.go
+++ b/pkg/fees/congestion_test.go
@@ -6,51 +6,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const EXPECTED_CONGESTION_FOR_125 = int64(26)
+const EXPECTED_CONGESTION_FOR_125 = int32(26)
 
 func TestCalculateAverageCongestion(t *testing.T) {
-	rates := [5]int64{125, 100, 100, 100, 100}
-	targetRate := int64(100)
+	rates := [5]int32{125, 100, 100, 100, 100}
+	targetRate := int32(100)
 
 	congestion := CalculateCongestion(rates, targetRate)
 	assert.Equal(t, EXPECTED_CONGESTION_FOR_125, congestion)
 }
 
 func TestCurrentMinuteCongestion(t *testing.T) {
-	rates := [5]int64{125, 0, 0, 0, 0}
-	targetRate := int64(100)
+	rates := [5]int32{125, 0, 0, 0, 0}
+	targetRate := int32(100)
 
 	congestion := CalculateCongestion(rates, targetRate)
 	assert.Equal(t, EXPECTED_CONGESTION_FOR_125, congestion)
 }
 
 func TestPreviousMinuteCongestion(t *testing.T) {
-	rates := [5]int64{0, 125, 0, 0, 0}
-	targetRate := int64(100)
+	rates := [5]int32{0, 125, 0, 0, 0}
+	targetRate := int32(100)
 
 	congestion := CalculateCongestion(rates, targetRate)
 	assert.Equal(t, EXPECTED_CONGESTION_FOR_125, congestion)
 }
 
 func TestFourMinuteAverageCongestion(t *testing.T) {
-	rates := [5]int64{0, 0, 400, 0, 0}
-	targetRate := int64(100)
+	rates := [5]int32{0, 0, 400, 0, 0}
+	targetRate := int32(100)
 
 	congestion := CalculateCongestion(rates, targetRate)
-	assert.Equal(t, int64(19), congestion)
+	assert.Equal(t, int32(19), congestion)
 }
 
 func TestTargetRateZero(t *testing.T) {
-	rates := [5]int64{100, 100, 100, 100, 100}
-	targetRate := int64(0)
+	rates := [5]int32{100, 100, 100, 100, 100}
+	targetRate := int32(0)
 
 	congestion := CalculateCongestion(rates, targetRate)
-	assert.Equal(t, int64(0), congestion)
+	assert.Equal(t, int32(0), congestion)
 }
 
 func TestWeightedAverage(t *testing.T) {
-	rates := [5]int64{100, 100, 100, 100, 200}
+	rates := [5]int32{100, 100, 100, 100, 200}
 
 	average := calculateFourMinuteAverage(rates)
-	assert.Equal(t, int64(110), average)
+	assert.Equal(t, int32(110), average)
 }

--- a/pkg/fees/interface.go
+++ b/pkg/fees/interface.go
@@ -1,9 +1,11 @@
 package fees
 
 import (
+	"context"
 	"time"
 
 	"github.com/xmtp/xmtpd/pkg/currency"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
 )
 
 // Rates containt the cost for each fee component at a given message time.
@@ -28,7 +30,9 @@ type IFeeCalculator interface {
 		storageDurationDays int64,
 	) (currency.PicoDollar, error)
 	CalculateCongestionFee(
+		ctx context.Context,
+		querier *queries.Queries,
 		messageTime time.Time,
-		congestionUnits int64,
+		originatorID uint32,
 	) (currency.PicoDollar, error)
 }

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -514,8 +514,12 @@ func (s *syncWorker) calculateFees(env *envUtils.OriginatorEnvelope) (currency.P
 		return 0, err
 	}
 
-	// TODO:(nm) Calculate real rate of congestion
-	congestionFee, err := s.feeCalculator.CalculateCongestionFee(messageTime, 0)
+	congestionFee, err := s.feeCalculator.CalculateCongestionFee(
+		s.ctx,
+		queries.New(s.store),
+		messageTime,
+		env.OriginatorNodeID(),
+	)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## tl;dr

- Updates the interface for the `FeeCalculator` to take in a DB and context
- Gets data from the DB and uses it to calculate the real rate of congestion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced congestion fee calculations now integrate real-time context and dynamic data inputs, aiming for more precise fee assessments that better reflect current network conditions.

- **Bug Fixes**
  - Adjustments made to error handling for congestion data retrieval, ensuring robust responses during failures.

- **Tests**
  - Updated test scenarios now simulate congestion behavior more accurately, with new constants and helper routines introduced while retiring outdated validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->