### PR TITLE
Do not register same pubkey for multiple nodes

### DIFF
--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -58,6 +58,7 @@ type RegisterNodeOptions struct {
 	OwnerAddress              string       `                                        long:"node-owner-address"            description:"Blockchain address of the intended owner of the registration NFT" required:"true"`
 	SigningKeyPub             string       `                                        long:"node-signing-key-pub"          description:"Signing key of the node to register"                              required:"true"`
 	MinMonthlyFeeMicroDollars int64        `                                        long:"min-monthly-fee-micro-dollars" description:"Minimum monthly fee to register the node"                         required:"false"`
+	Force                     bool         `                                        long:"force" description:"Register even if pubkey already exists"                         required:"false"`
 }
 
 type SetHttpAddressOptions struct {


### PR DESCRIPTION
In general, we do not want to re-register the same pubkey with a new NodeId.

If this is truly desired, one can register override with `--force`