### PR TITLE
Fix docker down

### DIFF
--- a/dev/docker/down
+++ b/dev/docker/down
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
-. dev/docker/env
+profile=${1:-single}
 
-docker_compose down --remove-orphans --volumes
+if [ "$1" = "single" ]; then
+  profile="single"
+elif [ "$1" = "dual" ]; then
+  profile="dual"
+else
+  echo "No profile provided, defaulting to single"
+fi
+
+docker compose \
+  -f dev/docker/docker-compose.yml \
+  --env-file dev/local.env \
+  -p "xmtpd" \
+  down --remove-orphans --volumes
+
+docker compose \
+  -f dev/docker/docker-compose-register.yml \
+  --env-file dev/local.env \
+  --profile ${profile} \
+  -p "xmtpd_register_nodes" \
+  down --remove-orphans --volumes


### PR DESCRIPTION
### Modify `dev/docker/down` script to support multiple Docker Compose profiles and separate project configurations
* Implements profile-based Docker Compose operations in [down](https://github.com/xmtp/xmtpd/pull/729/files#diff-7d10e63db3d97298d86fb22d36c4c0fb11bf8aa78cdc8566d33d1bebbb81b51b) script, supporting 'single' and 'dual' profiles
* Replaces sourced environment configuration with explicit Docker Compose commands using specific config files
* Separates Docker operations into two distinct commands targeting `xmtpd` and `xmtpd_register_nodes` projects
* Configures both commands to use `dev/local.env` environment file and `--remove-orphans --volumes` flags

#### 📍Where to Start
Begin by reviewing the main script logic in [down](https://github.com/xmtp/xmtpd/pull/729/files#diff-7d10e63db3d97298d86fb22d36c4c0fb11bf8aa78cdc8566d33d1bebbb81b51b) which contains the profile handling mechanism and Docker Compose commands.

----

_[Macroscope](https://app.macroscope.com) summarized cf8f46c._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a profile when bringing down Docker Compose projects, with "single" as the default.
- **Chores**
  - Improved handling of Docker Compose shutdown processes for multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->