### PR TITLE
Generate metrics catalog

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -40,3 +40,7 @@ jobs:
         uses: nickcharlton/diff-check@v1.0.0
         with:
           command: go tool -modfile=tools/go.mod mockery
+      - name: metrics catalog
+        uses: nickcharlton/diff-check@v1.0.0
+        with:
+          command: ./dev/generate-metrics-catalog

--- a/dev/generate-metrics-catalog
+++ b/dev/generate-metrics-catalog
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+# Work always from the root directory
+script_dir=$(dirname "$(realpath "$0")")
+repo_root=$(realpath "${script_dir}/../")
+cd "${repo_root}"
+
+go run pkg/metrics/docs/generator.go

--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -1,0 +1,20 @@
+| Name | Type | Description | File |
+|------|------|-------------|------|
+| `xmtp_api_incoming_node_connection_by_version_gauge` | `Gauge` | Number of incoming node connections by version | `pkg/metrics/api.go` |
+| `xmtp_api_node_connection_requests_by_version_counter` | `Counter` | Number of incoming node connections by version | `pkg/metrics/api.go` |
+| `xmtp_api_open_connections_gauge` | `Gauge` | Number of open API connections | `pkg/metrics/api.go` |
+| `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist | `pkg/metrics/payer.go` |
+| `xmtp_payer_messages_originated` | `Counter` | Number of messages originated by the payer. | `pkg/metrics/payer.go` |
+| `xmtp_payer_node_publish_duration_seconds` | `Histogram` | Duration of the node publish call | `pkg/metrics/payer.go` |
+| `xmtp_payer_read_own_commit_in_time_seconds` | `Histogram` | Read your own commit duration in seconds | `pkg/metrics/payer.go` |
+| `xmtp_sync_failed_outgoing_sync_connections_counter` | `Counter` | Counter of total number of failed outgoing sync connection attempts | `pkg/metrics/sync.go` |
+| `xmtp_sync_messages_received_count` | `Counter` | Count of messages received from the originator | `pkg/metrics/sync.go` |
+| `xmtp_sync_messages_received_error_count` | `Counter` | Count of failed/errored messages received from the originator | `pkg/metrics/sync.go` |
+| `xmtp_sync_originator_sequence_id` | `Gauge` | Last synced sequence id of the originator | `pkg/metrics/sync.go` |
+| `xmtpd_indexer_log_streamer_block_lag` | `Gauge` | Lag between current block and max block | `pkg/metrics/indexer.go` |
+| `xmtpd_indexer_log_streamer_current_block` | `Gauge` | Current block being processed by the log streamer | `pkg/metrics/indexer.go` |
+| `xmtpd_indexer_log_streamer_get_logs_duration` | `Histogram` | Duration of the get logs call | `pkg/metrics/indexer.go` |
+| `xmtpd_indexer_log_streamer_get_logs_requests` | `Counter` | Number of get logs requests | `pkg/metrics/indexer.go` |
+| `xmtpd_indexer_log_streamer_logs` | `Counter` | Number of logs found by the log streamer | `pkg/metrics/indexer.go` |
+| `xmtpd_indexer_log_streamer_max_block` | `Gauge` | Max block on the chain to be processed by the log streamer | `pkg/metrics/indexer.go` |
+| `xmtpd_indexer_retryable_storage_error_count` | `Counter` | Number of retryable storage errors | `pkg/metrics/indexer.go` |

--- a/pkg/metrics/docs/generator.go
+++ b/pkg/metrics/docs/generator.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const MARKDOWN_OUTPUT = "doc/metrics_catalog.md"
+
+type Metric struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description,omitempty"`
+	File        string `yaml:"file,omitempty"`
+}
+
+type MetricType struct {
+	enabled bool
+	name    string
+}
+
+var metricTypes = map[string]MetricType{
+	"NewCounterVec":   {true, "Counter"},
+	"NewGaugeVec":     {true, "Gauge"},
+	"NewHistogramVec": {true, "Histogram"},
+	"NewSummaryVec":   {true, "Summary"},
+}
+
+func main() {
+	var metrics []Metric
+	root := "pkg/metrics"
+
+	fmt.Printf("Parsing %s to generate %s\n", root, MARKDOWN_OUTPUT)
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		fileMetrics, err := parseFile(path)
+		if err != nil {
+			log.Printf("Error parsing %s: %v", path, err)
+			return nil
+		}
+		metrics = append(metrics, fileMetrics...)
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("Error walking through files: %v", err)
+	}
+
+	dumpToMarkdown(metrics)
+}
+
+func dumpToMarkdown(metrics []Metric) {
+	sort.Slice(metrics, func(i, j int) bool {
+		return metrics[i].Name < metrics[j].Name
+	})
+
+	var sb strings.Builder
+	sb.WriteString("| Name | Type | Description | File |\n")
+	sb.WriteString("|------|------|-------------|------|\n")
+
+	for _, m := range metrics {
+		desc := m.Description
+		if desc == "" {
+			desc = "-"
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s | `%s` |\n",
+			m.Name, m.Type, desc, m.File))
+	}
+
+	if err := os.WriteFile(MARKDOWN_OUTPUT, []byte(sb.String()), 0644); err != nil {
+		log.Fatalf("Error writing Markdown file: %v", err)
+	}
+
+	fmt.Printf("✅ %s generated with %d metrics\n", MARKDOWN_OUTPUT, len(metrics))
+}
+
+func parseFile(path string) ([]Metric, error) {
+	var results []Metric
+	fs := token.NewFileSet()
+	node, err := parser.ParseFile(fs, path, nil, parser.AllErrors)
+	if err != nil {
+		return nil, err
+	}
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		callExpr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := callExpr.Fun.(*ast.SelectorExpr)
+		if !ok || !metricTypes[sel.Sel.Name].enabled {
+			return true
+		}
+
+		// Parse metric name and help string
+		if len(callExpr.Args) > 0 {
+			firstArg, ok := callExpr.Args[0].(*ast.CompositeLit)
+			if ok {
+				metric := Metric{Type: metricTypes[sel.Sel.Name].name, File: path}
+
+				for _, elt := range firstArg.Elts {
+					if kv, ok := elt.(*ast.KeyValueExpr); ok {
+						key := fmt.Sprint(kv.Key)
+						switch key {
+						case "Name":
+							if val, ok := kv.Value.(*ast.BasicLit); ok {
+								metric.Name = strings.Trim(val.Value, `"`)
+							}
+						case "Help":
+							if val, ok := kv.Value.(*ast.BasicLit); ok {
+								metric.Description = strings.Trim(val.Value, `"`)
+							}
+						}
+					}
+				}
+
+				if metric.Name != "" {
+					results = append(results, metric)
+				}
+			}
+		}
+		return true
+	})
+	return results, nil
+}

--- a/pkg/metrics/docs/generator.go
+++ b/pkg/metrics/docs/generator.go
@@ -40,13 +40,17 @@ func main() {
 	fmt.Printf("Parsing %s to generate %s\n", root, MARKDOWN_OUTPUT)
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil || !strings.HasSuffix(path, ".go") {
+		if err != nil {
+			log.Printf("Error walking path %s: %v", path, err)
+			return err
+		}
+		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
 		fileMetrics, err := parseFile(path)
 		if err != nil {
 			log.Printf("Error parsing %s: %v", path, err)
-			return nil
+			return err
 		}
 		metrics = append(metrics, fileMetrics...)
 		return nil
@@ -76,7 +80,7 @@ func dumpToMarkdown(metrics []Metric) {
 			m.Name, m.Type, desc, m.File))
 	}
 
-	if err := os.WriteFile(MARKDOWN_OUTPUT, []byte(sb.String()), 0644); err != nil {
+	if err := os.WriteFile(MARKDOWN_OUTPUT, []byte(sb.String()), 0o644); err != nil {
 		log.Fatalf("Error writing Markdown file: %v", err)
 	}
 


### PR DESCRIPTION
### Add automated metrics catalog generation to document application metrics in a markdown table
Implements a metrics documentation system through:

* A new Go program in [generator.go](https://github.com/xmtp/xmtpd/pull/719/files#diff-3b7e158857c4d43acbfbd55becdce9ba9afff64d4ce7524cf4b7f71afecdead3) that parses metric declarations from the codebase and generates a markdown table documenting 18 metrics
* A bash script [generate-metrics-catalog](https://github.com/xmtp/xmtpd/pull/719/files#diff-3a71567b56bf36f125e999811b1254c6ddcf32dc7f4682a54941771733d7f4a2) that executes the generator program
* A GitHub workflow step in [lint-go.yml](https://github.com/xmtp/xmtpd/pull/719/files#diff-e3eb5891b2343a83d8ea323d0f6ebf2724e3eb90de760155b1926e50f86039e9) that runs the metrics catalog generation
* The generated output in [metrics_catalog.md](https://github.com/xmtp/xmtpd/pull/719/files#diff-76ce58ca7626239d9d1fcf2571f79d0337a091f72961c3ef6113b2f5fe06a994) containing the metrics documentation table

#### 📍Where to Start
Start with the main generator program in [generator.go](https://github.com/xmtp/xmtpd/pull/719/files#diff-3b7e158857c4d43acbfbd55becdce9ba9afff64d4ce7524cf4b7f71afecdead3) which contains the core logic for parsing metric declarations and generating the documentation.

----

_[Macroscope](https://app.macroscope.com) summarized c0e7286._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated generation of a metrics catalog, providing a comprehensive Markdown reference for all metrics used in the project.
- **Documentation**
  - Added a new metrics catalog documentation file listing metric names, types, descriptions, and their source locations.
- **Chores**
  - Updated the GitHub Actions workflow to include a step for generating the metrics catalog automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->