### PR TITLE
Improve nonce replenishment

### DIFF
--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -199,9 +199,8 @@ WHERE
 	AND (@minutes_since_epoch_lt::BIGINT = 0
 		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT);
 
--- name: FillNonceSequence :exec
-SELECT
-	fill_nonce_gap(@pending_nonce, @num_elements);
+-- name: FillNonceSequence :one
+SELECT COALESCE(fill_nonce_gap(@pending_nonce, @num_elements), @num_elements)::INT AS inserted_rows;
 
 -- name: GetNextAvailableNonce :one
 SELECT

--- a/pkg/db/sequences_test.go
+++ b/pkg/db/sequences_test.go
@@ -21,7 +21,7 @@ func TestFillRows(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  100,
 	})
@@ -37,7 +37,7 @@ func TestEmptyRows(t *testing.T) {
 	_, err := querier.GetNextAvailableNonce(ctx)
 	require.Error(t, err)
 
-	err = querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err = querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  100,
 	})
@@ -90,7 +90,7 @@ func TestConcurrentReads(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  100,
 	})
@@ -143,7 +143,7 @@ func TestRequestsUnused(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  100,
 	})
@@ -169,7 +169,7 @@ func TestRequestsUsed(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  100,
 	})
@@ -196,7 +196,7 @@ func TestRequestsFailed(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  100,
 	})
@@ -225,7 +225,7 @@ func TestFillerCanProceedWithOpenTxn(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  10,
 	})
@@ -248,7 +248,7 @@ func TestFillerCanProceedWithOpenTxn(t *testing.T) {
 	_, err = txQuerier.GetNextAvailableNonce(ctx)
 	require.NoError(t, err)
 
-	err = querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err = querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  30,
 	})
@@ -263,17 +263,19 @@ func TestFillerRerun(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	cnt, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  10,
 	})
 	require.NoError(t, err)
+	require.EqualValues(t, 10, cnt)
 
-	err = querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	cnt, err = querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  30,
 	})
 	require.NoError(t, err)
+	require.EqualValues(t, 20, cnt)
 }
 
 func TestAbandonNonces(t *testing.T) {
@@ -283,7 +285,7 @@ func TestAbandonNonces(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  10,
 	})
@@ -306,7 +308,7 @@ func TestAbandonCanProceedWithOpenTxn(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  10,
 	})
@@ -346,7 +348,7 @@ func TestAbandonSkipsOpenTxn(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  10,
 	})
@@ -391,7 +393,7 @@ func TestAbandonConcurrently(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  500,
 	})
@@ -425,7 +427,7 @@ func TestAbandonConcurrentlyWithOpenTransaction(t *testing.T) {
 
 	querier := queries.New(db)
 
-	err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
+	_, err := querier.FillNonceSequence(ctx, queries.FillNonceSequenceParams{
 		PendingNonce: 0,
 		NumElements:  500,
 	})

--- a/pkg/migrations/00008_payer-nonces.up.sql
+++ b/pkg/migrations/00008_payer-nonces.up.sql
@@ -4,7 +4,9 @@ CREATE TABLE nonce_table (
 );
 
 CREATE OR REPLACE FUNCTION fill_nonce_gap(pending_nonce BIGINT, num_elements INT)
-    RETURNS VOID AS $$
+    RETURNS INT AS $$
+DECLARE
+    inserted_rows INT;
 BEGIN
     WITH nonces AS (
         -- Generate the required number of nonces
@@ -15,5 +17,10 @@ BEGIN
     FROM nonces n
     WHERE NOT EXISTS (SELECT 1 FROM nonce_table nt WHERE nt.nonce = n.nonce) -- Skip existing ones
     ON CONFLICT DO NOTHING; -- Ensure no duplicates
+
+    -- Capture the number of inserted rows
+    GET DIAGNOSTICS inserted_rows = ROW_COUNT;
+
+    RETURN inserted_rows;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
This will print the number of nonces inserted, which can be super helpful.

I directly modify migration step 8) which means that our playground environment won't pick the change up. It is mitigated by the COALESCE which is backwards compatible. Once we nuke the DB, the payer will start printing the correct value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced nonce management with improved feedback, now displaying the number of processed nonce entries in operational logs.
  - Updated database procedures to return consistent count values with fallback support, ensuring more reliable tracking of operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->