### PR TITLE
Do not block forever on read-your-own-commits

### DIFF
--- a/pkg/api/payer/nodeCursorTracker.go
+++ b/pkg/api/payer/nodeCursorTracker.go
@@ -85,6 +85,8 @@ func (ct *NodeCursorTracker) BlockUntilDesiredCursorReached(
 		select {
 		case <-ct.ctx.Done():
 			return status.Errorf(codes.Aborted, "node terminated. Cancelled wait for cursor")
+		case <-parentCtx.Done():
+			return nil
 		case <-ctx.Done():
 			return status.Errorf(
 				codes.DeadlineExceeded,

--- a/pkg/api/payer/nodeCursorTracker.go
+++ b/pkg/api/payer/nodeCursorTracker.go
@@ -86,7 +86,11 @@ func (ct *NodeCursorTracker) BlockUntilDesiredCursorReached(
 		case <-ct.ctx.Done():
 			return status.Errorf(codes.Aborted, "node terminated. Cancelled wait for cursor")
 		case <-ctx.Done():
-			return status.Errorf(codes.DeadlineExceeded, "Wait for cursor was unsuccessful after %s", time.Since(start))
+			return status.Errorf(
+				codes.DeadlineExceeded,
+				"Wait for cursor was unsuccessful after %s",
+				time.Since(start),
+			)
 		case err := <-errCh:
 			if errors.Is(ctx.Err(), context.Canceled) {
 				return nil

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -385,6 +385,7 @@ func (s *Service) publishToBlockchain(
 		s.log.Error(
 			"Chosen node for cursor check is unreachable",
 			zap.Uint32("targetNodeId", targetNodeId),
+			zap.Error(err),
 		)
 	}
 


### PR DESCRIPTION
### Add 10-second timeout to `BlockUntilDesiredCursorReached` function to prevent indefinite blocking on read-your-own-commits
* Implements a 10-second timeout in [nodeCursorTracker.go](https://github.com/xmtp/xmtpd/pull/743/files#diff-53bc52b24f8bd6ebdbf96bf10c2fe152f927d6c8c0487f89e3e94d73a31b7e74) using `context.WithTimeout` to prevent indefinite blocking
* Refines error handling by using more specific error codes (`codes.Aborted` for node termination, `codes.DeadlineExceeded` for timeouts)
* Adds error details to logging in [service.go](https://github.com/xmtp/xmtpd/pull/743/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280) when `BlockUntilDesiredCursorReached` fails

#### 📍Where to Start
Start with the `BlockUntilDesiredCursorReached` function in [nodeCursorTracker.go](https://github.com/xmtp/xmtpd/pull/743/files#diff-53bc52b24f8bd6ebdbf96bf10c2fe152f927d6c8c0487f89e3e94d73a31b7e74) which contains the core timeout and error handling changes.

----

_[Macroscope](https://app.macroscope.com) summarized 1bf5d81._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for cursor tracking operations, providing clearer feedback for different cancellation and timeout scenarios.
- **Chores**
  - Enhanced logging to include detailed error information when a node is unreachable during cursor checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->