### PR TITLE
Update tests to use local anvil

### DIFF
--- a/pkg/blockchain/ratesAdmin.go
+++ b/pkg/blockchain/ratesAdmin.go
@@ -82,3 +82,7 @@ func (r *RatesAdmin) AddRates(
 
 	return err
 }
+
+func (r *RatesAdmin) Contract() *ratesmanager.RatesManager {
+	return r.contract
+}

--- a/pkg/blockchain/registryCaller_test.go
+++ b/pkg/blockchain/registryCaller_test.go
@@ -1,4 +1,4 @@
-package blockchain
+package blockchain_test
 
 import (
 	"testing"

--- a/pkg/blockchain/rpcLogStreamer_test.go
+++ b/pkg/blockchain/rpcLogStreamer_test.go
@@ -2,11 +2,13 @@ package blockchain_test
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum"
-	"github.com/xmtp/xmtpd/pkg/blockchain"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/xmtp/xmtpd/pkg/blockchain"
+	"github.com/xmtp/xmtpd/pkg/testutils/anvil"
 
 	mocks "github.com/xmtp/xmtpd/pkg/mocks/blockchain"
 	"github.com/xmtp/xmtpd/pkg/testutils"
@@ -43,9 +45,11 @@ func buildStreamer(
 }
 
 func TestBuilder(t *testing.T) {
+	rpcUrl, anvilCleanup := anvil.StartAnvil(t, false)
+	t.Cleanup(anvilCleanup)
 	testclient, err := blockchain.NewClient(
 		context.Background(),
-		testutils.GetContractsOptions(t).RpcUrl,
+		rpcUrl,
 	)
 	require.NoError(t, err)
 	builder := blockchain.NewRpcLogStreamBuilder(

--- a/pkg/indexer/e2e_test.go
+++ b/pkg/indexer/e2e_test.go
@@ -3,9 +3,11 @@ package indexer_test
 import (
 	"context"
 	"database/sql"
-	"github.com/xmtp/xmtpd/pkg/indexer"
 	"testing"
 	"time"
+
+	"github.com/xmtp/xmtpd/pkg/config"
+	"github.com/xmtp/xmtpd/pkg/indexer"
 
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
@@ -13,23 +15,32 @@ import (
 	"github.com/xmtp/xmtpd/pkg/envelopes"
 	"github.com/xmtp/xmtpd/pkg/mocks/mlsvalidate"
 	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/testutils/anvil"
 	envelopesTestUtils "github.com/xmtp/xmtpd/pkg/testutils/envelopes"
 	"github.com/xmtp/xmtpd/pkg/topic"
 	"google.golang.org/protobuf/proto"
 )
 
-func startIndexing(t *testing.T) (*sql.DB, *queries.Queries, context.Context, func()) {
+func startIndexing(
+	t *testing.T,
+) (*sql.DB, *queries.Queries, config.ContractsOptions, context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger := testutils.NewLog(t)
 	db, _, cleanup := testutils.NewDB(t, ctx)
-	cfg := testutils.GetContractsOptions(t)
+
+	rpcUrl, anvilCleanup := anvil.StartAnvil(t, false)
+	cfg := testutils.NewContractsOptions(rpcUrl)
+	cfg.MessagesContractAddress = testutils.DeployGroupMessagesContract(t, rpcUrl)
+	cfg.IdentityUpdatesContractAddress = testutils.DeployIdentityUpdatesContract(t, rpcUrl)
+
 	validationService := mlsvalidate.NewMockMLSValidationService(t)
 
 	indx := indexer.NewIndexer(ctx, logger)
 	err := indx.StartIndexer(db, cfg, validationService)
 	require.NoError(t, err)
 
-	return db, queries.New(db), ctx, func() {
+	return db, queries.New(db), cfg, ctx, func() {
+		defer anvilCleanup()
 		cleanup()
 		cancel()
 	}
@@ -39,9 +50,9 @@ func messagePublisher(
 	t *testing.T,
 	ctx context.Context,
 	db *sql.DB,
+	contractsCfg config.ContractsOptions,
 ) *blockchain.BlockchainPublisher {
 	payerCfg := testutils.GetPayerOptions(t)
-	contractsCfg := testutils.GetContractsOptions(t)
 	var signer blockchain.TransactionSigner
 	signer, err := blockchain.NewPrivateKeySigner(payerCfg.PrivateKey, contractsCfg.ChainID)
 	require.NoError(t, err)
@@ -65,8 +76,8 @@ func messagePublisher(
 }
 
 func TestStoreMessages(t *testing.T) {
-	db, querier, ctx, cleanup := startIndexing(t)
-	publisher := messagePublisher(t, ctx, db)
+	db, querier, cfg, ctx, cleanup := startIndexing(t)
+	publisher := messagePublisher(t, ctx, db, cfg)
 	defer cleanup()
 
 	message := testutils.RandomBytes(78)

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -1,14 +1,9 @@
 package testutils
 
 import (
-	"os"
-	"path"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-	"github.com/valyala/fastjson"
 	"github.com/xmtp/xmtpd/pkg/config"
 )
 
@@ -18,68 +13,9 @@ const BLOCKCHAIN_RPC_URL = "http://localhost:7545"
 // This is safe to commit
 const TEST_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
-/*
-*
-In tests it's weirdly difficult to get the working directory of the project root.
-
-Keep moving up the folder hierarchy until you find a go.mod
-*
-*/
-func rootPath(t *testing.T) string {
-	dir, err := os.Getwd()
-	require.NoError(t, err)
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir { // reached the root directory
-			t.Fatal("Could not find the root directory")
-		}
-		dir = parent
-	}
-}
-
-/*
-*
-Parse the JSON file at this location to get the deployed contract address.
-*
-*/
-func getContractAddress(t *testing.T, fileName string, key string) string {
-	data, err := os.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("Failed to read json: %v", err)
-	}
-
-	return fastjson.GetString(data, "addresses", key)
-}
-
-func GetContractsOptions(t *testing.T) config.ContractsOptions {
-	rootDir := rootPath(t)
-
+func NewContractsOptions(rpcUrl string) config.ContractsOptions {
 	return config.ContractsOptions{
-		RpcUrl: BLOCKCHAIN_RPC_URL,
-		MessagesContractAddress: getContractAddress(
-			t,
-			path.Join(rootDir, "./contracts/config/anvil_localnet/GroupMessages.json"),
-			"proxy",
-		),
-		NodesContractAddress: getContractAddress(
-			t,
-			path.Join(rootDir, "./contracts/config/anvil_localnet/XMTPNodeRegistry.json"),
-			"implementation",
-		),
-		IdentityUpdatesContractAddress: getContractAddress(
-			t,
-			path.Join(rootDir, "./contracts/config/anvil_localnet/IdentityUpdates.json"),
-			"proxy",
-		),
-		RatesManagerContractAddress: getContractAddress(
-			t,
-			path.Join(rootDir, "./contracts/config/anvil_localnet/RatesManager.json"),
-			"proxy",
-		),
+		RpcUrl:                  rpcUrl,
 		RegistryRefreshInterval: 100 * time.Millisecond,
 		RatesRefreshInterval:    100 * time.Millisecond,
 		ChainID:                 31337,

--- a/pkg/testutils/contracts.go
+++ b/pkg/testutils/contracts.go
@@ -104,7 +104,7 @@ func BuildIdentityUpdateLog(
 Deploy a contract and return the contract's address. Will return a different address for each run, making it suitable for testing
 *
 */
-func deployContract(t *testing.T, contractName string) string {
+func deployContract(t *testing.T, contractName, rpcUrl string) string {
 	retryMax := 10
 	var retry = 0
 	var err error
@@ -119,7 +119,7 @@ func deployContract(t *testing.T, contractName string) string {
 		}
 
 		var client *ethclient.Client
-		client, err = ethclient.Dial(ANVIL_LOCALNET_HOST)
+		client, err = ethclient.Dial(rpcUrl)
 		if err != nil {
 			continue
 		}
@@ -142,8 +142,18 @@ func deployContract(t *testing.T, contractName string) string {
 			addr, _, _, err = nodes.DeployNodes(auth, client, auth.From)
 		case GROUP_MESSAGES_CONTRACT_NAME:
 			addr, _, _, err = groupmessages.DeployGroupMessages(auth, client)
+			require.NoError(t, err)
+			var contract *groupmessages.GroupMessages
+			contract, err = groupmessages.NewGroupMessages(addr, client)
+			require.NoError(t, err)
+			_, err = contract.Initialize(auth, auth.From)
 		case IDENTITY_UPDATES_CONTRACT_NAME:
 			addr, _, _, err = identityupdates.DeployIdentityUpdates(auth, client)
+			require.NoError(t, err)
+			var contract *identityupdates.IdentityUpdates
+			contract, err = identityupdates.NewIdentityUpdates(addr, client)
+			require.NoError(t, err)
+			_, err = contract.Initialize(auth, auth.From)
 		case RATES_MANAGER_CONTRACT_NAME:
 			addr, _, _, err = ratesmanager.DeployRatesManager(auth, client)
 			require.NoError(t, err)
@@ -166,18 +176,18 @@ func deployContract(t *testing.T, contractName string) string {
 
 }
 
-func DeployNodesContract(t *testing.T) string {
-	return deployContract(t, NODES_CONTRACT_NAME)
+func DeployNodesContract(t *testing.T, rpcUrl string) string {
+	return deployContract(t, NODES_CONTRACT_NAME, rpcUrl)
 }
 
-func DeployGroupMessagesContract(t *testing.T) string {
-	return deployContract(t, GROUP_MESSAGES_CONTRACT_NAME)
+func DeployGroupMessagesContract(t *testing.T, rpcUrl string) string {
+	return deployContract(t, GROUP_MESSAGES_CONTRACT_NAME, rpcUrl)
 }
 
-func DeployIdentityUpdatesContract(t *testing.T) string {
-	return deployContract(t, IDENTITY_UPDATES_CONTRACT_NAME)
+func DeployIdentityUpdatesContract(t *testing.T, rpcUrl string) string {
+	return deployContract(t, IDENTITY_UPDATES_CONTRACT_NAME, rpcUrl)
 }
 
-func DeployRatesManagerContract(t *testing.T) string {
-	return deployContract(t, RATES_MANAGER_CONTRACT_NAME)
+func DeployRatesManagerContract(t *testing.T, rpcUrl string) string {
+	return deployContract(t, RATES_MANAGER_CONTRACT_NAME, rpcUrl)
 }

--- a/pkg/testutils/contracts_test.go
+++ b/pkg/testutils/contracts_test.go
@@ -5,14 +5,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils/anvil"
 )
 
 func TestDeployContract(t *testing.T) {
-	deployedTo := DeployNodesContract(t)
+	rpcUrl, cleanup := anvil.StartAnvil(t, false)
+	defer cleanup()
+	deployedTo := DeployNodesContract(t, rpcUrl)
 	require.True(t, common.IsHexAddress(deployedTo), "invalid contract address")
 }
 
 func TestDeployGroupMessages(t *testing.T) {
-	deployedTo := DeployGroupMessagesContract(t)
+	rpcUrl, cleanup := anvil.StartAnvil(t, false)
+	defer cleanup()
+	deployedTo := DeployGroupMessagesContract(t, rpcUrl)
 	require.True(t, common.IsHexAddress(deployedTo), "invalid contract address")
 }


### PR DESCRIPTION
### TL;DR

Refactored blockchain tests to use Anvil for isolated test environments

## Issues
https://github.com/xmtp/xmtpd/pull/630

### What changed?

- Modified blockchain test files to use isolated Anvil instances for each test
- Updated contract deployment functions to accept an RPC URL parameter
- Added proper cleanup of Anvil instances after tests complete
- Added a `Contract()` accessor method to `RatesAdmin` to expose the underlying contract
- Moved blockchain package tests to `blockchain_test` package for better isolation
- Replaced `defer cleanup()` with `t.Cleanup(cleanup)` in some tests
- Added `NewContractsOptions` function that accepts an RPC URL parameter
- Fixed initialization of deployed contracts in test utilities

### How to test?

Run the blockchain tests:
```
go test ./pkg/blockchain/... -v
```

### Why make this change?

This change improves test reliability by ensuring each test runs in an isolated blockchain environment. By using separate Anvil instances for each test, we eliminate potential interference between tests and make them more deterministic. The code also properly cleans up resources after tests complete, preventing resource leaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new administrative interface that enables direct access to rate management functionality.

- **Quality Improvements**
  - Upgraded blockchain integration and configuration to support dynamic contract deployments.
  - Streamlined resource cleanup and testing processes to enhance system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->