### PR TITLE
fix spelling errors

### DIFF
--- a/pkg/api/message/subscribeWorker.go
+++ b/pkg/api/message/subscribeWorker.go
@@ -245,7 +245,7 @@ func (s *subscribeWorker) dispatchToOriginators(envs []*envelopes.OriginatorEnve
 }
 
 func (s *subscribeWorker) dispatchToTopics(envs []*envelopes.OriginatorEnvelope) {
-	// We iterate envelopes one-by-one, because we expect the number of envelopers
+	// We iterate envelopes one-by-one, because we expect the number of envelopes
 	// per-topic to be small in each tick
 	for _, env := range envs {
 		listeners := s.topicListeners.getListeners(env.TargetTopic().String())

--- a/pkg/api/payer/nodeCursorTracker_test.go
+++ b/pkg/api/payer/nodeCursorTracker_test.go
@@ -84,7 +84,7 @@ func TestCursorTrackerClientShutsDownAfterExecution(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
-func TestCursorTrackerClientServerIsShutown(t *testing.T) {
+func TestCursorTrackerClientServerIsShutdown(t *testing.T) {
 	ctx := context.Background()
 
 	desiredOriginator := uint32(1)


### PR DESCRIPTION
pkg/api/message/subscribeWorker.go
`envelopers` - `envelopes`

pkg/api/payer/nodeCursorTracker_test.go
`TestCursorTrackerClientServerIsShutown` - `TestCursorTrackerClientServerIsShutdown` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated internal comments to improve clarity in describing processed data.
  
- **Tests**
  - Corrected a typographical error in a test name for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->