### PR TITLE
New default formatter for SQL

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": ["bradymholt.pgformatter", "golang.go", "emeraldwalk.runonsave"],
+  "recommendations": ["mtxr.sqltools", "golang.go", "emeraldwalk.runonsave"],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,16 @@
 {
   "go.lintTool": "golangci-lint",
   "go.lintFlags": ["--fast"],
-  "pgFormatter.typeCase": "uppercase",
-  "pgFormatter.tabs": true,
   "[sql]": {
-    "editor.defaultFormatter": "bradymholt.pgformatter"
+    "editor.defaultFormatter": "mtxr.sqltools",
+    "editor.formatOnSave": true
+  },
+  "sqltools.highlightQuery": false,
+  "sqltools.format": {
+    "linesBetweenQueries": 2,
+    "language": "sql",
+    "reservedWordCase": "upper",
+    "typeCase": "upper"
   },
   // Instructions from https://github.com/segmentio/golines
   "emeraldwalk.runonsave": {

--- a/pkg/db/queries.sql
+++ b/pkg/db/queries.sql
@@ -1,44 +1,49 @@
 -- name: InsertNodeInfo :execrows
 INSERT INTO node_info(node_id, public_key)
-	VALUES (@node_id, @public_key)
-ON CONFLICT
-	DO NOTHING;
+VALUES (@node_id, @public_key) ON CONFLICT DO NOTHING;
 
 -- name: SelectNodeInfo :one
-SELECT
-	*
-FROM
-	node_info
-WHERE
-	singleton_id = 1;
+SELECT *
+FROM node_info
+WHERE singleton_id = 1;
 
 -- name: InsertGatewayEnvelope :execrows
-INSERT INTO gateway_envelopes(originator_node_id, originator_sequence_id, topic, originator_envelope, payer_id, gateway_time)
-	VALUES (@originator_node_id, @originator_sequence_id, @topic, @originator_envelope, @payer_id, COALESCE(@gateway_time, NOW()))
-ON CONFLICT
-	DO NOTHING;
+INSERT INTO gateway_envelopes(
+		originator_node_id,
+		originator_sequence_id,
+		topic,
+		originator_envelope,
+		payer_id,
+		gateway_time
+	)
+VALUES (
+		@originator_node_id,
+		@originator_sequence_id,
+		@topic,
+		@originator_envelope,
+		@payer_id,
+		COALESCE(@gateway_time, NOW())
+	) ON CONFLICT DO NOTHING;
 
 -- name: SelectGatewayEnvelopes :many
-SELECT
-	*
-FROM
-	select_gateway_envelopes(@cursor_node_ids::INT[], @cursor_sequence_ids::BIGINT[], @topics::BYTEA[], @originator_node_ids::INT[], @row_limit::INT);
+SELECT *
+FROM select_gateway_envelopes(
+		@cursor_node_ids::INT [],
+		@cursor_sequence_ids::BIGINT [],
+		@topics::BYTEA [],
+		@originator_node_ids::INT [],
+		@row_limit::INT
+	);
 
 -- name: InsertStagedOriginatorEnvelope :one
-SELECT
-	*
-FROM
-	insert_staged_originator_envelope(@topic, @payer_envelope);
+SELECT *
+FROM insert_staged_originator_envelope(@topic, @payer_envelope);
 
 -- name: SelectStagedOriginatorEnvelopes :many
-SELECT
-	*
-FROM
-	staged_originator_envelopes
-WHERE
-	id > @last_seen_id
-ORDER BY
-	id ASC
+SELECT *
+FROM staged_originator_envelopes
+WHERE id > @last_seen_id
+ORDER BY id ASC
 LIMIT @num_rows;
 
 -- name: DeleteStagedOriginatorEnvelope :execrows
@@ -46,174 +51,175 @@ DELETE FROM staged_originator_envelopes
 WHERE id = @id;
 
 -- name: SelectVectorClock :many
-SELECT DISTINCT ON (originator_node_id)
-	originator_node_id,
+SELECT DISTINCT ON (originator_node_id) originator_node_id,
 	originator_sequence_id,
 	originator_envelope
-FROM
-	gateway_envelopes
-ORDER BY
-	originator_node_id,
+FROM gateway_envelopes
+ORDER BY originator_node_id,
 	originator_sequence_id DESC;
 
 -- name: GetAddressLogs :many
-SELECT
-	a.address,
+SELECT a.address,
 	encode(a.inbox_id, 'hex') AS inbox_id,
 	a.association_sequence_id
-FROM
-	address_log a
+FROM address_log a
 	INNER JOIN (
-		SELECT
-			address,
+		SELECT address,
 			MAX(association_sequence_id) AS max_association_sequence_id
-		FROM
-			address_log
-		WHERE
-			address = ANY (@addresses::TEXT[])
+		FROM address_log
+		WHERE address = ANY (@addresses::TEXT [])
 			AND revocation_sequence_id IS NULL
-		GROUP BY
-			address) b ON a.address = b.address
+		GROUP BY address
+	) b ON a.address = b.address
 	AND a.association_sequence_id = b.max_association_sequence_id;
 
 -- name: InsertAddressLog :execrows
-INSERT INTO address_log(address, inbox_id, association_sequence_id, revocation_sequence_id)
-	VALUES (@address, decode(@inbox_id, 'hex'), @association_sequence_id, NULL)
-ON CONFLICT (address, inbox_id)
-	DO UPDATE SET
-		revocation_sequence_id = NULL, association_sequence_id = @association_sequence_id
-	WHERE (address_log.revocation_sequence_id IS NULL
-		OR address_log.revocation_sequence_id < @association_sequence_id)
-		AND address_log.association_sequence_id < @association_sequence_id;
+INSERT INTO address_log(
+		address,
+		inbox_id,
+		association_sequence_id,
+		revocation_sequence_id
+	)
+VALUES (
+		@address,
+		decode(@inbox_id, 'hex'),
+		@association_sequence_id,
+		NULL
+	) ON CONFLICT (address, inbox_id) DO
+UPDATE
+SET revocation_sequence_id = NULL,
+	association_sequence_id = @association_sequence_id
+WHERE (
+		address_log.revocation_sequence_id IS NULL
+		OR address_log.revocation_sequence_id < @association_sequence_id
+	)
+	AND address_log.association_sequence_id < @association_sequence_id;
 
 -- name: RevokeAddressFromLog :execrows
-UPDATE
-	address_log
-SET
-	revocation_sequence_id = @revocation_sequence_id
-WHERE
-	address = @address
+UPDATE address_log
+SET revocation_sequence_id = @revocation_sequence_id
+WHERE address = @address
 	AND inbox_id = decode(@inbox_id, 'hex');
 
 -- name: GetLatestSequenceId :one
-SELECT
-	COALESCE(max(originator_sequence_id), 0)::BIGINT AS originator_sequence_id
-FROM
-	gateway_envelopes
-WHERE
-	originator_node_id = @originator_node_id;
+SELECT COALESCE(max(originator_sequence_id), 0)::BIGINT AS originator_sequence_id
+FROM gateway_envelopes
+WHERE originator_node_id = @originator_node_id;
 
 -- name: SetLatestBlock :exec
 INSERT INTO latest_block(contract_address, block_number, block_hash)
-	VALUES (@contract_address, @block_number, @block_hash)
-ON CONFLICT (contract_address)
-	DO UPDATE SET
-		block_number = @block_number, block_hash = @block_hash
-	WHERE
-		@block_number > latest_block.block_number
-		AND @block_hash != latest_block.block_hash;
+VALUES (@contract_address, @block_number, @block_hash) ON CONFLICT (contract_address) DO
+UPDATE
+SET block_number = @block_number,
+	block_hash = @block_hash
+WHERE @block_number > latest_block.block_number
+	AND @block_hash != latest_block.block_hash;
 
 -- name: GetLatestBlock :one
-SELECT
-	block_number,
+SELECT block_number,
 	block_hash
-FROM
-	latest_block
-WHERE
-	contract_address = @contract_address;
+FROM latest_block
+WHERE contract_address = @contract_address;
 
 -- name: GetLatestCursor :many
-SELECT
-	originator_node_id,
+SELECT originator_node_id,
 	MAX(originator_sequence_id)::BIGINT AS max_sequence_id
-FROM
-	gateway_envelopes
-GROUP BY
-	originator_node_id;
+FROM gateway_envelopes
+GROUP BY originator_node_id;
 
 -- name: InsertBlockchainMessage :exec
-INSERT INTO blockchain_messages(block_number, block_hash, originator_node_id, originator_sequence_id, is_canonical)
-	VALUES (@block_number, @block_hash, @originator_node_id, @originator_sequence_id, @is_canonical)
-ON CONFLICT
-	DO NOTHING;
+INSERT INTO blockchain_messages(
+		block_number,
+		block_hash,
+		originator_node_id,
+		originator_sequence_id,
+		is_canonical
+	)
+VALUES (
+		@block_number,
+		@block_hash,
+		@originator_node_id,
+		@originator_sequence_id,
+		@is_canonical
+	) ON CONFLICT DO NOTHING;
 
 -- name: GetBlocksInRange :many
 -- Returns blocks in ascending order (oldest to newest)
 -- StartBlock should be the lower bound (older block)
 -- EndBlock should be the upper bound (newer block)
 -- Example: GetBlocksInRange(1000, 2000), returns 1000, 1001, 1002, ..., 2000
-SELECT DISTINCT ON (block_number)
-	block_number,
+SELECT DISTINCT ON (block_number) block_number,
 	block_hash
-FROM
-	blockchain_messages
-WHERE
-	block_number BETWEEN @start_block AND @end_block
+FROM blockchain_messages
+WHERE block_number BETWEEN @start_block AND @end_block
 	AND block_hash IS NOT NULL
 	AND is_canonical = TRUE
-ORDER BY
-	block_number ASC,
+ORDER BY block_number ASC,
 	block_hash;
 
 -- name: UpdateBlocksCanonicalityInRange :exec
-UPDATE
-	blockchain_messages AS bm
-SET
-	is_canonical = FALSE
+UPDATE blockchain_messages AS bm
+SET is_canonical = FALSE
 FROM (
-	SELECT
-		block_number
-	FROM
-		blockchain_messages
-	WHERE
-		bm.block_number BETWEEN @start_block_number AND @end_block_number
-	FOR UPDATE) AS locked_rows
-WHERE
-	bm.block_number = locked_rows.block_number;
+		SELECT block_number
+		FROM blockchain_messages
+		WHERE bm.block_number BETWEEN @start_block_number AND @end_block_number FOR
+		UPDATE
+	) AS locked_rows
+WHERE bm.block_number = locked_rows.block_number;
 
 -- name: FindOrCreatePayer :one
 INSERT INTO payers(address)
-	VALUES (@address)
-ON CONFLICT (address)
-	DO UPDATE SET
-		address = @address
-	RETURNING
-		id;
+VALUES (@address) ON CONFLICT (address) DO
+UPDATE
+SET address = @address
+RETURNING id;
 
 -- name: IncrementUnsettledUsage :exec
-INSERT INTO unsettled_usage(payer_id, originator_id, minutes_since_epoch, spend_picodollars, last_sequence_id)
-	VALUES (@payer_id, @originator_id, @minutes_since_epoch, @spend_picodollars, @sequence_id)
-ON CONFLICT (payer_id, originator_id, minutes_since_epoch)
-	DO UPDATE SET
-		spend_picodollars = unsettled_usage.spend_picodollars + @spend_picodollars,
-		last_sequence_id = GREATEST(unsettled_usage.last_sequence_id, @sequence_id);
+INSERT INTO unsettled_usage(
+		payer_id,
+		originator_id,
+		minutes_since_epoch,
+		spend_picodollars,
+		last_sequence_id
+	)
+VALUES (
+		@payer_id,
+		@originator_id,
+		@minutes_since_epoch,
+		@spend_picodollars,
+		@sequence_id
+	) ON CONFLICT (payer_id, originator_id, minutes_since_epoch) DO
+UPDATE
+SET spend_picodollars = unsettled_usage.spend_picodollars + @spend_picodollars,
+	last_sequence_id = GREATEST(unsettled_usage.last_sequence_id, @sequence_id);
 
 -- name: GetPayerUnsettledUsage :one
-SELECT
-	COALESCE(SUM(spend_picodollars), 0)::BIGINT AS total_spend_picodollars,
+SELECT COALESCE(SUM(spend_picodollars), 0)::BIGINT AS total_spend_picodollars,
 	COALESCE(MAX(last_sequence_id), 0)::BIGINT AS last_sequence_id
-FROM
-	unsettled_usage
-WHERE
-	payer_id = @payer_id
-	AND (@minutes_since_epoch_gt::BIGINT = 0
-		OR minutes_since_epoch > @minutes_since_epoch_gt::BIGINT)
-	AND (@minutes_since_epoch_lt::BIGINT = 0
-		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT);
+FROM unsettled_usage
+WHERE payer_id = @payer_id
+	AND (
+		@minutes_since_epoch_gt::BIGINT = 0
+		OR minutes_since_epoch > @minutes_since_epoch_gt::BIGINT
+	)
+	AND (
+		@minutes_since_epoch_lt::BIGINT = 0
+		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT
+	);
 
 -- name: FillNonceSequence :one
-SELECT COALESCE(fill_nonce_gap(@pending_nonce, @num_elements), @num_elements)::INT AS inserted_rows;
+SELECT COALESCE(
+		fill_nonce_gap(@pending_nonce, @num_elements),
+		@num_elements
+	)::INT AS inserted_rows;
 
 -- name: GetNextAvailableNonce :one
-SELECT
-	nonce
-FROM
-	nonce_table
-ORDER BY
-	nonce ASC
-LIMIT 1
-FOR UPDATE
-	SKIP LOCKED;
+SELECT nonce
+FROM nonce_table
+ORDER BY nonce ASC
+LIMIT 1 FOR
+UPDATE SKIP LOCKED;
 
 -- name: DeleteAvailableNonce :execrows
 DELETE FROM nonce_table
@@ -221,84 +227,70 @@ WHERE nonce = @nonce;
 
 -- name: DeleteObsoleteNonces :execrows
 WITH deletable AS (
-	SELECT
-		n.nonce
-	FROM
-		nonce_table n
-	WHERE
-		n.nonce < @nonce
-	FOR UPDATE
-		SKIP LOCKED)
+	SELECT n.nonce
+	FROM nonce_table n
+	WHERE n.nonce < @nonce FOR
+	UPDATE SKIP LOCKED
+)
 DELETE FROM nonce_table USING deletable
 WHERE nonce_table.nonce = deletable.nonce;
 
 -- name: IncrementOriginatorCongestion :exec
 INSERT INTO originator_congestion(originator_id, minutes_since_epoch, num_messages)
-	VALUES (@originator_id, @minutes_since_epoch, 1)
-ON CONFLICT (originator_id, minutes_since_epoch)
-	DO UPDATE SET
-		num_messages = originator_congestion.num_messages + 1;
-
+VALUES (@originator_id, @minutes_since_epoch, 1) ON CONFLICT (originator_id, minutes_since_epoch) DO
+UPDATE
+SET num_messages = originator_congestion.num_messages + 1;
 
 -- name: GetRecentOriginatorCongestion :many
-SELECT 
-	minutes_since_epoch,
+SELECT minutes_since_epoch,
 	num_messages
-FROM
-	originator_congestion
-WHERE
-	originator_id = $1
+FROM originator_congestion
+WHERE originator_id = $1
 	AND minutes_since_epoch <= sqlc.arg(end_minute)::INT
 	AND minutes_since_epoch > sqlc.arg(end_minute)::INT - sqlc.arg(num_minutes)::INT
 ORDER BY minutes_since_epoch DESC;
 
 -- name: SumOriginatorCongestion :one
-SELECT
-	COALESCE(SUM(num_messages), 0)::BIGINT AS num_messages
-FROM
-	originator_congestion
-WHERE
-	originator_id = @originator_id
-	AND (@minutes_since_epoch_gt::BIGINT = 0
-		OR minutes_since_epoch > @minutes_since_epoch_gt::BIGINT)
-	AND (@minutes_since_epoch_lt::BIGINT = 0
-		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT);
+SELECT COALESCE(SUM(num_messages), 0)::BIGINT AS num_messages
+FROM originator_congestion
+WHERE originator_id = @originator_id
+	AND (
+		@minutes_since_epoch_gt::BIGINT = 0
+		OR minutes_since_epoch > @minutes_since_epoch_gt::BIGINT
+	)
+	AND (
+		@minutes_since_epoch_lt::BIGINT = 0
+		OR minutes_since_epoch < @minutes_since_epoch_lt::BIGINT
+	);
 
 -- name: BuildPayerReport :many
-SELECT
-	payers.address as payer_address,
+SELECT payers.address AS payer_address,
 	SUM(spend_picodollars)::BIGINT AS total_spend_picodollars
-FROM
-	unsettled_usage
-JOIN payers on payers.id = unsettled_usage.payer_id
-WHERE
-	originator_id = @originator_id
+FROM unsettled_usage
+	JOIN payers ON payers.id = unsettled_usage.payer_id
+WHERE originator_id = @originator_id
 	AND minutes_since_epoch > @start_minutes_since_epoch
 	AND minutes_since_epoch <= @end_minutes_since_epoch
-GROUP BY
-	payers.address;
+GROUP BY payers.address;
 
 -- name: GetGatewayEnvelopeByID :one
-SELECT * FROM gateway_envelopes
-WHERE originator_sequence_id = @originator_sequence_id
--- Include the node ID to take advantage of the primary key index
-AND originator_node_id = @originator_node_id;
+SELECT *
+FROM gateway_envelopes
+WHERE originator_sequence_id = @originator_sequence_id -- Include the node ID to take advantage of the primary key index
+	AND originator_node_id = @originator_node_id;
 
 -- name: GetSecondNewestMinute :one
-WITH second_newest_minute
-AS
-  (
-           SELECT minutes_since_epoch
-           FROM     unsettled_usage
-           WHERE    originator_id = @originator_id
-           AND      unsettled_usage.minutes_since_epoch > @minimum_minutes_since_epoch
-           GROUP BY unsettled_usage.minutes_since_epoch
-           ORDER BY unsettled_usage.minutes_since_epoch DESC
-           LIMIT    1
-           OFFSET   1)
-  SELECT coalesce(max(last_sequence_id), 0)::BIGINT as max_sequence_id,
-         coalesce(max(unsettled_usage.minutes_since_epoch), 0)::INT as minutes_since_epoch
-  FROM   unsettled_usage
-  JOIN   second_newest_minute
-  ON     second_newest_minute.minutes_since_epoch = unsettled_usage.minutes_since_epoch
-  WHERE  unsettled_usage.originator_id = @originator_id;
+WITH second_newest_minute AS (
+	SELECT minutes_since_epoch
+	FROM unsettled_usage
+	WHERE originator_id = @originator_id
+		AND unsettled_usage.minutes_since_epoch > @minimum_minutes_since_epoch
+	GROUP BY unsettled_usage.minutes_since_epoch
+	ORDER BY unsettled_usage.minutes_since_epoch DESC
+	LIMIT 1 OFFSET 1
+)
+SELECT coalesce(max(last_sequence_id), 0)::BIGINT AS max_sequence_id,
+	coalesce(max(unsettled_usage.minutes_since_epoch), 0)::INT AS minutes_since_epoch
+FROM unsettled_usage
+	JOIN second_newest_minute ON second_newest_minute.minutes_since_epoch = unsettled_usage.minutes_since_epoch
+WHERE unsettled_usage.originator_id = @originator_id;


### PR DESCRIPTION
### TL;DR

Replace pgFormatter with SQLTools for SQL formatting in VS Code.

### Why?

sqltools is more actively maintained. The previous formatter was dropped from the Cursor extensions marketplace. I also think the formatting is nicer. 

### What changed?

- Replaced `bradymholt.pgformatter` with `mtxr.sqltools` in VS Code extensions recommendations
- Updated VS Code settings to use SQLTools as the default SQL formatter
- Configured SQLTools formatting options (uppercase reserved words, line spacing)
- Reformatted all SQL queries in `pkg/db/queries.sql` with the new formatter

### How to test?

1. Install the SQLTools extension in VS Code
2. Open any SQL file and verify that formatting works correctly on save
3. Check that SQL queries maintain proper functionality while having improved readability
4. Verify that SQL reserved words are properly capitalized

### Why make this change?

SQLTools provides better SQL formatting capabilities than pgFormatter, with more configuration options and better integration with VS Code. The new formatting style improves SQL readability while maintaining the same functionality, making the codebase more maintainable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the workspace’s recommended SQL extension.
	- Enabled automatic formatting on save with enhanced SQL formatting settings.

- **Style**
	- Refined the formatting of SQL queries to improve readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->