### PR TITLE
docs(readme): add license and twitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Test](https://github.com/xmtp/xmtpd/actions/workflows/test.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/test.yml)
 [![Lint](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml)
 [![Build](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml)
+[![License](https://img.shields.io/github/license/xmtp/xmtpd)](https://github.com/xmtp/xmtpd/blob/main/LICENSE)
 
 **⚠️ Experimental:** This software is in early development. Expect frequent changes and unresolved issues.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Lint](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml)
 [![Build](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml)
 [![License](https://img.shields.io/github/license/xmtp/xmtpd)](https://github.com/xmtp/xmtpd/blob/main/LICENSE)
+[![Twitter](https://img.shields.io/twitter/follow/xmtp_)](https://x.com/xmtp_)
 
 **⚠️ Experimental:** This software is in early development. Expect frequent changes and unresolved issues.
 


### PR DESCRIPTION
### Add license badge to repository README to display license type
Updates [README.md](https://github.com/xmtp/xmtpd/pull/732/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) by adding a badge that displays and links to the repository's license information.

#### 📍Where to Start
Review the changes in [README.md](https://github.com/xmtp/xmtpd/pull/732/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) which contains the new license badge addition.

----

_[Macroscope](https://app.macroscope.com) summarized ba5f43e._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a license status badge to the README, displaying the project's license type and linking to the LICENSE file.
  - Added a Twitter follower count badge to the README, linking to the project's Twitter page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->