### PR TITLE
Add DevContainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Go Dev Container",
+  "build": {
+    // Sets the run context to one level up instead of the .devcontainer folder.
+    "context": "..",
+    // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+    "dockerfile": "../dev/docker/devcontainer.Dockerfile"
+  },
+  "remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}", "HOST_DOCKER_DEV_FOLDER": "${localWorkspaceFolder}/dev/docker" },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "go.gopath": "/go",
+        "go.useLanguageServer": true
+      },
+      "extensions": [
+        "mtxr.sqltools",
+        "golang.go",
+        "emeraldwalk.runonsave",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "postCreateCommand": "go mod tidy",
+  "forwardPorts": [],
+  "runArgs": ["--network=host"],
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  }
+}

--- a/dev/docker/compose
+++ b/dev/docker/compose
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eo pipefail
+
+docker compose \
+  -f dev/docker/docker-compose.yml \
+  --env-file dev/local.env \
+  -p "xmtpd" \
+  "$@"

--- a/dev/docker/devcontainer.Dockerfile
+++ b/dev/docker/devcontainer.Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/vscode/devcontainers/go:1.24
+
+# Install golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2
+
+# Add spellcheck and jq
+RUN apt-get update && apt-get install -y \
+    shellcheck \
+    jq

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - 9090:9090
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ${HOST_DOCKER_DEV_FOLDER:-.}/prometheus.yml:/etc/prometheus/prometheus.yml
 
   grafana:
     image: grafana/grafana


### PR DESCRIPTION
## tl;dr

- Adds devcontainer configuration that allows the container to access Docker on the host machine

Give it a try. I could use feedback. I am able to run all the tests from inside the container, and VSCode works normally for me.

## TODO
- I need to figure out how to pass through Graphite configuration to the devcontainer
- Ideally we would not use host networking at all, and have all containers use docker internal networking. That's a bigger refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a development container configuration for Go projects, including pre-installed tools and VS Code extensions for enhanced development experience.
  - Added a custom Dockerfile to set up Go development tools and utilities such as golangci-lint, shellcheck, and jq.
  - Provided a Bash script for streamlined Docker Compose management with environment variable support.

- **Chores**
  - Updated Docker Compose configuration to allow customizable Prometheus configuration file paths using environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->