### PR TITLE
Fix issue with identity update storer

### DIFF
--- a/pkg/indexer/storer/identityUpdate.go
+++ b/pkg/indexer/storer/identityUpdate.go
@@ -221,7 +221,9 @@ func (s *IdentityUpdateStorer) validateIdentityUpdate(
 	gatewayEnvelopes, err := querier.SelectGatewayEnvelopes(
 		ctx,
 		queries.SelectGatewayEnvelopesParams{
-			Topics:            []db.Topic{db.Topic(BuildInboxTopic(inboxId))},
+			Topics: []db.Topic{
+				db.Topic(topic.NewTopic(topic.TOPIC_KIND_IDENTITY_UPDATES_V1, inboxId[:]).Bytes()),
+			},
 			OriginatorNodeIds: []int32{IDENTITY_UPDATE_ORIGINATOR_ID},
 			RowLimit:          256,
 		},
@@ -240,10 +242,6 @@ func (s *IdentityUpdateStorer) validateIdentityUpdate(
 		gatewayEnvelopes,
 		identityUpdate.IdentityUpdate,
 	)
-}
-
-func BuildInboxTopic(inboxId [32]byte) string {
-	return fmt.Sprintf("i/%x", inboxId)
 }
 
 func buildOriginatorEnvelope(


### PR DESCRIPTION
### TL;DR

- Replace custom inbox topic format with standardized topic implementation for identity updates.
- Adds a test for sequential identity update inserts

### What changed?

- Replaced the custom `BuildInboxTopic` function with the standardized `topic.NewTopic` implementation
- Removed the now-unused `BuildInboxTopic` function
- Added a test case `TestStoreSequential` to verify sequential identity updates work correctly with the new topic format

### How to test?

1. Run the identity update tests to verify they pass with the new topic format:
   ```
   go test -v ./pkg/indexer/storer -run TestStoreIdentityUpdate
   go test -v ./pkg/indexer/storer -run TestStoreSequential
   ```
2. Verify that identity updates are properly stored and can be retrieved using the new topic format

### Why make this change?

This change standardizes how we handle topics for identity updates by using the common topic package instead of a custom string format. This improves consistency across the codebase and ensures that all components use the same topic format when working with identity updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved error checking in existing identity update storage tests.
	- Added a new test to verify correct handling of sequential identity update logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->