### PR TITLE
Add from-0.3.0 upgrade tests

### DIFF
--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -10,9 +10,9 @@ import (
 
 // Guaranteed to be in order of increasing version
 var (
-	// contracts v0.3.0 are not compatible with xmtpd v0.2.X
-	// re-enable this test when we have a xmtpd compatible release.
-	xmtpdVersions = []string{}
+	xmtpdVersions = []string{
+		"0.3.0",
+	}
 
 	ghcrRepository = "ghcr.io/xmtp/xmtpd"
 )


### PR DESCRIPTION
### Enable upgrade tests for xmtpd version 0.3.0 by updating version compatibility in test configuration
Updates the `xmtpdVersions` test configuration in [upgrade_test.go](https://github.com/xmtp/xmtpd/pull/710/files#diff-3847e89fc66c5ccdfca872616eb1dd96c8a781edbed21efe5f5fbbdfe41f5396) to include version `0.3.0`, re-enabling previously disabled compatibility tests.

#### 📍Where to Start
Start with the `xmtpdVersions` slice definition in [upgrade_test.go](https://github.com/xmtp/xmtpd/pull/710/files#diff-3847e89fc66c5ccdfca872616eb1dd96c8a781edbed21efe5f5fbbdfe41f5396) which configures the versions used in upgrade testing.

----

_[Macroscope](https://app.macroscope.com) summarized 449be71._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the test suite to validate using xmtpd version 0.3.0 for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->