### PR TITLE
Fix generate identity hang and add more metrics

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -7,10 +7,9 @@ set -eu
 export XMTPD_REFLECTION_ENABLE=true
 export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
-#export XMTPD_SYNC_ENABLE=true
+export XMTPD_SYNC_ENABLE=true
 export XMTPD_INDEXER_ENABLE=true
 export XMTPD_METRICS_ENABLE=true
 export XMTPD_METRICS_METRICS_ADDRESS=0.0.0.0
-export XMTPD_LOG_LEVEL=debug
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/dev/run
+++ b/dev/run
@@ -7,9 +7,10 @@ set -eu
 export XMTPD_REFLECTION_ENABLE=true
 export XMTPD_PAYER_ENABLE=true
 export XMTPD_REPLICATION_ENABLE=true
-export XMTPD_SYNC_ENABLE=true
+#export XMTPD_SYNC_ENABLE=true
 export XMTPD_INDEXER_ENABLE=true
 export XMTPD_METRICS_ENABLE=true
 export XMTPD_METRICS_METRICS_ADDRESS=0.0.0.0
+export XMTPD_LOG_LEVEL=debug
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -168,6 +168,10 @@ func (r *RpcLogStreamer) watchContract(watcher ContractConfig) {
 			// reset self-termination timer
 			timer.Reset(watcher.maxDisconnectTime)
 
+			if nextBlock != nil {
+				fromBlock = *nextBlock
+			}
+
 			if len(logs) == 0 {
 				time.Sleep(NO_LOGS_SLEEP_TIME)
 				continue
@@ -177,13 +181,11 @@ func (r *RpcLogStreamer) watchContract(watcher ContractConfig) {
 				"Got logs",
 				zap.Int("numLogs", len(logs)),
 				zap.Uint64("fromBlock", fromBlock),
+				zap.Time("time", time.Now()),
 			)
 
 			for _, log := range logs {
 				watcher.EventChannel <- log
-			}
-			if nextBlock != nil {
-				fromBlock = *nextBlock
 			}
 		}
 	}

--- a/pkg/indexer/storer/identityUpdate.go
+++ b/pkg/indexer/storer/identityUpdate.go
@@ -58,7 +58,6 @@ func (s *IdentityUpdateStorer) StoreLog(
 	if err != nil {
 		return NewUnrecoverableLogStorageError(err)
 	}
-
 	err = db.RunInTx(
 		ctx,
 		s.db,
@@ -83,6 +82,7 @@ func (s *IdentityUpdateStorer) StoreLog(
 			s.logger.Info(
 				"Inserting identity update from contract",
 				zap.String("topic", messageTopic.String()),
+				zap.Time("time", time.Now()),
 			)
 
 			clientEnvelope, err := envelopes.NewClientEnvelopeFromBytes(msgSent.Update)

--- a/pkg/interceptors/server/openConnections.go
+++ b/pkg/interceptors/server/openConnections.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"context"
+	"github.com/xmtp/xmtpd/pkg/metrics"
+	"google.golang.org/grpc"
+)
+
+// OpenConnectionsInterceptor reports open connections for unary and stream RPCs.
+type OpenConnectionsInterceptor struct {
+}
+
+// NewOpenConnectionsInterceptor creates a new instance of OpenConnectionsInterceptor.
+func NewOpenConnectionsInterceptor() (*OpenConnectionsInterceptor, error) {
+	return &OpenConnectionsInterceptor{}, nil
+}
+
+// Unary intercepts unary RPC calls to log errors.
+func (i *OpenConnectionsInterceptor) Unary() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		oc := metrics.NewApiOpenConnection("unary", info.FullMethod)
+		defer oc.Close()
+		return handler(ctx, req) // Call the actual RPC handler
+	}
+}
+
+// Stream intercepts stream RPC calls to log errors.
+func (i *OpenConnectionsInterceptor) Stream() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		oc := metrics.NewApiOpenConnection("stream", info.FullMethod)
+		defer oc.Close()
+		return handler(srv, ss) // Call the actual stream handler
+	}
+}

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var apiOpenConnections = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtp_api_open_connections_gauge",
+		Help: "Duration of the node publish call",
+	},
+	[]string{"style", "method"},
+)
+
+type ApiOpenConnection struct {
+	style  string
+	method string
+}
+
+func NewApiOpenConnection(style string, method string) *ApiOpenConnection {
+	oc := ApiOpenConnection{
+		style:  style,
+		method: method,
+	}
+
+	apiOpenConnections.With(prometheus.Labels{"style": oc.style, "method": oc.method}).Inc()
+
+	return &oc
+}
+
+func (oc *ApiOpenConnection) Close() {
+	apiOpenConnections.With(prometheus.Labels{"style": oc.style, "method": oc.method}).Dec()
+}

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -7,7 +7,7 @@ import (
 var apiOpenConnections = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "xmtp_api_open_connections_gauge",
-		Help: "Duration of the node publish call",
+		Help: "Number of open API connections",
 	},
 	[]string{"style", "method"},
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -83,6 +83,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		syncOutgoingSyncConnections,
 		syncFailedOutgoingSyncConnections,
 		syncFailedOutgoingSyncConnectionCounter,
+		apiOpenConnections,
 	}
 
 	for _, col := range cols {


### PR DESCRIPTION
In a rare case when there are no logs in a batch of 1000, the batch start point never moves and the entire indexer hangs. Fix it.

Also add metrics that were used to debug this.

Fixes #659 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced connection monitoring with a new interceptor for managing open connections in the API server.
  - Refined logging across key operations, including block handling and identity updates, with precise timestamp details.
  - Integrated Prometheus-based metrics to track active API connections for improved performance insights.

- **Bug Fixes**
  - Corrected the logic for updating the `fromBlock` variable to ensure it reflects the latest available block.

- **Documentation**
  - Added detailed logging statements to improve observability of operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->