### PR TITLE
CalculateBalanceNodesCount to handle int

### DIFF
--- a/pkg/merkle/tree.go
+++ b/pkg/merkle/tree.go
@@ -279,22 +279,22 @@ func makeLeaves(leaves []Leaf) ([]Leaf, error) {
 
 // CalculateBalancedNodesCount returns the number of nodes in a balanced tree.
 // To calculate the number of nodes in a tree, we need to round up to the next power of 2.
-// Returns an error if the element count is too large to be represented in a uint32.
+// Returns an error if the element count is too large to be represented in a int32.
 func CalculateBalancedNodesCount(count int) (int, error) {
 	if count <= 0 {
 		return 0, fmt.Errorf("count must be greater than 0")
 	}
 
-	if count > int(1<<31) {
-		return 0, fmt.Errorf("count must be less than or equal to 2^31")
+	if count > 1<<31-1 {
+		return 0, fmt.Errorf("count must be less than or equal than max int32 (%d)", 1<<31-1)
 	}
 
-	return int(roundUpToPowerOf2(uint32(count))), nil
+	return roundUpToPowerOf2(count), nil
 }
 
 // roundUpToPowerOf2 rounds up a number to the next power of 2.
-func roundUpToPowerOf2(n uint32) uint32 {
-	if bits.OnesCount32(n) == 1 {
+func roundUpToPowerOf2(n int) int {
+	if bits.OnesCount(uint(n)) == 1 {
 		return n
 	}
 

--- a/pkg/merkle/tree_test.go
+++ b/pkg/merkle/tree_test.go
@@ -437,5 +437,5 @@ func TestCalculateBalancedLeafCountError(t *testing.T) {
 	massiveInput := int(^uint32(0)) + 1
 	_, err := merkle.CalculateBalancedNodesCount(massiveInput)
 	assert.Error(t, err)
-	assert.Equal(t, "count must be less than or equal to 2^31", err.Error())
+	assert.Contains(t, err.Error(), "count must be less than or equal than max int32")
 }


### PR DESCRIPTION
Closes https://github.com/xmtp/xmtpd/issues/726

I'd assume our code will always run in 64 bit hardware, but it's non cost to also make this package compatible with 32 bits, as we don't expect such huge trees anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input validation for node count limits, now using signed 32-bit integer boundaries for more accurate error handling.
  - Updated error messages to clearly indicate the new maximum allowed value.
- **Tests**
  - Adjusted tests to check for the updated error message and relaxed the assertion to allow for message changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->