### PR TITLE
Generate payer reports

### DIFF
--- a/pkg/db/gatewayEnvelope.go
+++ b/pkg/db/gatewayEnvelope.go
@@ -33,6 +33,10 @@ func InsertGatewayEnvelopeAndIncrementUnsettledUsage(
 
 			var wg sync.WaitGroup
 			var incrementErr, congestionErr error
+			// Use the sequence ID from the envelope to set the last sequence ID value
+			if incrementParams.SequenceID == 0 {
+				incrementParams.SequenceID = insertParams.OriginatorSequenceID
+			}
 
 			wg.Add(2)
 

--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -181,15 +181,17 @@ ON CONFLICT (address)
 		id;
 
 -- name: IncrementUnsettledUsage :exec
-INSERT INTO unsettled_usage(payer_id, originator_id, minutes_since_epoch, spend_picodollars)
-	VALUES (@payer_id, @originator_id, @minutes_since_epoch, @spend_picodollars)
+INSERT INTO unsettled_usage(payer_id, originator_id, minutes_since_epoch, spend_picodollars, last_sequence_id)
+	VALUES (@payer_id, @originator_id, @minutes_since_epoch, @spend_picodollars, @sequence_id)
 ON CONFLICT (payer_id, originator_id, minutes_since_epoch)
 	DO UPDATE SET
-		spend_picodollars = unsettled_usage.spend_picodollars + @spend_picodollars;
+		spend_picodollars = unsettled_usage.spend_picodollars + @spend_picodollars,
+		last_sequence_id = GREATEST(unsettled_usage.last_sequence_id, @sequence_id);
 
 -- name: GetPayerUnsettledUsage :one
 SELECT
-	COALESCE(SUM(spend_picodollars), 0)::BIGINT AS total_spend_picodollars
+	COALESCE(SUM(spend_picodollars), 0)::BIGINT AS total_spend_picodollars,
+	COALESCE(MAX(last_sequence_id), 0)::BIGINT AS last_sequence_id
 FROM
 	unsettled_usage
 WHERE
@@ -261,3 +263,42 @@ WHERE
 		OR minutes_since_epoch > @minutes_since_epoch_gt::BIGINT)
 	AND (@minutes_since_epoch_lt::BIGINT = 0
 		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT);
+
+-- name: BuildPayerReport :many
+SELECT
+	payers.address as payer_address,
+	SUM(spend_picodollars)::BIGINT AS total_spend_picodollars
+FROM
+	unsettled_usage
+JOIN payers on payers.id = unsettled_usage.payer_id
+WHERE
+	originator_id = @originator_id
+	AND minutes_since_epoch > @start_minutes_since_epoch
+	AND minutes_since_epoch <= @end_minutes_since_epoch
+GROUP BY
+	payers.address;
+
+-- name: GetGatewayEnvelopeByID :one
+SELECT * FROM gateway_envelopes
+WHERE originator_sequence_id = @originator_sequence_id
+-- Include the node ID to take advantage of the primary key index
+AND originator_node_id = @originator_node_id;
+
+-- name: GetSecondNewestMinute :one
+WITH second_newest_minute
+AS
+  (
+           SELECT minutes_since_epoch
+           FROM     unsettled_usage
+           WHERE    originator_id = @originator_id
+           AND      unsettled_usage.minutes_since_epoch > @minimum_minutes_since_epoch
+           GROUP BY unsettled_usage.minutes_since_epoch
+           ORDER BY unsettled_usage.minutes_since_epoch DESC
+           LIMIT    1
+           OFFSET   1)
+  SELECT coalesce(max(last_sequence_id), 0)::BIGINT as max_sequence_id,
+         coalesce(max(unsettled_usage.minutes_since_epoch), 0)::INT as minutes_since_epoch
+  FROM   unsettled_usage
+  JOIN   second_newest_minute
+  ON     second_newest_minute.minutes_since_epoch = unsettled_usage.minutes_since_epoch
+  WHERE  unsettled_usage.originator_id = @originator_id;

--- a/pkg/db/queries/models.go
+++ b/pkg/db/queries/models.go
@@ -73,4 +73,5 @@ type UnsettledUsage struct {
 	OriginatorID      int32
 	MinutesSinceEpoch int32
 	SpendPicodollars  int64
+	LastSequenceID    int64
 }

--- a/pkg/db/unsettledUsage_test.go
+++ b/pkg/db/unsettledUsage_test.go
@@ -34,7 +34,7 @@ func TestIncrementUnsettledUsage(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, unsettledUsage, int64(100))
+	require.Equal(t, unsettledUsage.TotalSpendPicodollars, int64(100))
 
 	require.NoError(t, querier.IncrementUnsettledUsage(ctx, queries.IncrementUnsettledUsageParams{
 		PayerID:           payerId,
@@ -50,7 +50,7 @@ func TestIncrementUnsettledUsage(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, unsettledUsage, int64(200))
+	require.Equal(t, unsettledUsage.TotalSpendPicodollars, int64(200))
 }
 
 func TestGetUnsettledUsage(t *testing.T) {
@@ -86,7 +86,7 @@ func TestGetUnsettledUsage(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, unsettledUsage, int64(300))
+	require.Equal(t, unsettledUsage.TotalSpendPicodollars, int64(300))
 
 	unsettledUsage, err = querier.GetPayerUnsettledUsage(
 		ctx,
@@ -96,5 +96,5 @@ func TestGetUnsettledUsage(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, unsettledUsage, int64(500))
+	require.Equal(t, unsettledUsage.TotalSpendPicodollars, int64(500))
 }

--- a/pkg/migrations/00010_add-last-sequence-id-to-unsettled-usage.down.sql
+++ b/pkg/migrations/00010_add-last-sequence-id-to-unsettled-usage.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE unsettled_usage DROP COLUMN last_sequence_id;

--- a/pkg/migrations/00010_add-last-sequence-id-to-unsettled-usage.up.sql
+++ b/pkg/migrations/00010_add-last-sequence-id-to-unsettled-usage.up.sql
@@ -1,0 +1,14 @@
+-- Dropping the table to add a new column with a not null constraint
+DROP TABLE unsettled_usage;
+
+CREATE TABLE unsettled_usage(
+	payer_id INTEGER NOT NULL,
+	originator_id INTEGER NOT NULL,
+	minutes_since_epoch INTEGER NOT NULL,
+	spend_picodollars BIGINT NOT NULL,
+	last_sequence_id BIGINT NOT NULL,
+	PRIMARY KEY (payer_id, originator_id, minutes_since_epoch)
+);
+
+CREATE INDEX idx_unsettled_usage_originator_id_minutes_since_epoch
+    ON unsettled_usage(originator_id, minutes_since_epoch DESC);

--- a/pkg/payerreport/interface.go
+++ b/pkg/payerreport/interface.go
@@ -1,0 +1,48 @@
+package payerreport
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/xmtp/xmtpd/pkg/currency"
+)
+
+type PayerReport struct {
+	// The Originator Node that the report is about
+	OriginatorNodeID uint32
+	// The report applies to messages with sequence IDs > StartSequenceID
+	StartSequenceID uint64
+	// The report applies to messages with sequence IDs <= EndSequenceID
+	EndSequenceID uint64
+	// The payers in the report and the number of messages they paid for
+	Payers map[common.Address]currency.PicoDollar
+	// The merkle root of the Payers mapping
+	PayersMerkleRoot []byte
+	// The number of leaves in the Payers merkle tree
+	PayersLeafCount uint32
+}
+
+type NodeSignature struct {
+	NodeID    uint32
+	Signature []byte
+}
+
+type PayerReportAttestation struct {
+	Report        *PayerReport
+	NodeSignature NodeSignature
+}
+
+type PayerReportGenerationParams struct {
+	OriginatorID            uint32
+	LastReportEndSequenceID uint64
+	NumHours                int
+}
+
+type IPayerReportManager interface {
+	GenerateReport(ctx context.Context, params PayerReportGenerationParams) (*PayerReport, error)
+	AttestReport(
+		ctx context.Context,
+		prevReport *PayerReport,
+		newReport *PayerReport,
+	) (*PayerReportAttestation, error)
+}

--- a/pkg/payerreport/manager.go
+++ b/pkg/payerreport/manager.go
@@ -1,0 +1,151 @@
+package payerreport
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/xmtp/xmtpd/pkg/currency"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/envelopes"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"go.uber.org/zap"
+)
+
+type PayerReportManager struct {
+	log     *zap.Logger
+	queries *queries.Queries
+}
+
+func NewPayerReportManager(
+	log *zap.Logger,
+	queries *queries.Queries,
+) *PayerReportManager {
+	return &PayerReportManager{
+		log:     log,
+		queries: queries,
+	}
+}
+
+func (p *PayerReportManager) GenerateReport(
+	ctx context.Context,
+	params PayerReportGenerationParams,
+) (*PayerReport, error) {
+	originatorID := int32(params.OriginatorID)
+	startMinute, err := p.getStartMinute(
+		ctx,
+		int64(params.LastReportEndSequenceID),
+		originatorID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	endMinute, endSequenceID, err := p.getEndMinute(ctx, originatorID, startMinute)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the end sequence ID is 0, we don't have enough envelopes to generate a report.
+	// Returns an empty report rather than an error here
+	if endSequenceID == 0 {
+		return &PayerReport{
+			OriginatorNodeID: uint32(originatorID),
+			Payers:           make(map[common.Address]currency.PicoDollar),
+			StartSequenceID:  params.LastReportEndSequenceID,
+			EndSequenceID:    params.LastReportEndSequenceID,
+			// TODO: Implement merkle calculation
+			PayersMerkleRoot: []byte("fix me"),
+			PayersLeafCount:  uint32(0),
+		}, nil
+	}
+
+	payers, err := p.queries.BuildPayerReport(
+		ctx,
+		queries.BuildPayerReportParams{
+			OriginatorID:           originatorID,
+			StartMinutesSinceEpoch: startMinute,
+			EndMinutesSinceEpoch:   endMinute,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PayerReport{
+		OriginatorNodeID: uint32(originatorID),
+		Payers:           buildPayersMap(payers),
+		StartSequenceID:  params.LastReportEndSequenceID,
+		EndSequenceID:    uint64(endSequenceID),
+		// TODO: Implement merkle calculation
+		PayersMerkleRoot: []byte("fix me"),
+		PayersLeafCount:  uint32(len(payers)),
+	}, nil
+}
+
+/*
+*  Returns the start minute to use for the report.
+*
+*  It does this by getting the envelope from the database with the given sequence ID.
+*
+*  It then parses the envelope and returns the minute.
+ */
+func (p *PayerReportManager) getStartMinute(
+	ctx context.Context,
+	sequenceID int64,
+	originatorID int32,
+) (int32, error) {
+	// If the sequence ID is 0, we're starting from the first envelope
+	if sequenceID == 0 {
+		return 0, nil
+	}
+
+	envelope, err := p.queries.GetGatewayEnvelopeByID(ctx, queries.GetGatewayEnvelopeByIDParams{
+		OriginatorSequenceID: sequenceID,
+		OriginatorNodeID:     originatorID,
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	parsedEnvelope, err := envelopes.NewOriginatorEnvelopeFromBytes(envelope.OriginatorEnvelope)
+	if err != nil {
+		return 0, err
+	}
+
+	return utils.MinutesSinceEpoch(parsedEnvelope.OriginatorTime()), nil
+}
+
+/*
+* Returns the end minute to use for the report.
+* It is looking for the second last minute with an envelope for the originator
+ */
+func (p *PayerReportManager) getEndMinute(
+	ctx context.Context,
+	originatorID int32,
+	startMinute int32,
+) (int32, int64, error) {
+	result, err := p.queries.GetSecondNewestMinute(
+		ctx,
+		queries.GetSecondNewestMinuteParams{
+			OriginatorID:             originatorID,
+			MinimumMinutesSinceEpoch: startMinute,
+		},
+	)
+
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return result.MinutesSinceEpoch, result.MaxSequenceID, nil
+}
+
+func buildPayersMap(rows []queries.BuildPayerReportRow) map[common.Address]currency.PicoDollar {
+	payersMap := make(map[common.Address]currency.PicoDollar)
+	for _, row := range rows {
+		payersMap[common.HexToAddress(row.PayerAddress)] = currency.PicoDollar(
+			row.TotalSpendPicodollars,
+		)
+	}
+	return payersMap
+}

--- a/pkg/payerreport/manager_test.go
+++ b/pkg/payerreport/manager_test.go
@@ -1,0 +1,221 @@
+package payerreport
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/currency"
+	dbHelpers "github.com/xmtp/xmtpd/pkg/db"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	envelopeTestUtils "github.com/xmtp/xmtpd/pkg/testutils/envelopes"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"google.golang.org/protobuf/proto"
+)
+
+func setup(t *testing.T) (*sql.DB, *PayerReportManager) {
+	db, _, cleanup := testutils.NewDB(t, context.Background())
+	t.Cleanup(cleanup)
+
+	generator := NewPayerReportManager(testutils.NewLog(t), queries.New(db))
+
+	return db, generator
+}
+
+func addEnvelope(
+	t *testing.T,
+	db *sql.DB,
+	originatorID int32,
+	sequenceID int64,
+	payerAddress common.Address,
+	timestamp time.Time,
+) {
+	payerID := testutils.CreatePayer(t, db, payerAddress.Hex())
+
+	envelope := envelopeTestUtils.CreateOriginatorEnvelopeWithTimestamp(
+		t,
+		uint32(originatorID),
+		uint64(sequenceID),
+		timestamp,
+	)
+
+	envelopeBytes, err := proto.Marshal(envelope)
+	require.NoError(t, err)
+
+	_, err = dbHelpers.InsertGatewayEnvelopeAndIncrementUnsettledUsage(
+		context.Background(),
+		db,
+		queries.InsertGatewayEnvelopeParams{
+			OriginatorNodeID:     originatorID,
+			OriginatorSequenceID: sequenceID,
+			OriginatorEnvelope:   envelopeBytes,
+			Topic:                testutils.RandomBytes(32),
+			PayerID:              dbHelpers.NullInt32(payerID),
+		},
+		queries.IncrementUnsettledUsageParams{
+			PayerID:           payerID,
+			OriginatorID:      originatorID,
+			MinutesSinceEpoch: utils.MinutesSinceEpoch(timestamp),
+			SpendPicodollars:  100,
+		},
+	)
+	require.NoError(t, err)
+}
+
+func getMinute(minutesSinceEpoch int) time.Time {
+	return time.Unix(0, 0).Add(time.Duration(minutesSinceEpoch) * time.Minute)
+}
+
+func TestFirstReport(t *testing.T) {
+	db, generator := setup(t)
+
+	payerAddress := testutils.RandomAddress()
+	originatorID := testutils.RandomInt32()
+
+	// Two envelopes in the first minute since the epoch
+	addEnvelope(t, db, originatorID, 1, payerAddress, getMinute(1))
+	addEnvelope(t, db, originatorID, 2, payerAddress, getMinute(1))
+
+	// One envelope in the second minute since the epoch
+	addEnvelope(t, db, originatorID, 3, payerAddress, getMinute(2))
+
+	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: 0,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint32(1), report.PayersLeafCount)
+	// Make sure the end sequence ID is the last sequence ID from the previous minute
+	require.Equal(t, uint64(2), report.EndSequenceID)
+	require.Equal(t, currency.PicoDollar(200), report.Payers[payerAddress])
+}
+
+func TestReportWithMultiplePayers(t *testing.T) {
+	db, generator := setup(t)
+
+	payerAddress1 := testutils.RandomAddress()
+	payerAddress2 := testutils.RandomAddress()
+	originatorID := testutils.RandomInt32()
+
+	addEnvelope(t, db, originatorID, 1, payerAddress1, getMinute(1))
+	addEnvelope(t, db, originatorID, 2, payerAddress2, getMinute(1))
+	addEnvelope(t, db, originatorID, 3, payerAddress1, getMinute(2))
+
+	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: 0,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint32(2), report.PayersLeafCount)
+	require.Equal(t, uint64(2), report.EndSequenceID)
+	require.Equal(t, currency.PicoDollar(100), report.Payers[payerAddress1])
+	require.Equal(t, currency.PicoDollar(100), report.Payers[payerAddress2])
+}
+
+func TestReportWithNoMessages(t *testing.T) {
+	_, generator := setup(t)
+
+	originatorID := testutils.RandomInt32()
+
+	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: 0,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint32(0), report.PayersLeafCount)
+	require.Equal(t, uint64(0), report.StartSequenceID)
+	require.Equal(t, uint64(0), report.EndSequenceID)
+	require.Equal(t, 0, len(report.Payers))
+}
+
+func TestSecondReportWithNoMessages(t *testing.T) {
+	db, generator := setup(t)
+
+	originatorID := testutils.RandomInt32()
+	payerAddress1 := testutils.RandomAddress()
+
+	addEnvelope(t, db, originatorID, 1, payerAddress1, getMinute(1))
+
+	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: 1,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint32(0), report.PayersLeafCount)
+	require.Equal(t, uint64(1), report.StartSequenceID)
+	require.Equal(t, uint64(1), report.EndSequenceID)
+}
+
+func TestSecondReport(t *testing.T) {
+	db, generator := setup(t)
+
+	originatorID := testutils.RandomInt32()
+	payerAddress := testutils.RandomAddress()
+
+	addEnvelope(t, db, originatorID, 1, payerAddress, getMinute(1))
+	addEnvelope(t, db, originatorID, 2, payerAddress, getMinute(1))
+	addEnvelope(t, db, originatorID, 3, payerAddress, getMinute(2))
+
+	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: 0,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint64(0), report.StartSequenceID)
+	require.Equal(t, uint32(1), report.PayersLeafCount)
+	require.Equal(t, uint64(2), report.EndSequenceID)
+	require.Equal(t, currency.PicoDollar(200), report.Payers[payerAddress])
+
+	addEnvelope(t, db, originatorID, 4, payerAddress, getMinute(3))
+	addEnvelope(t, db, originatorID, 4, payerAddress, getMinute(4))
+
+	report, err = generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: report.EndSequenceID,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint32(1), report.PayersLeafCount)
+	require.Equal(t, uint64(3), report.EndSequenceID)
+	require.Equal(t, currency.PicoDollar(100), report.Payers[payerAddress])
+}
+
+// Make sure that we don't pick up sequence IDs from other originators in the report
+func TestReportWithNoEnvelopesFromOriginator(t *testing.T) {
+	db, generator := setup(t)
+
+	originatorID := testutils.RandomInt32()
+	otherOriginatorID := testutils.RandomInt32()
+	payerAddress := testutils.RandomAddress()
+
+	addEnvelope(t, db, otherOriginatorID, 1, payerAddress, getMinute(1))
+	addEnvelope(t, db, otherOriginatorID, 2, payerAddress, getMinute(2))
+	addEnvelope(t, db, otherOriginatorID, 3, payerAddress, getMinute(3))
+
+	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
+		OriginatorID:            uint32(originatorID),
+		LastReportEndSequenceID: 0,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
+	require.Equal(t, uint32(0), report.PayersLeafCount)
+	require.Equal(t, uint64(0), report.StartSequenceID)
+	require.Equal(t, uint64(0), report.EndSequenceID)
+	require.Equal(t, 0, len(report.Payers))
+}

--- a/pkg/testutils/envelopes/envelopes.go
+++ b/pkg/testutils/envelopes/envelopes.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -108,10 +109,11 @@ func CreatePayerEnvelope(
 	}
 }
 
-func CreateOriginatorEnvelope(
+func CreateOriginatorEnvelopeWithTimestamp(
 	t *testing.T,
 	originatorNodeID uint32,
 	originatorSequenceID uint64,
+	timestamp time.Time,
 	payerEnv ...*envelopes.PayerEnvelope,
 ) *envelopes.OriginatorEnvelope {
 	if len(payerEnv) == 0 {
@@ -124,7 +126,7 @@ func CreateOriginatorEnvelope(
 	unsignedEnv := &envelopes.UnsignedOriginatorEnvelope{
 		OriginatorNodeId:     originatorNodeID,
 		OriginatorSequenceId: originatorSequenceID,
-		OriginatorNs:         0,
+		OriginatorNs:         timestamp.UnixNano(),
 		PayerEnvelopeBytes:   marshaledPayerEnv,
 	}
 
@@ -135,6 +137,20 @@ func CreateOriginatorEnvelope(
 		UnsignedOriginatorEnvelope: unsignedBytes,
 		Proof:                      nil,
 	}
+}
+
+func CreateOriginatorEnvelope(
+	t *testing.T,
+	originatorNodeID uint32,
+	originatorSequenceID uint64,
+	payerEnv ...*envelopes.PayerEnvelope,
+) *envelopes.OriginatorEnvelope {
+	return CreateOriginatorEnvelopeWithTimestamp(
+		t,
+		originatorNodeID,
+		originatorSequenceID,
+		time.Unix(0, 0),
+		payerEnv...)
 }
 
 func CreateOriginatorEnvelopeWithTopic(


### PR DESCRIPTION
## tl;dr

- Defines structs for the off chain representation of Payer Reports
- Actually generates Payer Reports
- Alters the `unsettled_usage` table to keep track of the last known sequence ID for each originator/payer combo in a given minute. This makes it cheap to look up when generating a Payer Report

## Notes

### Minimum Report Size

- To generate a Payer Report you need a minimum of two messages, originated in two distinct minutes. This resolves https://github.com/xmtp/xmtpd/issues/645

## Tickets

Implements part of https://github.com/xmtp/xmtpd/issues/514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new queries to aggregate spending data and retrieve envelope details, enhancing data reporting.
  - Added a comprehensive mechanism for generating and verifying payer reports, improving overall reporting accuracy.
  - Improved envelope creation by integrating timestamp support for more precise data handling.
  - Added new queries for enhanced data retrieval capabilities, including payer reports and gateway envelope details.
  - Introduced a new field for tracking last sequence IDs in unsettled usage records, enhancing data integrity.

- **Bug Fixes**
  - Adjusted existing queries to return additional data fields, ensuring accurate reporting.

- **Tests**
  - Expanded test coverage to validate various report generation scenarios, ensuring reliable performance.
  - Added tests for handling out-of-order sequence IDs during database operations, improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->