### PR TITLE
docs(readme): add badge and link to lint workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # xmtpd
 
 [![Test](https://github.com/xmtp/xmtpd/actions/workflows/test.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/test.yml)
+[![Lint](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml)
 [![Build](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml)
 
 **⚠️ Experimental:** This software is in early development. Expect frequent changes and unresolved issues.


### PR DESCRIPTION
## Add Lint Workflow Badge to README
Added a GitHub Actions Lint workflow status badge to the README header, positioned between existing Test and Build badges

### 📍Where to Start
The badge and workflow link changes in [README.md](https://github.com/xmtp/xmtpd/pull/677/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R0)

----

_[Macroscope](https://app.macroscope.com) summarized c78a3cf._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a linting status badge in the project documentation to provide immediate feedback on code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->