### PR TITLE
Fix abigen 0.2-dev

### DIFF
--- a/contracts/dev/generate
+++ b/contracts/dev/generate
@@ -26,7 +26,7 @@ function generate_bindings() {
     rm -f "${output_dir}/${package}"/*.go
 
     # Generate ABI and bytecode
-    if ! forge inspect "${source_artifact}:${filename}" abi > "${build_artifact}.abi.json"; then
+    if ! forge inspect --json "${source_artifact}:${filename}" abi > "${build_artifact}.abi.json"; then
         echo "ERROR: Failed to generate ABI for ${filename}" >&2
         exit 1
     fi


### PR DESCRIPTION
## Add JSON flag to forge inspect ABI generation
Modified the `forge inspect` command to include `--json` flag when generating contract ABI files in the contract artifact generation process

### 📍Where to Start
The contract generation script in [generate](https://github.com/xmtp/xmtpd/pull/673/files#diff-16396152aa84a7bd0a1dc57253b14142f9a26e125671247450c69f6c98ce4999R0)

----

_[Macroscope](https://app.macroscope.com) summarized 067704b._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- ABI generation now produces outputs in a standardized JSON format, providing a more consistent and structured representation of ABI data for improved integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->