### PR TITLE
Re-enable upgrade tests

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -14,39 +14,35 @@
        - "go.sum"
        - "tools.go"
  jobs:
-   noop:
+   test:
+     name: Upgrade Tests
      runs-on: ubuntu-latest
      steps:
-       - run: echo "Upgrade tests are disabled"
-#   test:
-#     name: Upgrade Tests
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#         with:
-#           submodules: recursive
-#           fetch-tags: true
-#           fetch-depth: 0
+       - uses: actions/checkout@v4
+         with:
+           submodules: recursive
+           fetch-tags: true
+           fetch-depth: 0
 
-#       - uses: actions/setup-go@v5
-#         with:
-#           go-version-file: go.mod
-#           cache-dependency-path: "**/*.sum"
+       - uses: actions/setup-go@v5
+         with:
+           go-version-file: go.mod
+           cache-dependency-path: "**/*.sum"
 
-#       - run: dev/docker/up
+       - run: dev/docker/up
 
-#       - name: Install Foundry
-#         uses: foundry-rs/foundry-toolchain@v1
-#         with:
-#           version: v1.0.0
+       - name: Install Foundry
+         uses: foundry-rs/foundry-toolchain@v1
+         with:
+           version: v1.0.0
 
-#       - run: contracts/dev/deploy local
+       - run: contracts/dev/deploy local
 
-#       - run: dev/register-local-node
+       - run: dev/register-local-node
 
-#       - name: Run Upgrade Tests
-#         run: |
-#           export GOPATH="${HOME}/go/"
-#           export PATH="${PATH}:${GOPATH}/bin"
-#           export ENABLE_UPGRADE_TESTS=1
-#           go test github.com/xmtp/xmtpd/pkg/upgrade -v
+       - name: Run Upgrade Tests
+         run: |
+           export GOPATH="${HOME}/go/"
+           export PATH="${PATH}:${GOPATH}/bin"
+           export ENABLE_UPGRADE_TESTS=1
+           go test github.com/xmtp/xmtpd/pkg/upgrade -v

--- a/pkg/upgrade/docker_utils_test.go
+++ b/pkg/upgrade/docker_utils_test.go
@@ -152,30 +152,26 @@ func runContainer(
 	defer cancel()
 
 	req := testcontainers.ContainerRequest{
-		Image: imageName,
-		Name:  containerName,
-		Env:   envVars,
+		Image:        imageName,
+		Name:         containerName,
+		Env:          envVars,
+		ExposedPorts: []string{"5050/tcp"},
+
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.ExtraHosts = append(hc.ExtraHosts, "host.docker.internal:host-gateway")
 		},
 		WaitingFor: wait.ForLog(
-			"replication.api\tserving grpc",
+			"serving grpc",
 		), // TODO: Ideally we wait for health/liveness probe
 	}
 
-	container, err := testcontainers.GenericContainer(ctxwc, testcontainers.GenericContainerRequest{
+	xmtpContainer, err := testcontainers.GenericContainer(ctxwc, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 		Logger:           testcontainers.TestLogger(t),
 	})
-	if err != nil {
-		return err
-	}
 
-	err = container.Terminate(ctxwc)
-	if err != nil {
-		return err
-	}
+	testcontainers.CleanupContainer(t, xmtpContainer)
 
-	return nil
+	return err
 }

--- a/pkg/upgrade/docker_utils_test.go
+++ b/pkg/upgrade/docker_utils_test.go
@@ -165,11 +165,14 @@ func runContainer(
 		), // TODO: Ideally we wait for health/liveness probe
 	}
 
-	xmtpContainer, err := testcontainers.GenericContainer(ctxwc, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-		Logger:           testcontainers.TestLogger(t),
-	})
+	xmtpContainer, err := testcontainers.GenericContainer(
+		ctxwc,
+		testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+			Logger:           testcontainers.TestLogger(t),
+		},
+	)
 
 	testcontainers.CleanupContainer(t, xmtpContainer)
 

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -11,6 +11,9 @@ import (
 // Guaranteed to be in order of increasing version
 var (
 	xmtpdVersions = []string{
+		// 0.2.X versions and below are no longer compatible
+		// there is no released version that works
+		// use a known stable dev version instead
 		"sha-94af7b1",
 	}
 

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -11,9 +11,7 @@ import (
 // Guaranteed to be in order of increasing version
 var (
 	xmtpdVersions = []string{
-		"0.1.4",
-		"0.2.0",
-		"0.2.1",
+		"sha-94af7b1",
 	}
 
 	ghcrRepository = "ghcr.io/xmtp/xmtpd"


### PR DESCRIPTION
## Re-enable and Update Upgrade Tests with Container Configuration Changes
Re-enabled upgrade test workflow in GitHub Actions, modified container test configuration in `docker_utils_test.go` to expose port 5050/tcp and use `testcontainers.CleanupContainer`, and updated test versions in `upgrade_test.go` to use `sha-94af7b1` instead of deprecated 0.2.X versions.

### 📍Where to Start
The GitHub Actions workflow configuration in [upgrade-test.yml](https://github.com/xmtp/xmtpd/pull/657/files#diff-fb56dbf5e717892486fea44843511f8f08436ed0bda8df952befdd9e165a04d5) which defines the overall test execution setup.

----

_[Macroscope](https://app.macroscope.com) summarized e96f26b._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the upgrade testing process to ensure active validation of system improvements.
- **Tests**
	- Refined container management tests to enhance efficiency and reliability.
	- Updated compatibility checks to focus on a known stable development version for smoother upgrade transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->