### PR TITLE
Lower log levels for HA duplicate entries

### DIFF
--- a/pkg/indexer/storer/groupMessage.go
+++ b/pkg/indexer/storer/groupMessage.go
@@ -88,7 +88,7 @@ func (s *GroupMessageStorer) StoreLog(
 		return NewUnrecoverableLogStorageError(err)
 	}
 
-	s.logger.Debug("Inserting message from contract", zap.String("topic", topicStruct.String()))
+	s.logger.Info("Inserting message from contract", zap.String("topic", topicStruct.String()))
 
 	if _, err = s.queries.InsertGatewayEnvelope(ctx, queries.InsertGatewayEnvelopeParams{
 		OriginatorNodeID:     GROUP_MESSAGE_ORIGINATOR_ID,

--- a/pkg/indexer/storer/identityUpdate.go
+++ b/pkg/indexer/storer/identityUpdate.go
@@ -69,8 +69,8 @@ func (s *IdentityUpdateStorer) StoreLog(
 			}
 
 			if uint64(latestSequenceId) >= msgSent.SequenceId {
-				s.logger.Warn(
-					"Duplicate identity update",
+				s.logger.Debug(
+					"Identity update already inserted. Skipping... ",
 					zap.Uint64("latest_sequence_id", uint64(latestSequenceId)),
 					zap.Uint64("msg_sequence_id", msgSent.SequenceId),
 				)
@@ -82,7 +82,6 @@ func (s *IdentityUpdateStorer) StoreLog(
 			s.logger.Info(
 				"Inserting identity update from contract",
 				zap.String("topic", messageTopic.String()),
-				zap.Time("time", time.Now()),
 			)
 
 			clientEnvelope, err := envelopes.NewClientEnvelopeFromBytes(msgSent.Update)


### PR DESCRIPTION
Most if not all identity updates will see duplicates when running in HA mode. No need to warn about these.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced logging messages to improve tracking for message insertions.
  - Refined log outputs for identity updates to reduce duplicate alerts and streamline monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->