### PR TITLE
deleted broken link  deploy.md

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -77,7 +77,7 @@ And you should get something along these lines:
 
 ## Deploy XMTPD nodes
 
-Node deployment is currently fully handled by [Ephemera](https://github.com/ephemeraHQ/infrastructure) and only members of @ephemerahq/backend have access to it.
+Node deployment is currently fully handled by [Ephemera]() and only members of @ephemerahq/backend have access to it.
 
 There are currently two nodes running:
 


### PR DESCRIPTION
Hi, I was reading the documentation and found a broken link. The `infrastructure` repository in the `Ephemera` project was deleted. If there's a replacement, I'm happy to update it. Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the hyperlink in the Deploy XMTPD nodes section to remove the outdated URL, resulting in a blank reference for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->