### PR TITLE
chore: fix some struct names in comment

### DIFF
--- a/pkg/currency/currency.go
+++ b/pkg/currency/currency.go
@@ -6,7 +6,7 @@ import (
 	"math"
 )
 
-// Picodollar is a type to represent currency with 12 decimal precision
+// PicoDollar is a type to represent currency with 12 decimal precision
 type PicoDollar int64
 
 const (

--- a/pkg/fees/contractRates.go
+++ b/pkg/fees/contractRates.go
@@ -37,7 +37,7 @@ type indexedRates struct {
 	rates     *Rates
 }
 
-// ContractsRatesFetcher pulls all the rates from the RatesManager contract
+// ContractRatesFetcher pulls all the rates from the RatesManager contract
 // and stores them in a sorted set to find the appropriate rate for a given timestamp
 type ContractRatesFetcher struct {
 	ctx             context.Context


### PR DESCRIPTION
fix some struct names in comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling in comments to accurately reflect type names. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->