### PR TITLE
chore: add icon and link to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # xmtpd
 
+[![Github tag](https://img.shields.io/github/v/tag/xmtp/xmtpd.svg?sort=semver)](https://github.com/xmtp/xmtpd/releases/latest)
 [![Test](https://github.com/xmtp/xmtpd/actions/workflows/test.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/test.yml)
 [![Lint](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml)
 [![Build](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml)


### PR DESCRIPTION
## Add GitHub tag badge to README
Added a GitHub tag badge to README.md that displays and links to the latest version release of the xmtpd repository

### 📍Where to Start
The badge addition in [README.md](https://github.com/xmtp/xmtpd/pull/678/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R0)

----

_[Macroscope](https://app.macroscope.com) summarized a16deea._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated project documentation with a new badge that displays the latest release version for easy reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->