### PR TITLE
Add support for new envelope types

### DIFF
--- a/pkg/envelopes/client.go
+++ b/pkg/envelopes/client.go
@@ -81,6 +81,10 @@ func (c *ClientEnvelope) TopicMatchesPayload() bool {
 		return targetTopicKind == topic.TOPIC_KIND_IDENTITY_UPDATES_V1
 	case *envelopesProto.ClientEnvelope_UploadKeyPackage:
 		return targetTopicKind == topic.TOPIC_KIND_KEY_PACKAGES_V1
+	case *envelopesProto.ClientEnvelope_PayerReport:
+		return targetTopicKind == topic.TOPIC_KIND_PAYER_REPORTS_V1
+	case *envelopesProto.ClientEnvelope_PayerReportAttestation:
+		return targetTopicKind == topic.TOPIC_KIND_PAYER_REPORT_ATTESTATIONS_V1
 	default:
 		return false
 	}

--- a/pkg/envelopes/envelopes_test.go
+++ b/pkg/envelopes/envelopes_test.go
@@ -134,6 +134,14 @@ func TestPayloadType(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.False(t, clientEnvelope.TopicMatchesPayload())
+
+	// Payer Report envelope with wrong topic
+	clientEnvelope, err = NewClientEnvelope(&envelopesProto.ClientEnvelope{
+		Payload: &envelopesProto.ClientEnvelope_PayerReport{},
+		Aad:     buildAad(topic.NewTopic(topic.TOPIC_KIND_GROUP_MESSAGES_V1, []byte{1, 2, 3})),
+	})
+	require.NoError(t, err)
+	require.False(t, clientEnvelope.TopicMatchesPayload())
 }
 
 func TestRecoverSigner(t *testing.T) {

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -12,6 +12,8 @@ const (
 	TOPIC_KIND_WELCOME_MESSAGES_V1
 	TOPIC_KIND_IDENTITY_UPDATES_V1
 	TOPIC_KIND_KEY_PACKAGES_V1
+	TOPIC_KIND_PAYER_REPORTS_V1
+	TOPIC_KIND_PAYER_REPORT_ATTESTATIONS_V1
 )
 
 func (k TopicKind) String() string {
@@ -24,6 +26,10 @@ func (k TopicKind) String() string {
 		return "identity_updates_v1"
 	case TOPIC_KIND_KEY_PACKAGES_V1:
 		return "key_packages_v1"
+	case TOPIC_KIND_PAYER_REPORTS_V1:
+		return "payer_reports_v1"
+	case TOPIC_KIND_PAYER_REPORT_ATTESTATIONS_V1:
+		return "payer_report_attestations_v1"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
### TL;DR

Added support for payer reports and payer report attestations in the envelope system.

### What changed?

- Added two new topic kinds: `TOPIC_KIND_PAYER_REPORTS_V1` and `TOPIC_KIND_PAYER_REPORT_ATTESTATIONS_V1` to the topic package
- Extended the `TopicMatchesPayload()` function to handle the new payload types: `PayerReport` and `PayerReportAttestation`
- Added a test case for payer report envelopes with mismatched topics

### How to test?

1. Run the existing test suite to verify that the new topic kinds and payload types are properly handled:
   ```
   go test ./pkg/envelopes/...
   go test ./pkg/topic/...
   ```
2. Create client envelopes with payer report payloads and verify they match with the correct topic kinds.

### Why make this change?

This change extends the envelope system to support payer reports and their attestations, which are needed for payment verification and reporting functionality. The envelope system needs to properly match these new payload types with their corresponding topics to ensure messages are routed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded message processing to support additional report and attestation types, enhancing how diverse data is managed.
  - Improved topic categorization to align with these new data types.

- **Tests**
  - Added a scenario to verify that the system correctly handles cases where the data type does not match the expected topic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->