### PR TITLE
Indexer metrics + indexer refactors

### DIFF
--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -138,7 +138,9 @@ func (r *RpcLogStreamer) watchContract(watcher ContractConfig) {
 			logger.Debug("Stopping watcher")
 			return
 		case <-timer.C:
-			logger.Fatal("Max disconnect time exceeded. Node might drift too far away from expected state. Shutting down...")
+			logger.Fatal(
+				"Max disconnect time exceeded. Node might drift too far away from expected state. Shutting down...",
+			)
 
 		case reorgBlock, open := <-watcher.reorgChannel:
 			if !open {

--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -202,9 +202,11 @@ func (r *RpcLogStreamer) GetNextPage(
 
 	highestBlockCanProcess := highestBlock - LAG_FROM_HIGHEST_BLOCK
 	if fromBlock > highestBlockCanProcess {
-		r.logger.Debug("Chain is up to date. Skipping update")
+		metrics.EmitIndexerCurrentBlockLag(contractAddress, 0)
 		return []types.Log{}, nil, nil
 	}
+
+	metrics.EmitIndexerCurrentBlockLag(contractAddress, highestBlock-fromBlock)
 
 	toBlock := min(fromBlock+BACKFILL_BLOCKS, highestBlockCanProcess)
 
@@ -222,7 +224,6 @@ func (r *RpcLogStreamer) GetNextPage(
 	}
 
 	metrics.EmitIndexerCurrentBlock(contractAddress, toBlock)
-	metrics.EmitIndexerCurrentBlockLag(contractAddress, toBlock-fromBlock)
 	metrics.EmitIndexerNumLogsFound(contractAddress, len(logs))
 
 	nextBlockNumber := toBlock + 1

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -356,7 +356,12 @@ func indexLogs(
 	logger.Debug("finished")
 }
 
-func retry(logger *zap.Logger, sleep time.Duration, address string, fn func() storer.LogStorageError) error {
+func retry(
+	logger *zap.Logger,
+	sleep time.Duration,
+	address string,
+	fn func() storer.LogStorageError,
+) error {
 	for {
 		if err := fn(); err != nil {
 			logger.Error("error storing log", zap.Error(err))

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -337,14 +337,13 @@ func indexLogs(
 			}
 		}
 
-	Retry:
 		for {
 			errStorage = logStorer.StoreLog(ctx, event)
 			if errStorage != nil {
 				logger.Error("error storing log", zap.Error(errStorage))
 				if errStorage.ShouldRetry() {
 					time.Sleep(100 * time.Millisecond)
-					continue Retry
+					continue
 				}
 			} else {
 				logger.Info("Stored log", zap.Uint64("blockNumber", event.BlockNumber))
@@ -352,7 +351,7 @@ func indexLogs(
 					logger.Error("error updating block tracker", zap.Error(trackerErr))
 				}
 			}
-			break Retry
+			break
 		}
 	}
 	logger.Debug("finished")

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -100,7 +100,11 @@ func TestIndexLogsRetryableError(t *testing.T) {
 		StoreLog(mock.Anything, event).
 		RunAndReturn(func(ctx context.Context, log types.Log) storer.LogStorageError {
 			attemptNumber++
-			return storer.NewLogStorageError(errors.New("retryable error"), attemptNumber < 2)
+			if attemptNumber < 2 {
+				return storer.NewRetryableLogStorageError(errors.New("retryable error"))
+			} else {
+				return storer.NewUnrecoverableLogStorageError(errors.New("non-retryable error"))
+			}
 		})
 
 	channel <- event

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -62,6 +62,7 @@ func TestIndexLogsSuccess(t *testing.T) {
 		logStorer,
 		blockTracker,
 		reorgHandler,
+		"testContract",
 	)
 
 	time.Sleep(100 * time.Millisecond)
@@ -118,6 +119,7 @@ func TestIndexLogsRetryableError(t *testing.T) {
 		logStorer,
 		blockTracker,
 		reorgHandler,
+		"testContract",
 	)
 
 	time.Sleep(200 * time.Millisecond)

--- a/pkg/indexer/storer/error.go
+++ b/pkg/indexer/storer/error.go
@@ -5,22 +5,34 @@ type LogStorageError interface {
 	ShouldRetry() bool
 }
 
-type logStorageError struct {
-	err         error
-	shouldRetry bool
+type UnrecoverableLogStorageError struct {
+	err error
 }
 
-func NewLogStorageError(err error, shouldRetry bool) logStorageError {
-	return logStorageError{
-		err:         err,
-		shouldRetry: shouldRetry,
-	}
-}
-
-func (e logStorageError) Error() string {
+func (e UnrecoverableLogStorageError) Error() string {
 	return e.err.Error()
 }
 
-func (e logStorageError) ShouldRetry() bool {
-	return e.shouldRetry
+func (e UnrecoverableLogStorageError) ShouldRetry() bool {
+	return false
+}
+
+func NewUnrecoverableLogStorageError(err error) UnrecoverableLogStorageError {
+	return UnrecoverableLogStorageError{err: err}
+}
+
+type RetryableLogStorageError struct {
+	err error
+}
+
+func (e RetryableLogStorageError) Error() string {
+	return e.err.Error()
+}
+
+func (e RetryableLogStorageError) ShouldRetry() bool {
+	return true
+}
+
+func NewRetryableLogStorageError(err error) RetryableLogStorageError {
+	return RetryableLogStorageError{err: err}
 }

--- a/pkg/metrics/indexer.go
+++ b/pkg/metrics/indexer.go
@@ -39,6 +39,14 @@ var indexerCurrentBlockLag = prometheus.NewGaugeVec(
 	[]string{"contract_address"},
 )
 
+var indexerCountRetryableStorageErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtpd_indexer_retryable_storage_error_count",
+		Help: "Number of retryable storage errors",
+	},
+	[]string{"contract_address"},
+)
+
 var indexerGetLogsDuration = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "xmtpd_indexer_log_streamer_get_logs_duration",
@@ -79,6 +87,10 @@ func EmitIndexerGetLogsDuration(contractAddress string, duration time.Duration) 
 func EmitIndexerCurrentBlockLag(contractAddress string, lag uint64) {
 	indexerCurrentBlockLag.With(prometheus.Labels{"contract_address": contractAddress}).
 		Set(float64(lag))
+}
+
+func EmitIndexerRetryableStorageError(contractAddress string) {
+	indexerCountRetryableStorageErrors.With(prometheus.Labels{"contract_address": contractAddress}).Inc()
 }
 
 func MeasureGetLogs[Return any](contractAddress string, fn func() (Return, error)) (Return, error) {

--- a/pkg/metrics/indexer.go
+++ b/pkg/metrics/indexer.go
@@ -23,6 +23,22 @@ var indexerCurrentBlock = prometheus.NewGaugeVec(
 	[]string{"contract_address"},
 )
 
+var indexerMaxBlock = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtpd_indexer_log_streamer_max_block",
+		Help: "Max block on the chain to be processed by the log streamer",
+	},
+	[]string{"contract_address"},
+)
+
+var indexerCurrentBlockLag = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtpd_indexer_log_streamer_block_lag",
+		Help: "Lag between current block and max block",
+	},
+	[]string{"contract_address"},
+)
+
 var indexerGetLogsDuration = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "xmtpd_indexer_log_streamer_get_logs_duration",
@@ -45,14 +61,24 @@ func EmitIndexerNumLogsFound(contractAddress string, numLogs int) {
 		Add(float64(numLogs))
 }
 
-func EmitIndexerCurrentBlock(contractAddress string, block int) {
+func EmitIndexerCurrentBlock(contractAddress string, block uint64) {
 	indexerCurrentBlock.With(prometheus.Labels{"contract_address": contractAddress}).
+		Set(float64(block))
+}
+
+func EmitIndexerMaxBlock(contractAddress string, block uint64) {
+	indexerMaxBlock.With(prometheus.Labels{"contract_address": contractAddress}).
 		Set(float64(block))
 }
 
 func EmitIndexerGetLogsDuration(contractAddress string, duration time.Duration) {
 	indexerGetLogsDuration.With(prometheus.Labels{"contract_address": contractAddress}).
 		Observe(float64(duration.Milliseconds()))
+}
+
+func EmitIndexerCurrentBlockLag(contractAddress string, lag uint64) {
+	indexerCurrentBlockLag.With(prometheus.Labels{"contract_address": contractAddress}).
+		Set(float64(lag))
 }
 
 func MeasureGetLogs[Return any](contractAddress string, fn func() (Return, error)) (Return, error) {

--- a/pkg/metrics/indexer.go
+++ b/pkg/metrics/indexer.go
@@ -90,7 +90,8 @@ func EmitIndexerCurrentBlockLag(contractAddress string, lag uint64) {
 }
 
 func EmitIndexerRetryableStorageError(contractAddress string) {
-	indexerCountRetryableStorageErrors.With(prometheus.Labels{"contract_address": contractAddress}).Inc()
+	indexerCountRetryableStorageErrors.With(prometheus.Labels{"contract_address": contractAddress}).
+		Inc()
 }
 
 func MeasureGetLogs[Return any](contractAddress string, fn func() (Return, error)) (Return, error) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -66,10 +66,12 @@ func (s *Server) Close() {
 }
 
 func registerCollectors(reg prometheus.Registerer) {
-	//TODO: add metrics here
 	cols := []prometheus.Collector{
 		indexerNumLogsFound,
 		indexerCurrentBlock,
+		indexerMaxBlock,
+		indexerCurrentBlockLag,
+		indexerCountRetryableStorageErrors,
 		indexerGetLogsDuration,
 		indexerGetLogsRequests,
 		payerNodePublishDuration,

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -19,6 +19,7 @@ func NewContractsOptions(rpcUrl string) config.ContractsOptions {
 		RegistryRefreshInterval: 100 * time.Millisecond,
 		RatesRefreshInterval:    100 * time.Millisecond,
 		ChainID:                 31337,
+		MaxChainDisconnectTime:  10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Adds all metrics from #568 

On top of that:
- refactors self-termination watchContract
- mutes loud debug logs
- uses waitgroups in some tests to speed them up
- some other driveby refactors

Fixes #568 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced monitoring that displays new metrics for key blockchain processing statistics, including maximum block processed, block lag, and storage error counts.
  - Added a configurable disconnect timeout to help ensure a more graceful recovery during prolonged network interruptions.

- **Refactor**
  - Streamlined error handling and retry processes to improve overall system stability and reliability during blockchain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->