### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,6 @@ linters:
     - nakedret
     - nilerr
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck


### PR DESCRIPTION
Remove gosimple from the enable section, as it is no longer supported in newer versions of golangci-lint. The other linters can be left. Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide.](https://golangci-lint.run/product/migration-guide/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Made adjustments to internal code quality configurations to streamline analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->