### PR TITLE
More nonce improvements

### DIFF
--- a/pkg/blockchain/blockchainPublisher.go
+++ b/pkg/blockchain/blockchainPublisher.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/xmtp/xmtpd/pkg/tracing"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"math/big"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -228,14 +228,6 @@ func findLog[T any](
 	return nil, errors.New(errorMsg)
 }
 
-func randomSleep(maxDuration time.Duration) {
-	if maxDuration <= 0 {
-		return // No sleep if duration is invalid
-	}
-	randDuration := time.Duration(rand.Float64() * float64(maxDuration))
-	time.Sleep(randDuration)
-}
-
 func withNonce[T any](ctx context.Context,
 	logger *zap.Logger,
 	nonceManager NonceManager,
@@ -286,7 +278,7 @@ func withNonce[T any](ctx context.Context,
 					zap.Uint64("nonce", nonce.Uint64()),
 					zap.Error(err),
 				)
-				randomSleep(500 * time.Millisecond)
+				utils.RandomSleep(ctx, 500*time.Millisecond)
 				nonceContext.Cancel()
 				continue
 			}

--- a/pkg/blockchain/ratesAdmin_test.go
+++ b/pkg/blockchain/ratesAdmin_test.go
@@ -44,7 +44,12 @@ func TestAddRates(t *testing.T) {
 		StartTime:     1000,
 	}
 
-	err := ratesAdmin.AddRates(context.Background(), rates)
+	var err error
+
+	require.Eventually(t, func() bool {
+		err = ratesAdmin.AddRates(context.Background(), rates)
+		return err == nil
+	}, 500*time.Millisecond, 50*time.Millisecond)
 	require.NoError(t, err)
 
 	var returnedRates struct {

--- a/pkg/utils/sleep.go
+++ b/pkg/utils/sleep.go
@@ -1,10 +1,20 @@
 package utils
 
 import (
+	"context"
 	"math/rand"
 	"time"
 )
 
-func RandomSleep(maxTimeMs int) {
-	time.Sleep(time.Millisecond * time.Duration(rand.Intn(maxTimeMs)))
+func RandomSleep(ctx context.Context, maxDuration time.Duration) {
+	if maxDuration <= 0 {
+		return // No sleep if duration is invalid
+	}
+	randDuration := time.Duration(rand.Float64() * float64(maxDuration))
+
+	select {
+	case <-time.After(randDuration):
+	case <-ctx.Done():
+		return
+	}
 }


### PR DESCRIPTION
When hammering our alchemy node in testnet, I noticed a bunch of issues that weren't seen in the local test development.

1) "nonce too high" - it usually indicates that the mempool is too full.
- gracefully hide the error from the caller if it does get hit
- prevent it from happening as often by limiting the concurrent number of transactions in flight

2) https://github.com/xmtp/xmtpd/issues/624
- Added a few tests that are useful, but dont fix 624

3) drive-by fix of TestAddRates

Otherwise HA payer works perfectly.

Closes #423 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a delay mechanism that gracefully handles transient operational issues, contributing to smoother transaction processing.
	- Enhanced concurrent request management to improve performance and stability during simultaneous operations.
- **Tests**
	- Added new tests to verify the resilience and robustness of concurrent operations under load.
	- Improved error handling in tests to manage transient failures more effectively, including a retry mechanism for certain operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->