### PR TITLE
Rework retry and Fix Version Verifier

### DIFF
--- a/pkg/authn/claims_test.go
+++ b/pkg/authn/claims_test.go
@@ -130,6 +130,9 @@ func TestClaimsValidator(t *testing.T) {
 
 	currentVersion := *testutils.GetLatestVersion(t)
 
+	patch0Version := *semver.New(currentVersion.Major(), currentVersion.Minor(), 0, "", "")
+	version010 := *semver.New(0, 1, 0, "", "")
+
 	tests := []struct {
 		name          string
 		version       semver.Version
@@ -156,9 +159,27 @@ func TestClaimsValidator(t *testing.T) {
 			true,
 		},
 		{
+			"future-minor-rejects-us",
+			currentVersion,
+			currentVersion.IncMinor(),
+			true,
+		},
+		{
 			"future-patch-accepts-us",
 			currentVersion,
 			currentVersion.IncPatch(),
+			false,
+		},
+		{
+			"patch-0-accepts-us",
+			currentVersion,
+			patch0Version,
+			false,
+		},
+		{
+			"version-0-1-0-rejects-us",
+			currentVersion,
+			version010,
 			true,
 		},
 	}

--- a/pkg/authn/verifier.go
+++ b/pkg/authn/verifier.go
@@ -3,6 +3,7 @@ package authn
 import (
 	"fmt"
 	"github.com/Masterminds/semver/v3"
+	"go.uber.org/zap"
 	"strconv"
 	"time"
 
@@ -26,11 +27,12 @@ A RegistryVerifier connects to the NodeRegistry and verifies JWTs against the re
 based on the JWT's subject field
 */
 func NewRegistryVerifier(
+	logger *zap.Logger,
 	registry registry.NodeRegistry,
 	myNodeID uint32,
 	serverVersion *semver.Version,
 ) (*RegistryVerifier, error) {
-	validator, err := NewClaimValidator(serverVersion)
+	validator, err := NewClaimValidator(logger, serverVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authn/verifier_test.go
+++ b/pkg/authn/verifier_test.go
@@ -27,6 +27,7 @@ func buildVerifier(
 ) (*authn.RegistryVerifier, *registryMocks.MockNodeRegistry) {
 	mockRegistry := registryMocks.NewMockNodeRegistry(t)
 	verifier, err := authn.NewRegistryVerifier(
+		testutils.NewLog(t),
 		mockRegistry,
 		verifierNodeID,
 		version,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -307,6 +307,7 @@ func startAPIServer(
 
 	if s.nodeRegistry != nil && s.registrant != nil {
 		jwtVerifier, err = authn.NewRegistryVerifier(
+			logger,
 			s.nodeRegistry,
 			s.registrant.NodeID(),
 			serverVersion,

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"io"
+	"strings"
 	"sync"
 	"time"
 )
@@ -43,14 +44,6 @@ type originatorStream struct {
 	nodeID       uint32
 	lastEnvelope *envUtils.OriginatorEnvelope
 	stream       message_api.ReplicationApi_SubscribeEnvelopesClient
-}
-
-type ExitLoopError struct {
-	Message string
-}
-
-func (e *ExitLoopError) Error() string {
-	return e.Message
 }
 
 func startSyncWorker(
@@ -233,18 +226,16 @@ func (s *syncWorker) subscribeToNodeRegistration(
 
 		connectionsStatusCounter.MarkSuccess()
 
-		_ = s.listenToStream(registration.ctx, *node, stream)
-		return "", nil // try again from the start and reset backoff
+		err = s.listenToStream(registration.ctx, *node, stream)
+		return "", err
 	}
 
-	for {
-		// re-establish the connection unless we are shutting down
-		_, err = backoff.Retry(registration.ctx, operation, backoff.WithBackOff(expBackoff))
-		if err != nil {
-			return
-		}
-	}
-
+	_, _ = backoff.Retry(
+		registration.ctx,
+		operation,
+		backoff.WithBackOff(expBackoff),
+		backoff.WithMaxElapsedTime(0),
+	)
 }
 
 func (s *syncWorker) handleUnhealthyNode(registration NodeRegistration) {
@@ -389,7 +380,7 @@ func (s *syncWorker) listenToStream(
 		select {
 		case <-s.ctx.Done():
 			s.log.Info("Context canceled, stopping stream listener")
-			return nil
+			return backoff.Permanent(s.ctx.Err())
 
 		case envs := <-recvChan:
 			s.log.Debug(
@@ -405,14 +396,22 @@ func (s *syncWorker) listenToStream(
 		case err := <-errChan:
 			if err == io.EOF {
 				s.log.Info("Stream closed with EOF")
-				// let the caller rebuild the stream if required
-				return nil
+				// reset backoff to 1 second
+				return backoff.RetryAfter(1)
 			}
 			s.log.Error(
 				"Stream closed with error",
 				zap.String("peer", node.HttpAddress),
 				zap.Error(err),
 			)
+
+			if strings.Contains(err.Error(), "is not compatible") {
+				// the node won't accept our version
+				// try again in an hour in case their config has changed
+				return backoff.RetryAfter(3600)
+			}
+
+			// keep existing backoff
 			return err
 		}
 	}

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -120,6 +120,7 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks, fu
 	mockValidationService := mlsvalidateMocks.NewMockMLSValidationService(t)
 
 	jwtVerifier, err := authn.NewRegistryVerifier(
+		log,
 		mockRegistry,
 		registrant.NodeID(),
 		testutils.GetLatestVersion(t),


### PR DESCRIPTION
The verifier constraint on 0.2.2 was parsed as ^0.2.2 which does not allow for 0.2.0 or 0.2.1. This now parses the constraint as `^0.2` which translates to `>=0.2.0 and <0.3.0`.
Fixes #670 

Retry was working OK, but it some cases it would get too fast, ignoring the exponential backoff. This PR explicitly controls the backoff strategy.
