### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/lint-spellcheck.yml
+++ b/.github/workflows/lint-spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint Spellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: shellcheck
         run: |
           sudo apt-get -y install tree


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to use the latest version of the checkout action for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->