### PR TITLE
POC MLS C Bindings

### DIFF
--- a/pkg/embeddedmls/lib/libxmtpmls.h
+++ b/pkg/embeddedmls/lib/libxmtpmls.h
@@ -1,0 +1,19 @@
+#ifndef LIBXMTDMLS_H
+#define LIBXMTDMLS_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct ValidationResult {
+  bool ok;
+  char *message;
+} ValidationResult;
+
+struct ValidationResult validate_inbox_id_key_package_ffi(const unsigned char *data_ptr,
+                                                          size_t data_len);
+
+void free_c_string(char *s);
+
+#endif  /* LIBXMTDMLS_H */

--- a/pkg/embeddedmls/validation.go
+++ b/pkg/embeddedmls/validation.go
@@ -1,0 +1,27 @@
+package embeddedmls
+
+/*
+#cgo LDFLAGS: -L./lib -lbindings_c
+#include <stdbool.h>
+#include <stdlib.h>
+#include "lib/libxmtpmls.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+func ValidateKeyPackage(data []byte) error {
+	result := C.validate_inbox_id_key_package_ffi(
+		(*C.uchar)(unsafe.Pointer(&data[0])),
+		C.ulong(len(data)),
+	)
+	defer C.free_c_string(result.message)
+	if !result.ok {
+		return errors.New(C.GoString(result.message))
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Replace service-based MLS validation with embedded C library in message service by integrating new `embeddedmls` package
* Introduces new C bindings for MLS validation through [libxmtpmls.h](https://github.com/xmtp/xmtpd/pull/715/files#diff-a4f9788b9541832bad9d52bf869dc40d3a3d07a0e3930924ee189c61a1579308) header file defining the `ValidationResult` struct and `validate_inbox_id_key_package_ffi` function
* Creates Go wrapper in [validation.go](https://github.com/xmtp/xmtpd/pull/715/files#diff-dd42dcbc6dd547d667410731bc41918df9bdae6e0ef4120b9718d46781ce14e3) providing `ValidateKeyPackage` function to interface with C library
* Modifies [service.go](https://github.com/xmtp/xmtpd/pull/715/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) to use direct `embeddedmls.ValidateKeyPackage` calls instead of service-based validation, removing context parameter requirement

#### 📍Where to Start
Start with the `ValidateKeyPackage` function in [validation.go](https://github.com/xmtp/xmtpd/pull/715/files#diff-dd42dcbc6dd547d667410731bc41918df9bdae6e0ef4120b9718d46781ce14e3) which provides the Go interface to the C validation library.

----

_[Macroscope](https://app.macroscope.com) summarized e98bdde._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced key package validation system that integrates with external utilities to deliver clearer error feedback and increased reliability during message dispatch. This upgrade provides a smoother user experience with more resilient messaging.

- **Refactor**
  - Simplified the envelope processing workflow to enhance overall performance and reduce overhead.
  - Optimized memory management within the validation process for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->