### PR TITLE
Sanitize gRPC API error responses to prevent exposure of internal error details in the logging interceptor

### DIFF
--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -1,5 +1,6 @@
 | Name | Type | Description | File |
 |------|------|-------------|------|
+| `xmtp_api_failed_grpc_requests` | `Counter` | Number of failed GRPC requests by code | `pkg/metrics/api.go` |
 | `xmtp_api_incoming_node_connection_by_version_gauge` | `Gauge` | Number of incoming node connections by version | `pkg/metrics/api.go` |
 | `xmtp_api_node_connection_requests_by_version_counter` | `Counter` | Number of incoming node connections by version | `pkg/metrics/api.go` |
 | `xmtp_api_open_connections_gauge` | `Gauge` | Number of open API connections | `pkg/metrics/api.go` |

--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -1,6 +1,6 @@
 | Name | Type | Description | File |
 |------|------|-------------|------|
-| `xmtp_api_failed_grpc_requests` | `Counter` | Number of failed GRPC requests by code | `pkg/metrics/api.go` |
+| `xmtp_api_failed_grpc_requests_counter` | `Counter` | Number of failed GRPC requests by code | `pkg/metrics/api.go` |
 | `xmtp_api_incoming_node_connection_by_version_gauge` | `Gauge` | Number of incoming node connections by version | `pkg/metrics/api.go` |
 | `xmtp_api_node_connection_requests_by_version_counter` | `Counter` | Number of incoming node connections by version | `pkg/metrics/api.go` |
 | `xmtp_api_open_connections_gauge` | `Gauge` | Number of open API connections | `pkg/metrics/api.go` |

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -432,7 +432,7 @@ func (s *Service) validatePayerEnvelope(
 ) (*envelopes.PayerEnvelope, error) {
 	payerEnv, err := envelopes.NewPayerEnvelope(rawEnv)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	if payerEnv.TargetOriginator != s.registrant.NodeID() {
@@ -440,7 +440,7 @@ func (s *Service) validatePayerEnvelope(
 	}
 
 	if _, err = payerEnv.RecoverSigner(); err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	if err := s.validateClientInfo(&payerEnv.ClientEnvelope); err != nil {
@@ -490,12 +490,12 @@ func (s *Service) validateClientInfo(clientEnv *envelopes.ClientEnvelope) error 
 		for nodeId, seqId := range aad.GetDependsOn().NodeIdToSequenceId {
 			lastSeqId, exists := lastSeenCursor.NodeIdToSequenceId[nodeId]
 			if !exists {
-				return fmt.Errorf(
+				return status.Errorf(codes.InvalidArgument,
 					"node ID %d specified in DependsOn has not been seen by this node",
 					nodeId,
 				)
 			} else if seqId > lastSeqId {
-				return fmt.Errorf(
+				return status.Errorf(codes.InvalidArgument,
 					"sequence ID %d for node ID %d specified in DependsOn exceeds last seen sequence ID %d",
 					seqId,
 					nodeId,

--- a/pkg/interceptors/server/logging.go
+++ b/pkg/interceptors/server/logging.go
@@ -128,6 +128,6 @@ func sanitizeError(err error) error {
 		}
 	}
 	// Emit metric for every non-nil error path
-	metrics.EmitNewFailedGRPCRequest(finalCode.String())
+	metrics.EmitNewFailedGRPCRequest(finalCode)
 	return status.Error(finalCode, finalMsg)
 }

--- a/pkg/interceptors/server/logging.go
+++ b/pkg/interceptors/server/logging.go
@@ -2,8 +2,12 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
+
+	"github.com/xmtp/xmtpd/pkg/metrics"
+	"google.golang.org/grpc/codes"
 
 	"go.uber.org/zap"
 
@@ -50,7 +54,7 @@ func (i *LoggingInterceptor) Unary() grpc.UnaryServerInterceptor {
 			)
 		}
 
-		return resp, err
+		return resp, sanitizeError(err)
 	}
 }
 
@@ -77,6 +81,45 @@ func (i *LoggingInterceptor) Stream() grpc.StreamServerInterceptor {
 			)
 		}
 
-		return err
+		return sanitizeError(err)
+	}
+}
+
+// sanitizeError standardizes and sanitizes gRPC errors to prevent internal details
+// from being exposed to clients. It maps known internal errors (e.g., context cancellations
+// or timeouts) to appropriate gRPC status codes and safely wraps unknown errors.
+//
+// If the error is a known Go context error (e.g., context.DeadlineExceeded or context.Canceled),
+// it returns a corresponding gRPC error with a sanitized message.
+//
+// If the error is already a gRPC status error, it inspects the code:
+//   - For InvalidArgument, NotFound and Unimplemented, it preserves the original code and message.
+//   - For Internal errors, it replaces the message with a generic "internal server error".
+//   - For all other codes, it replaces the message with a generic "request has failed".
+func sanitizeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return status.Error(codes.DeadlineExceeded, "request timed out")
+	case errors.Is(err, context.Canceled):
+		return status.Error(codes.Canceled, "request was canceled")
+	default:
+		st, ok := status.FromError(err)
+		if !ok {
+			return status.Error(codes.Internal, "internal server error")
+		}
+		msg := "request has failed"
+		switch st.Code() {
+		case codes.InvalidArgument, codes.Unimplemented, codes.NotFound:
+			msg = st.Message()
+		case codes.Internal:
+			msg = "internal server error"
+		}
+		metrics.EmitNewFailedGRPCRequest(st.Code().String())
+
+		return status.Error(st.Code(), msg)
 	}
 }

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -28,9 +28,9 @@ var apiNodeConnectionRequestsByVersionCounter = prometheus.NewCounterVec(
 	[]string{"version"},
 )
 
-var apiFailedGRPCRequests = prometheus.NewCounterVec(
+var apiFailedGRPCRequestsCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "xmtp_api_failed_grpc_requests",
+		Name: "xmtp_api_failed_grpc_requests_counter",
 		Help: "Number of failed GRPC requests by code",
 	},
 	[]string{"code"},
@@ -82,6 +82,6 @@ func EmitNewConnectionRequestVersion(version string) {
 }
 
 func EmitNewFailedGRPCRequest(code string) {
-	apiFailedGRPCRequests.With(prometheus.Labels{"code": code}).
+	apiFailedGRPCRequestsCounter.With(prometheus.Labels{"code": code}).
 		Inc()
 }

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -28,6 +28,14 @@ var apiNodeConnectionRequestsByVersionCounter = prometheus.NewCounterVec(
 	[]string{"version"},
 )
 
+var apiFailedGRPCRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtp_api_failed_grpc_requests",
+		Help: "Number of failed GRPC requests by code",
+	},
+	[]string{"code"},
+)
+
 type ApiOpenConnection struct {
 	style  string
 	method string
@@ -70,5 +78,10 @@ func (ct *IncomingConnectionTracker) Close() {
 
 func EmitNewConnectionRequestVersion(version string) {
 	apiNodeConnectionRequestsByVersionCounter.With(prometheus.Labels{"version": version}).
+		Inc()
+}
+
+func EmitNewFailedGRPCRequest(code string) {
+	apiFailedGRPCRequests.With(prometheus.Labels{"code": code}).
 		Inc()
 }

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/codes"
 )
 
 var apiOpenConnections = prometheus.NewGaugeVec(
@@ -81,7 +82,7 @@ func EmitNewConnectionRequestVersion(version string) {
 		Inc()
 }
 
-func EmitNewFailedGRPCRequest(code string) {
-	apiFailedGRPCRequestsCounter.With(prometheus.Labels{"code": code}).
+func EmitNewFailedGRPCRequest(code codes.Code) {
+	apiFailedGRPCRequestsCounter.With(prometheus.Labels{"code": code.String()}).
 		Inc()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -86,7 +86,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		apiOpenConnections,
 		apiIncomingNodeConnectionByVersionGauge,
 		apiNodeConnectionRequestsByVersionCounter,
-		apiFailedGRPCRequests,
+		apiFailedGRPCRequestsCounter,
 	}
 
 	for _, col := range cols {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -86,6 +86,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		apiOpenConnections,
 		apiIncomingNodeConnectionByVersionGauge,
 		apiNodeConnectionRequestsByVersionCounter,
+		apiFailedGRPCRequests,
 	}
 
 	for _, col := range cols {


### PR DESCRIPTION
Fixes #727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standardized and sanitized error messages are now returned for failed gRPC requests, improving consistency and security.
  - A new metric tracks the number of failed gRPC requests by error code, visible via the metrics endpoint.

- **Documentation**
  - Added documentation for the new failed gRPC requests metric in the metrics catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->