### PR TITLE
Expose MLS method invocation statistics

### DIFF
--- a/pkg/mlsvalidate/service.go
+++ b/pkg/mlsvalidate/service.go
@@ -3,6 +3,7 @@ package mlsvalidate
 import (
 	"context"
 	"fmt"
+
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 
 	"github.com/xmtp/xmtpd/pkg/config"


### PR DESCRIPTION
### Add Prometheus metrics collection to MLS validation service client and server gRPC calls to expose method invocation statistics
Implements Prometheus metrics collection for gRPC client operations in two key areas:

* Adds gRPC interceptors for metrics collection in [service.go](https://github.com/xmtp/xmtpd/pull/730/files#diff-cf2ccc76d6f62cb661c57271f77f99aeda76271380f1df4df1964599ea97f43a) by integrating `grpcprom.ClientMetrics` into the MLS validation service client
* Configures server-side metrics handling in [server.go](https://github.com/xmtp/xmtpd/pull/730/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996) by initializing and registering Prometheus client metrics, then passing them through the `NewReplicationServer` and `startAPIServer` functions

#### 📍Where to Start
Start with the `NewMlsValidationService` function in [service.go](https://github.com/xmtp/xmtpd/pull/730/files#diff-cf2ccc76d6f62cb661c57271f77f99aeda76271380f1df4df1964599ea97f43a) which shows how the Prometheus metrics interceptors are integrated into the gRPC client connection.

----

_[Macroscope](https://app.macroscope.com) summarized 00eb28c._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated Prometheus-based monitoring for gRPC client calls, enabling enhanced metrics collection and observability for MLS validation and replication services.

- **Chores**
  - Updated internal service initialization to support metrics instrumentation where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->