### PR TITLE
Add TPS to stress test

### DIFF
--- a/pkg/stress/stress.go
+++ b/pkg/stress/stress.go
@@ -50,6 +50,8 @@ func StressIdentityUpdates(
 	var nonceCounter atomic.Uint64
 	nonceCounter.Store(startingNonce)
 
+	totalTime := time.Now()
+
 	for i := 0; i < n; i++ {
 		wg.Add(1)
 		go func(idx int) {
@@ -94,6 +96,8 @@ func StressIdentityUpdates(
 
 	wg.Wait()
 
+	elapsedSec := time.Since(totalTime).Seconds()
+
 	// Analytics
 	var totalDuration time.Duration
 	var successCount int
@@ -104,6 +108,8 @@ func StressIdentityUpdates(
 		}
 	}
 
+	tps := float64(n) / elapsedSec
+
 	avgDuration := totalDuration / time.Duration(n)
 	logger.Info("Stress Test Summary",
 		zap.Int("total_transactions", n),
@@ -111,6 +117,7 @@ func StressIdentityUpdates(
 		zap.Float64("success_rate", float64(successCount)/float64(n)),
 		zap.Duration("total_duration", totalDuration),
 		zap.Duration("average_duration", avgDuration),
+		zap.Float64("tps", tps),
 	)
 
 	return nil


### PR DESCRIPTION
### Add TPS measurement and reporting to `StressIdentityUpdates` function in stress test package
The `StressIdentityUpdates` function in [stress.go](https://github.com/xmtp/xmtpd/pull/740/files#diff-c20b3951391371bef7d3285604e588282211b72b016c7da816b7f176e1fb271e) now calculates and reports transactions per second (TPS) metrics by:

* Tracking total execution time using `time.Now()`
* Computing elapsed time in seconds
* Calculating TPS by dividing total transactions by elapsed time
* Adding TPS metric to the log output using `zap.Float64`

#### 📍Where to Start
Start with the `StressIdentityUpdates` function in [stress.go](https://github.com/xmtp/xmtpd/pull/740/files#diff-c20b3951391371bef7d3285604e588282211b72b016c7da816b7f176e1fb271e) where the TPS measurement logic has been added.

----

_[Macroscope](https://app.macroscope.com) summarized 723e482._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added transactions per second (TPS) metric to the stress test summary, providing clearer performance insights for identity update transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->