### PR TITLE
0.2-dev Fix Version Verifier

### DIFF
--- a/pkg/authn/claims_test.go
+++ b/pkg/authn/claims_test.go
@@ -130,6 +130,9 @@ func TestClaimsValidator(t *testing.T) {
 
 	currentVersion := *testutils.GetLatestVersion(t)
 
+	patch0Version := *semver.New(currentVersion.Major(), currentVersion.Minor(), 0, "", "")
+	version010 := *semver.New(0, 1, 0, "", "")
+
 	tests := []struct {
 		name          string
 		version       semver.Version
@@ -156,9 +159,27 @@ func TestClaimsValidator(t *testing.T) {
 			true,
 		},
 		{
+			"future-minor-rejects-us",
+			currentVersion,
+			currentVersion.IncMinor(),
+			true,
+		},
+		{
 			"future-patch-accepts-us",
 			currentVersion,
 			currentVersion.IncPatch(),
+			false,
+		},
+		{
+			"patch-0-accepts-us",
+			currentVersion,
+			patch0Version,
+			false,
+		},
+		{
+			"version-0-1-0-rejects-us",
+			currentVersion,
+			version010,
 			true,
 		},
 	}

--- a/pkg/authn/verifier.go
+++ b/pkg/authn/verifier.go
@@ -3,6 +3,7 @@ package authn
 import (
 	"fmt"
 	"github.com/Masterminds/semver/v3"
+	"go.uber.org/zap"
 	"strconv"
 	"time"
 
@@ -26,11 +27,12 @@ A RegistryVerifier connects to the NodeRegistry and verifies JWTs against the re
 based on the JWT's subject field
 */
 func NewRegistryVerifier(
+	logger *zap.Logger,
 	registry registry.NodeRegistry,
 	myNodeID uint32,
 	serverVersion *semver.Version,
 ) (*RegistryVerifier, error) {
-	validator, err := NewClaimValidator(serverVersion)
+	validator, err := NewClaimValidator(logger, serverVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authn/verifier_test.go
+++ b/pkg/authn/verifier_test.go
@@ -27,6 +27,7 @@ func buildVerifier(
 ) (*authn.RegistryVerifier, *registryMocks.MockNodeRegistry) {
 	mockRegistry := registryMocks.NewMockNodeRegistry(t)
 	verifier, err := authn.NewRegistryVerifier(
+		testutils.NewLog(t),
 		mockRegistry,
 		verifierNodeID,
 		version,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -271,6 +271,7 @@ func startAPIServer(
 
 	if s.nodeRegistry != nil && s.registrant != nil {
 		jwtVerifier, err = authn.NewRegistryVerifier(
+			logger,
 			s.nodeRegistry,
 			s.registrant.NodeID(),
 			serverVersion,

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -117,6 +117,7 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks, fu
 	mockValidationService := mlsvalidateMocks.NewMockMLSValidationService(t)
 
 	jwtVerifier, err := authn.NewRegistryVerifier(
+		log,
 		mockRegistry,
 		registrant.NodeID(),
 		testutils.GetLatestVersion(t),


### PR DESCRIPTION
This is the fix for 0.2-dev. There will be another PR for main.

The verifier constraint on 0.2.2 was parsed as ^0.2.2 which does not allow for 0.2.0 or 0.2.1.

This now parses the constraint as `^0.2` which translates to `>=0.2.0 and <0.3.0`

Relates to #670. The fix to main will be closing this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced backend authentication and verification processes by integrating improved logging that offers clearer traceability for version compatibility. This streamlining of version handling helps ensure smoother and more maintainable internal synchronization.

- **Tests**
  - Expanded test coverage with new scenarios that rigorously validate version compatibility across various version increments, reinforcing robust system behavior and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->