### PR TITLE
Auth as PAT in nightly automation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           commit-message: Nightly Protos
           title: Update Protos
+          token: ${{ secrets.GH_PAT_NIGHTLY_AUTOMATION }}
           body: |
             - Nightly Proto Update
 


### PR DESCRIPTION
Small fix: The nightly workflow needs a PAT which is not GITHUB_TOKEN, so the resulting PR triggers the workflows.

Context: https://github.com/orgs/community/discussions/65321

```
When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
``` 