### PR TITLE
Reentrant add node to network

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/xmtp/xmtpd/pkg/abi/rateregistry"
@@ -268,7 +269,12 @@ func addNodeToNetwork(logger *zap.Logger, options *CLI) {
 		options.NetworkAdminOptions.NodeId,
 	)
 	if err != nil {
-		logger.Fatal("could not add node to network", zap.Error(err))
+		// TODO(borja): This is a patch until NodeRegistry implements fine grain errors.
+		if strings.Contains(err.Error(), "FailedToAddNodeToCanonicalNetwork") {
+			logger.Info("node already in network")
+		} else {
+			logger.Fatal("could not add node to network", zap.Error(err))
+		}
 	}
 }
 


### PR DESCRIPTION
### Modify `addNodeToNetwork` function in CLI to handle duplicate node additions gracefully
Updates error handling in [main.go](https://github.com/xmtp/xmtpd/pull/707/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) to prevent fatal errors when adding nodes that already exist in the network:

* Adds check for `FailedToAddNodeToCanonicalNetwork` error string
* Logs informational message instead of fatal error for duplicate nodes
* Includes temporary error handling until NodeRegistry implements granular errors

#### 📍Where to Start
Start with the `addNodeToNetwork` function in [main.go](https://github.com/xmtp/xmtpd/pull/707/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) where the error handling logic has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized 8011bc8._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error messaging during node addition to gracefully handle duplicate entry scenarios, providing clear notifications without abruptly terminating the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->