### PR TITLE
Add more test coverage for pkg/merkle

### DIFF
--- a/pkg/merkle/hash_test.go
+++ b/pkg/merkle/hash_test.go
@@ -1,0 +1,221 @@
+package merkle
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    []byte{},
+			expected: "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+		},
+		{
+			name:     "simple string",
+			input:    []byte("hello world"),
+			expected: "47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad",
+		},
+		{
+			name:     "binary data",
+			input:    []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			expected: "7d87c5ea75f7378bb701e404c50639161af3eff66293e9f375b5f17eb50476f4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Hash(tt.input)
+			resultHex := hex.EncodeToString(result)
+			if resultHex != tt.expected {
+				t.Errorf("Hash(%v) = %s, want %s", tt.input, resultHex, tt.expected)
+			}
+		})
+	}
+
+	// Test consistency.
+	t.Run("consistency", func(t *testing.T) {
+		input := []byte("test consistency")
+		result1 := Hash(input)
+		result2 := Hash(input)
+		if !bytes.Equal(result1, result2) {
+			t.Errorf("Hash is not consistent for the same input")
+		}
+	})
+
+	// Test different inputs produce different outputs.
+	t.Run("different inputs", func(t *testing.T) {
+		input1 := []byte("input1")
+		input2 := []byte("input2")
+		result1 := Hash(input1)
+		result2 := Hash(input2)
+		if bytes.Equal(result1, result2) {
+			t.Errorf("Different inputs produced the same hash")
+		}
+	})
+}
+
+func TestHashNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		left     []byte
+		right    []byte
+		expected string
+	}{
+		{
+			name:     "empty left and right",
+			left:     []byte{},
+			right:    []byte{},
+			expected: "8c83ac90634bd25e7214fbf0e3d45b5e8633bb010cb64411c122b53131c7c431",
+		},
+		{
+			name:     "non-empty left, empty right",
+			left:     []byte{0x01},
+			right:    []byte{},
+			expected: "83f78f037fd069ea3b5c402c21b4d1e122d206ba5c847ba67ca62ebe75bbf51f",
+		},
+		{
+			name:     "empty left, non-empty right",
+			left:     []byte{},
+			right:    []byte{0x01},
+			expected: "83f78f037fd069ea3b5c402c21b4d1e122d206ba5c847ba67ca62ebe75bbf51f",
+		},
+		{
+			name:     "non-empty left and right",
+			left:     []byte{0x01, 0x02},
+			right:    []byte{0x03, 0x04},
+			expected: "3db27c66a80724227ca3d27d202f29487959ec0912b0db2b9dbbf01953a7ab49",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HashNode(tt.left, tt.right)
+			resultHex := hex.EncodeToString(result)
+			if resultHex != tt.expected {
+				t.Errorf(
+					"HashNode(%v, %v) = %s, want %s",
+					tt.left,
+					tt.right,
+					resultHex,
+					tt.expected,
+				)
+			}
+		})
+	}
+
+	// Test that node prefix is used
+	t.Run("node prefix is used", func(t *testing.T) {
+		data := []byte{0x01, 0x02}
+		nodeHash := HashNode(data, []byte{})
+		directHash := Hash(append([]byte(NODE_PREFIX), append(data, []byte{}...)...))
+		if !bytes.Equal(nodeHash, directHash) {
+			t.Errorf("Node hash doesn't match manual construction with prefix")
+		}
+	})
+
+	// Test that HashNode is different from HashLeaf with same data
+	t.Run("node hash differs from leaf hash", func(t *testing.T) {
+		data1 := []byte{0x01}
+		data2 := []byte{0x02}
+		nodeHash := HashNode(data1, data2)
+		combinedData := append(data1, data2...)
+		leafHash := HashLeaf(combinedData)
+		if bytes.Equal(nodeHash, leafHash) {
+			t.Errorf("Node hash equals leaf hash for same data")
+		}
+	})
+}
+
+func TestHashLeaf(t *testing.T) {
+	tests := []struct {
+		name     string
+		leaf     []byte
+		expected string
+	}{
+		{
+			name:     "empty leaf",
+			leaf:     []byte{},
+			expected: "3ef0000fc8752f5372eb9bcff2d75ad56ac4dc0824bb0dffcf7e454001558bf7",
+		},
+		{
+			name:     "simple leaf",
+			leaf:     []byte("test leaf"),
+			expected: "a072d672610b40ba2ad9429f65421dddb525911c302c5933737ce7e62cc1da26",
+		},
+		{
+			name:     "binary data",
+			leaf:     []byte{0x01, 0x02, 0x03},
+			expected: "7c7b7f152b1492aadc0df2d4ab2bf9cc171d5359082fa840b18ef9304a3886e2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HashLeaf(tt.leaf)
+			resultHex := hex.EncodeToString(result)
+			if resultHex != tt.expected {
+				t.Errorf("HashLeaf(%v) = %s, want %s", tt.leaf, resultHex, tt.expected)
+			}
+		})
+	}
+
+	// Test that leaf prefix is used.
+	t.Run("HashLeaf uses leaf prefix", func(t *testing.T) {
+		data := []byte{0x01, 0x02}
+		leafHash := HashLeaf(data)
+		directHash := Hash(append([]byte(LEAF_PREFIX), data...))
+		if !bytes.Equal(leafHash, directHash) {
+			t.Errorf("Leaf hash doesn't match manual construction with prefix")
+		}
+	})
+}
+
+func TestHashEmptyLeaf(t *testing.T) {
+	// Test that HashEmptyLeaf returns the same result as HashLeaf with empty data.
+	t.Run("equals HashLeaf with empty data", func(t *testing.T) {
+		emptyLeafHash := HashEmptyLeaf()
+		manualEmptyLeafHash := HashLeaf([]byte{})
+		if !bytes.Equal(emptyLeafHash, manualEmptyLeafHash) {
+			t.Errorf("HashEmptyLeaf() doesn't match HashLeaf([]byte{})")
+		}
+	})
+
+	// HashEmpty leaf known value test.
+	t.Run("known value", func(t *testing.T) {
+		expected := "3ef0000fc8752f5372eb9bcff2d75ad56ac4dc0824bb0dffcf7e454001558bf7"
+		emptyLeafHash := HashEmptyLeaf()
+		resultHex := hex.EncodeToString(emptyLeafHash)
+		if resultHex != expected {
+			t.Errorf("HashEmptyLeaf() = %s, want %s", resultHex, expected)
+		}
+	})
+}
+
+func TestHashDomainSeparation(t *testing.T) {
+	// Test that leaf and node hashes are different even with the same data.
+	t.Run("leaf and node hash separation", func(t *testing.T) {
+		data := []byte{0x01, 0x02}
+		leafHash := HashLeaf(data)
+		nodeHash := HashNode(data, []byte{})
+		if bytes.Equal(leafHash, nodeHash) {
+			t.Errorf("Leaf and node hashes are not properly domain-separated")
+		}
+	})
+
+	// Test that different prefixes result in different hashes.
+	t.Run("prefix separation", func(t *testing.T) {
+		data := []byte{0x01, 0x02}
+		hash1 := Hash(append([]byte("prefix1|"), data...))
+		hash2 := Hash(append([]byte("prefix2|"), data...))
+		if bytes.Equal(hash1, hash2) {
+			t.Errorf("Different prefixes should result in different hashes")
+		}
+	})
+}

--- a/pkg/merkle/proof_internal_test.go
+++ b/pkg/merkle/proof_internal_test.go
@@ -1,0 +1,444 @@
+package merkle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidate tests the internal validate function for MultiProof.
+func TestValidate(t *testing.T) {
+	t.Run("valid proof", func(t *testing.T) {
+		values := make(IndexedValues, 1)
+		values[0] = IndexedValue{value: []byte("test"), index: 0}
+
+		proofs := []Node{
+			{hash: []byte("proof")},
+		}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    proofs,
+			leafCount: 2,
+		}
+
+		err := proof.validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty values", func(t *testing.T) {
+		proof := MultiProof{
+			values:    IndexedValues{},
+			proofs:    []Node{{hash: []byte("proof")}},
+			leafCount: 2,
+		}
+
+		err := proof.validate()
+		assert.ErrorIs(t, err, ErrNoElements)
+	})
+
+	t.Run("invalid leaf count", func(t *testing.T) {
+		values := make(IndexedValues, 1)
+		values[0] = IndexedValue{value: []byte("test"), index: 0}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    []Node{{hash: []byte("proof")}},
+			leafCount: 0,
+		}
+
+		err := proof.validate()
+		assert.ErrorIs(t, err, ErrInvalidLeafCount)
+	})
+
+	t.Run("duplicate indices", func(t *testing.T) {
+		values := make(IndexedValues, 2)
+		values[0] = IndexedValue{value: []byte("test1"), index: 0}
+		values[1] = IndexedValue{value: []byte("test2"), index: 0}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    []Node{{hash: []byte("proof")}},
+			leafCount: 2,
+		}
+
+		err := proof.validate()
+		assert.ErrorIs(t, err, ErrDuplicateIndices)
+	})
+
+	t.Run("nil element", func(t *testing.T) {
+		values := make(IndexedValues, 1)
+		values[0] = IndexedValue{value: nil, index: 0}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    []Node{{hash: []byte("proof")}},
+			leafCount: 2,
+		}
+
+		err := proof.validate()
+		assert.ErrorIs(t, err, ErrNilElement)
+	})
+
+	t.Run("nil proof", func(t *testing.T) {
+		values := make(IndexedValues, 1)
+		values[0] = IndexedValue{value: []byte("test"), index: 0}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    []Node{{hash: nil}},
+			leafCount: 2,
+		}
+
+		err := proof.validate()
+		assert.ErrorIs(t, err, ErrNilProof)
+	})
+
+	t.Run("no proofs needed for single element tree", func(t *testing.T) {
+		values := make(IndexedValues, 1)
+		values[0] = IndexedValue{value: []byte("test"), index: 0}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    []Node{},
+			leafCount: 1,
+		}
+
+		err := proof.validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("no proofs when needed", func(t *testing.T) {
+		values := make(IndexedValues, 1)
+		values[0] = IndexedValue{value: []byte("test"), index: 0}
+
+		proof := MultiProof{
+			values:    values,
+			proofs:    []Node{},
+			leafCount: 2,
+		}
+
+		err := proof.validate()
+		assert.ErrorIs(t, err, ErrNoProofs)
+	})
+}
+
+// TestGetNextProof tests the internal getNextProof function.
+func TestGetNextProof(t *testing.T) {
+	proofs := []Node{
+		{hash: []byte{0x01}},
+		{hash: []byte{0x02}},
+	}
+
+	proof := MultiProof{
+		values:    IndexedValues{{value: []byte("test"), index: 0}},
+		proofs:    proofs,
+		leafCount: 2,
+	}
+
+	idx := 0
+	p, err := proof.getNextProof(&idx)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x01}, p)
+	assert.Equal(t, 1, idx)
+
+	// Test getting the second proof.
+	p, err = proof.getNextProof(&idx)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02}, p)
+	assert.Equal(t, 2, idx)
+
+	// Test error when out of proofs.
+	p, err = proof.getNextProof(&idx)
+	assert.ErrorIs(t, err, ErrNoProofs)
+	assert.Nil(t, p)
+}
+
+// TestBuildNodeQueue tests the internal buildNodeQueue function.
+func TestBuildNodeQueue(t *testing.T) {
+	leaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+		[]byte("leaf4"),
+	}
+
+	// We don't actually need the tree for the test, just the leaves.
+	_, err := NewMerkleTree(leaves)
+	require.NoError(t, err)
+
+	indexedValues := make(IndexedValues, 2)
+	indexedValues[0] = IndexedValue{value: leaves[0], index: 0}
+	indexedValues[1] = IndexedValue{value: leaves[2], index: 2}
+
+	proof := MultiProof{
+		values:    indexedValues,
+		proofs:    []Node{},
+		leafCount: len(leaves),
+	}
+
+	// Build the node queue with 4 leaves, as it's the balanced leaf count for 4 leaves.
+	queue, err := proof.buildNodeQueue(4)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(queue))
+
+	// Check queue order and values.
+	assert.Equal(t, 6, queue[0].index) // 4+2 (balanced leaf count + index)
+	assert.Equal(t, HashLeaf(leaves[2]), queue[0].hash)
+	assert.Equal(t, 4, queue[1].index) // 4+0 (balanced leaf count + index)
+	assert.Equal(t, HashLeaf(leaves[0]), queue[1].hash)
+}
+
+// TestMakeIndexedValues tests the internal makeIndexedValues function.
+func TestMakeIndexedValues(t *testing.T) {
+	leaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+	}
+
+	indices := []int{0, 2}
+
+	indexedValues, err := makeIndexedValues(leaves, indices)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(indexedValues))
+
+	assert.Equal(t, []byte(leaves[0]), []byte(indexedValues[0].value))
+	assert.Equal(t, 0, indexedValues[0].index)
+	assert.Equal(t, []byte(leaves[2]), []byte(indexedValues[1].value))
+	assert.Equal(t, 2, indexedValues[1].index)
+}
+
+// TestMakeIndices tests the internal makeIndices function.
+func TestMakeIndices(t *testing.T) {
+	tests := []struct {
+		name          string
+		startingIndex int
+		count         int
+		expected      []int
+		wantErr       error
+	}{
+		{
+			name:          "valid indices",
+			startingIndex: 2,
+			count:         3,
+			expected:      []int{2, 3, 4},
+			wantErr:       nil,
+		},
+		{
+			name:          "negative starting index",
+			startingIndex: -1,
+			count:         3,
+			expected:      nil,
+			wantErr:       ErrInvalidRange,
+		},
+		{
+			name:          "zero count",
+			startingIndex: 0,
+			count:         0,
+			expected:      nil,
+			wantErr:       ErrInvalidRange,
+		},
+		{
+			name:          "negative count",
+			startingIndex: 0,
+			count:         -1,
+			expected:      nil,
+			wantErr:       ErrInvalidRange,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indices, err := makeIndices(tt.startingIndex, tt.count)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, indices)
+			}
+		})
+	}
+}
+
+// TestValidateIndices tests the internal validateIndices function.
+func TestValidateIndices(t *testing.T) {
+	tests := []struct {
+		name      string
+		indices   []int
+		leafCount int
+		wantErr   error
+	}{
+		{
+			name:      "valid indices",
+			indices:   []int{0, 1, 2},
+			leafCount: 4,
+			wantErr:   nil,
+		},
+		{
+			name:      "empty indices",
+			indices:   []int{},
+			leafCount: 4,
+			wantErr:   ErrNoIndices,
+		},
+		{
+			name:      "duplicate indices",
+			indices:   []int{0, 1, 1, 2},
+			leafCount: 4,
+			wantErr:   ErrDuplicateIndices,
+		},
+		{
+			name:      "out of bounds indices",
+			indices:   []int{0, 4, 2},
+			leafCount: 4,
+			wantErr:   ErrIndicesOutOfBounds,
+		},
+		{
+			name:      "negative index",
+			indices:   []int{0, -1, 2},
+			leafCount: 4,
+			wantErr:   ErrIndicesOutOfBounds,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIndices(tt.indices, tt.leafCount)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestHasDuplicates tests the internal hasDuplicates function.
+func TestHasDuplicates(t *testing.T) {
+	tests := []struct {
+		name     string
+		indices  []int
+		expected bool
+	}{
+		{
+			name:     "no duplicates",
+			indices:  []int{1, 2, 3, 4},
+			expected: false,
+		},
+		{
+			name:     "has duplicates in middle",
+			indices:  []int{1, 2, 2, 3},
+			expected: true,
+		},
+		{
+			name:     "has duplicates at start",
+			indices:  []int{1, 1},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasDuplicates(tt.indices)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestHasOutOfBounds tests the internal hasOutOfBounds function.
+func TestHasOutOfBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		indices   []int
+		leafCount int
+		expected  bool
+	}{
+		{
+			name:      "all in bounds",
+			indices:   []int{0, 1, 2, 3},
+			leafCount: 4,
+			expected:  false,
+		},
+		{
+			name:      "upper bound exceeded",
+			indices:   []int{0, 1, 4},
+			leafCount: 4,
+			expected:  true,
+		},
+		{
+			name:      "negative index",
+			indices:   []int{-1, 0, 1},
+			leafCount: 4,
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasOutOfBounds(tt.indices, tt.leafCount)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestIsLeftChild tests the internal isLeftChild function.
+func TestIsLeftChild(t *testing.T) {
+	// Even indices are left children.
+	assert.True(t, isLeftChild(0))
+	assert.True(t, isLeftChild(2))
+	assert.True(t, isLeftChild(4))
+
+	// Odd indices are right children.
+	assert.False(t, isLeftChild(1))
+	assert.False(t, isLeftChild(3))
+	assert.False(t, isLeftChild(5))
+}
+
+// TestComputeRoot tests the internal computeRoot function.
+func TestComputeRoot(t *testing.T) {
+	// Create a simple tree for testing.
+	leaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+		[]byte("leaf4"),
+	}
+
+	tree, err := NewMerkleTree(leaves)
+	require.NoError(t, err)
+
+	expectedRoot := tree.Root()
+
+	// Test with valid proof.
+	indices := []int{0, 2}
+	multiProof, err := tree.GenerateMultiProofWithIndices(indices)
+	require.NoError(t, err)
+
+	computedRoot, err := multiProof.computeRoot()
+	require.NoError(t, err)
+	assert.Equal(t, expectedRoot, computedRoot)
+
+	// Test with invalid leaf count.
+	badProof := &MultiProof{
+		values:    multiProof.values,
+		proofs:    multiProof.proofs,
+		leafCount: -1,
+	}
+
+	_, err = badProof.computeRoot()
+	assert.Error(t, err)
+
+	// Test with not enough proofs.
+	noProofsProof := &MultiProof{
+		values:    multiProof.values,
+		proofs:    []Node{},
+		leafCount: multiProof.leafCount,
+	}
+
+	_, err = noProofsProof.computeRoot()
+	assert.Error(t, err)
+}

--- a/pkg/merkle/tree_internal_test.go
+++ b/pkg/merkle/tree_internal_test.go
@@ -1,0 +1,168 @@
+package merkle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMakeNodes tests the internal makeNodes function.
+func TestMakeNodes(t *testing.T) {
+	// Test with valid leaves.
+	leaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+	}
+
+	nodes, err := makeNodes(leaves)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(nodes))
+
+	for i, leaf := range leaves {
+		assert.Equal(t, HashLeaf(leaf), nodes[i].Hash())
+	}
+
+	// Test with empty leaves.
+	_, err = makeNodes([]Leaf{})
+	assert.ErrorIs(t, err, ErrNoLeaves)
+}
+
+// TestMakeLeaves tests the internal makeLeaves function.
+func TestMakeLeaves(t *testing.T) {
+	// Test normal case (3 leaves becomes 4 balanced leaves).
+	originalLeaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+	}
+
+	balancedLeaves, err := makeLeaves(originalLeaves)
+	require.NoError(t, err)
+	assert.Equal(t, 4, len(balancedLeaves))
+
+	// Check original leaves are preserved.
+	for i, leaf := range originalLeaves {
+		assert.Equal(t, leaf, balancedLeaves[i])
+	}
+
+	// Check padding is with empty leaves.
+	assert.Equal(t, Leaf{}, balancedLeaves[3])
+
+	// Test with power of 2 leaves (4 leaves stays 4 leaves)
+	powTwoLeaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+		[]byte("leaf4"),
+	}
+
+	balancedLeaves, err = makeLeaves(powTwoLeaves)
+	require.NoError(t, err)
+	assert.Equal(t, 4, len(balancedLeaves))
+	assert.Equal(t, powTwoLeaves, balancedLeaves)
+}
+
+// TestMakeTree tests the internal makeTree function.
+func TestMakeTree(t *testing.T) {
+	// Test with empty nodes.
+	_, err := makeTree([]Node{})
+	assert.ErrorIs(t, err, ErrTreeEmpty)
+
+	// Test single node tree.
+	singleLeaf := []Leaf{[]byte("single")}
+	nodes, err := makeNodes(singleLeaf)
+	require.NoError(t, err)
+
+	tree, err := makeTree(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(tree))
+	assert.Equal(t, nodes[0].Hash(), tree[1].Hash())
+
+	// Test small balanced tree (2 nodes).
+	twoLeaves := []Leaf{[]byte("leaf1"), []byte("leaf2")}
+	nodes, err = makeNodes(twoLeaves)
+	require.NoError(t, err)
+
+	tree, err = makeTree(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, 4, len(tree))
+
+	// Root should be parent of two leaves.
+	expectedRoot := HashNode(nodes[0].Hash(), nodes[1].Hash())
+	assert.Equal(t, expectedRoot, tree[1].Hash())
+
+	// Leaves should be preserved.
+	assert.Equal(t, nodes[0].Hash(), tree[2].Hash())
+	assert.Equal(t, nodes[1].Hash(), tree[3].Hash())
+
+	// Test unbalanced tree (3 nodes).
+	threeLeaves := []Leaf{[]byte("leaf1"), []byte("leaf2"), []byte("leaf3")}
+	balancedLeaves, err := makeLeaves(threeLeaves)
+	require.NoError(t, err)
+	nodes, err = makeNodes(balancedLeaves)
+	require.NoError(t, err)
+
+	tree, err = makeTree(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, 8, len(tree))
+
+	// Check internal nodes.
+	leftSubtreeRoot := HashNode(nodes[0].Hash(), nodes[1].Hash())
+	rightSubtreeRoot := HashNode(nodes[2].Hash(), nodes[3].Hash())
+	expectedRoot = HashNode(leftSubtreeRoot, rightSubtreeRoot)
+	assert.Equal(t, expectedRoot, tree[1].Hash())
+	assert.Equal(t, leftSubtreeRoot, tree[2].Hash())
+	assert.Equal(t, rightSubtreeRoot, tree[3].Hash())
+}
+
+// TestLeaves tests the public Leaves method of MerkleTree.
+func TestLeaves(t *testing.T) {
+	// Test with normal leaves.
+	originalLeaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+	}
+
+	tree, err := NewMerkleTree(originalLeaves)
+	require.NoError(t, err)
+
+	// Test padding.
+	leaves := tree.Leaves()
+	assert.Equal(t, 4, len(leaves))
+
+	// Verify original leaves are preserved.
+	for i, leaf := range originalLeaves {
+		assert.Equal(t, leaf, leaves[i])
+	}
+
+	assert.Equal(t, Leaf{}, leaves[3])
+
+	// Test with exactly power of 2 leaves.
+	powTwoLeaves := []Leaf{
+		[]byte("leaf1"),
+		[]byte("leaf2"),
+		[]byte("leaf3"),
+		[]byte("leaf4"),
+	}
+
+	tree, err = NewMerkleTree(powTwoLeaves)
+	require.NoError(t, err)
+
+	leaves = tree.Leaves()
+	assert.Equal(t, 4, len(leaves)) // No padding needed.
+	assert.Equal(t, powTwoLeaves, leaves)
+}
+
+// TestNewMerkleTreeErrors tests more error cases for NewMerkleTree.
+func TestNewMerkleTreeErrors(t *testing.T) {
+	// Test with empty leaves.
+	_, err := NewMerkleTree([]Leaf{})
+	assert.ErrorIs(t, err, ErrNoLeaves)
+
+	// Test with a successful case as well.
+	_, err = NewMerkleTree([]Leaf{[]byte("test")})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
### Implement test coverage for hash functions, proofs, and tree operations in `pkg/merkle` package
* Adds test suite for hash functions in [hash_test.go](https://github.com/xmtp/xmtpd/pull/734/files#diff-d2c99acefc4396134645e668b59b852dbe2c8061efc070ddfa7ad413f20ece62) covering `Hash`, `HashNode`, `HashLeaf`, and `HashEmptyLeaf` functions
* Creates internal test coverage for `MultiProof` functionality in [proof_internal_test.go](https://github.com/xmtp/xmtpd/pull/734/files#diff-8d291eac2c2c1c0dff60f16e8de187b4c04db4f206446f0bef7768ac833a4590) testing proof verification process
* Extends [proof_test.go](https://github.com/xmtp/xmtpd/pull/734/files#diff-cfbdb4b5ff23d147c944f1ad21ba263df19911f82ad2a968d68cdc586c4b5e9a) with additional test cases for `MultiProof.GetLeafCount` and error handling in `Verify` function
* Introduces internal tests for `MerkleTree` implementation in [tree_internal_test.go](https://github.com/xmtp/xmtpd/pull/734/files#diff-540c3396d4ebaba1cd40d3f9ed6cfffcca49d6c00911f908bd182b449e645196) covering tree construction and manipulation

#### 📍Where to Start
Start with the basic hash function tests in [hash_test.go](https://github.com/xmtp/xmtpd/pull/734/files#diff-d2c99acefc4396134645e668b59b852dbe2c8061efc070ddfa7ad413f20ece62) as these functions are fundamental to the merkle tree operations and are used by the other components being tested.

----

_[Macroscope](https://app.macroscope.com) summarized 1ab9bdf._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive unit tests for Merkle tree hashing functions, multi-proof logic, and tree construction, including error handling and edge cases.
  - Enhanced verification tests for multi-proofs, covering both successful and failure scenarios.
  - Improved test coverage for internal tree and proof operations to ensure correctness and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->