### PR TITLE
Switch anvil to mixed mode mining

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   chain:
     platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry
-    entrypoint: ["anvil", "--host", "0.0.0.0"]
+    entrypoint: ["anvil", "--host", "0.0.0.0", "--mixed-mining", "--block-time", "1"]
     working_dir: /anvil
     ports:
       - 7545:8545

--- a/pkg/testutils/anvil/anvil.go
+++ b/pkg/testutils/anvil/anvil.go
@@ -48,7 +48,15 @@ func waitForAnvil(t *testing.T, url string) {
 func StartAnvil(t *testing.T, showLogs bool) (string, func()) {
 	port := networkTestUtils.FindFreePort(t)
 
-	cmd := exec.Command("anvil", "--port", fmt.Sprintf("%d", port))
+	// we need mixed mining to work around https://github.com/xmtp/xmtpd/issues/643
+	cmd := exec.Command(
+		"anvil",
+		"--port",
+		fmt.Sprintf("%d", port),
+		"--mixed-mining",
+		"--block-time",
+		"1",
+	)
 	if showLogs {
 		// (Optional) You can capture stdout/stderr for logs:
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
Fixes #643 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated mining configuration now enables mixed mining alongside a faster block generation interval (set to 1 second). These improvements enhance the performance and responsiveness of blockchain simulations in development and testing environments, providing a smoother experience for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->