### PR TITLE
Fix GRPC KeepAlive

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           context: .
           file: ./dev/docker/${{ steps.set_dockerfile.outputs.dockerfile }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "VERSION=${{ steps.ghd.outputs.describe }}"

--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           context: .
           file: ./dev/docker/${{ steps.set_dockerfile.outputs.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "VERSION=${{ steps.ghd.outputs.describe }}"

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -112,13 +112,16 @@ func (s *Service) SubscribeEnvelopes(
 		return err
 	}
 
+	// GRPC keep-alives are not sufficient in some load balanced environments
+	// we need to send an actual payload
+	// see https://github.com/xmtp/xmtpd/issues/669
 	ticker := time.NewTicker(s.options.SendKeepAliveInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			err = stream.Send(nil)
+			err = stream.Send(&message_api.SubscribeEnvelopesResponse{})
 			if err != nil {
 				return status.Errorf(codes.Internal, "could not send keepalive: %v", err)
 			}

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -120,9 +120,8 @@ func (s *Service) SubscribeEnvelopes(
 		case <-ticker.C:
 			err = stream.Send(nil)
 			if err != nil {
-				return status.Errorf(codes.Internal, "could not send header: %v", err)
+				return status.Errorf(codes.Internal, "could not send keepalive: %v", err)
 			}
-			log.Info("sending keep-alive")
 		case envs, open := <-ch:
 			ticker.Reset(s.options.SendKeepAliveInterval)
 			if open {

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -108,8 +108,17 @@ func (s *Service) SubscribeEnvelopes(
 		return err
 	}
 
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
+		case <-ticker.C:
+			err = stream.Send(nil)
+			if err != nil {
+				return status.Errorf(codes.Internal, "could not send header: %v", err)
+			}
+			log.Info("sending keep-alive")
 		case envs, open := <-ch:
 			if open {
 				err := s.sendEnvelopes(stream, query, envs)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -48,7 +48,8 @@ type PayerOptions struct {
 }
 
 type ReplicationOptions struct {
-	Enable bool `long:"enable" env:"XMTPD_REPLICATION_ENABLE" description:"Enable the replication API"`
+	Enable                bool          `long:"enable"                   env:"XMTPD_REPLICATION_ENABLE"           description:"Enable the replication API"`
+	SendKeepAliveInterval time.Duration `long:"send-keep-alive-interval" env:"XMTPD_API_SEND_KEEP_ALIVE_INTERVAL" description:"Send empty application level keepalive package interval" default:"30s"`
 }
 
 type SyncOptions struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -207,6 +207,7 @@ func startAPIServer(
 				s.validationService,
 				s.cursorUpdater,
 				getRatesFetcher(),
+				options.Replication,
 			)
 			if err != nil {
 				return err

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -57,7 +57,8 @@ func NewTestServer(
 			Enable: true,
 		},
 		Replication: config.ReplicationOptions{
-			Enable: true,
+			Enable:                true,
+			SendKeepAliveInterval: 30 * time.Second,
 		},
 	}, registry, db, fmt.Sprintf("localhost:%d", port), fmt.Sprintf("localhost:%d", httpPort), testutils.GetLatestVersion(t))
 	require.NoError(t, err)

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -21,7 +21,6 @@ import (
 	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/keepalive"
 	"io"
 	"sync"
 	"time"
@@ -299,11 +298,6 @@ func (s *syncWorker) connectToNode(node registry.Node) (*grpc.ClientConn, error)
 	dialOpts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(interceptor.Unary()),
 		grpc.WithStreamInterceptor(interceptor.Stream()),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                15 * time.Second,
-			Timeout:             5 * time.Second,
-			PermitWithoutStream: true,
-		}),
 	}
 	conn, err := node.BuildClient(dialOpts...)
 	if err != nil {

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -300,7 +300,7 @@ func (s *syncWorker) connectToNode(node registry.Node) (*grpc.ClientConn, error)
 		grpc.WithUnaryInterceptor(interceptor.Unary()),
 		grpc.WithStreamInterceptor(interceptor.Stream()),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                20 * time.Second,
+			Time:                15 * time.Second,
 			Timeout:             5 * time.Second,
 			PermitWithoutStream: true,
 		}),

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"io"
 	"sync"
 	"time"
@@ -298,6 +299,11 @@ func (s *syncWorker) connectToNode(node registry.Node) (*grpc.ClientConn, error)
 	dialOpts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(interceptor.Unary()),
 		grpc.WithStreamInterceptor(interceptor.Stream()),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                20 * time.Second,
+			Timeout:             5 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	}
 	conn, err := node.BuildClient(dialOpts...)
 	if err != nil {

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -398,6 +398,9 @@ func (s *syncWorker) listenToStream(
 			return nil
 
 		case envs := <-recvChan:
+			if envs == nil || len(envs.Envelopes) == 0 {
+				continue
+			}
 			s.log.Debug(
 				"Received envelopes",
 				zap.String("peer", node.HttpAddress),

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/xmtp/xmtpd/pkg/config"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -137,6 +139,9 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks, fu
 			mockValidationService,
 			metadata.NewCursorUpdater(ctx, log, db),
 			ratesFetcher,
+			config.ReplicationOptions{
+				SendKeepAliveInterval: 30 * time.Second,
+			},
 		)
 		require.NoError(t, err)
 		message_api.RegisterReplicationApiServer(grpcServer, replicationService)


### PR DESCRIPTION
GRPC keep-alives are not sufficient in some load balanced environments. We need to send an actual payload

Fixes https://github.com/xmtp/xmtpd/issues/669

## Add Connection Keep-Alive Mechanisms and Update Docker Build Workflow
Added keep-alive mechanisms to gRPC connections and message subscriptions, and modified Docker build workflow to always push images. Changes include: 5-second keep-alive ticker in `SubscribeEnvelopes`, gRPC keepalive parameters in `connectToNode`, and unconditional Docker image pushing in build workflow.

### 📍Where to Start
The `SubscribeEnvelopes` method in [service.go](https://github.com/xmtp/xmtpd/pull/680/files#diff-9d5e38f13e297fdd812f6e9228cb674e4a0671cf48362ea927ae776a9e3e43a4R0) which contains the new keep-alive implementation.

----

_[Macroscope](https://app.macroscope.com) summarized 958ca65._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the replication service with configurable periodic health checks to maintain robust connections.
	- Updated service initialization and test setups to include new configuration options.

- **Bug Fixes**
	- Improved stream processing by filtering out empty data, ensuring more stable and efficient operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->