### PR TITLE
Do not require 0x prefix for stress tests

### DIFF
--- a/pkg/stress/stress.go
+++ b/pkg/stress/stress.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"strings"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -144,13 +144,7 @@ func getCurrentNonce(ctx context.Context, privateKey, rpcUrl string) (uint64, er
 }
 
 func getAddressFromPrivateKey(privateKeyHex string) (common.Address, error) {
-	if strings.HasPrefix(privateKeyHex, "0x") {
-		privateKeyHex = privateKeyHex[2:]
-	} else {
-		return common.Address{}, fmt.Errorf("private key must start with 0x")
-	}
-
-	privateKey, err := crypto.HexToECDSA(privateKeyHex)
+	privateKey, err := utils.ParseEcdsaPrivateKey(privateKeyHex)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/pkg/stress/stress.go
+++ b/pkg/stress/stress.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/xmtp/xmtpd/pkg/utils"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/xmtp/xmtpd/pkg/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"


### PR DESCRIPTION
### Remove 0x prefix requirement for private key parsing in stress test package
Refactors private key parsing in [stress.go](https://github.com/xmtp/xmtpd/pull/742/files#diff-c20b3951391371bef7d3285604e588282211b72b016c7da816b7f176e1fb271e) by replacing direct ECDSA private key parsing logic with `utils.ParseEcdsaPrivateKey` function. The `getAddressFromPrivateKey` function no longer requires the '0x' prefix validation and handling.

#### 📍Where to Start
Start with the `getAddressFromPrivateKey` function in [stress.go](https://github.com/xmtp/xmtpd/pull/742/files#diff-c20b3951391371bef7d3285604e588282211b72b016c7da816b7f176e1fb271e) which contains the core changes to private key parsing logic.

----

_[Macroscope](https://app.macroscope.com) summarized 84d6b6d._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved private key parsing by delegating validation and formatting to a utility function, streamlining address extraction from private keys. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->