### PR TITLE
Add dummy chain watcher

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -578,6 +578,7 @@ func startChainWatcher(logger *zap.Logger, options *CLI) {
 
 	watcher, err := stress.NewWatcher(
 		ctx,
+		logger,
 		options.Watcher.Wss,
 		common.HexToAddress(options.Watcher.Contract),
 	)
@@ -585,7 +586,7 @@ func startChainWatcher(logger *zap.Logger, options *CLI) {
 		logger.Fatal("could not create watcher", zap.Error(err))
 	}
 
-	err = watcher.Listen(ctx)
+	err = watcher.Listen()
 	if err != nil {
 		logger.Fatal("could not listen", zap.Error(err))
 	}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/xmtp/xmtpd/pkg/fees"
 	"github.com/xmtp/xmtpd/pkg/abi/rateregistry"
 	"github.com/xmtp/xmtpd/pkg/blockchain/migrator"
 	"github.com/xmtp/xmtpd/pkg/config"
+	"github.com/xmtp/xmtpd/pkg/fees"
 	"github.com/xmtp/xmtpd/pkg/stress"
 
 	"github.com/jessevdk/go-flags"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -567,6 +567,7 @@ func identityUpdatesStress(logger *zap.Logger, options *CLI) {
 		options.IdentityUpdatesStress.Contract,
 		options.IdentityUpdatesStress.Rpc,
 		options.IdentityUpdatesStress.PrivateKey,
+		options.IdentityUpdatesStress.Async,
 	)
 	if err != nil {
 		logger.Fatal("could not create identity updates", zap.Error(err))

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -93,6 +93,7 @@ type IdentityUpdatesStressOptions struct {
 	Contract   string `long:"contract"    description:"Contract address"`
 	Rpc        string `long:"rpc"         description:"RPC URL"`
 	Count      int    `long:"count"       description:"Number of transactions to send"`
+	Async      bool   `long:"async"       description:"Send transactions asynchronously"`
 }
 
 type WatcherOptions struct {

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -94,3 +94,8 @@ type IdentityUpdatesStressOptions struct {
 	Rpc        string `long:"rpc"         description:"RPC URL"`
 	Count      int    `long:"count"       description:"Number of transactions to send"`
 }
+
+type WatcherOptions struct {
+	Contract string `long:"contract" description:"Contract address"`
+	Wss      string `long:"wss"      description:"WSS URL"`
+}

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -96,6 +96,6 @@ type IdentityUpdatesStressOptions struct {
 }
 
 type WatcherOptions struct {
-	Contract string `long:"contract" description:"Contract address"`
-	Wss      string `long:"wss"      description:"WSS URL"`
+	Contract string `long:"contract" description:"Contract address" required:"true"`
+	Wss      string `long:"wss"      description:"WSS URL"          required:"true"`
 }

--- a/pkg/stress/cast.go
+++ b/pkg/stress/cast.go
@@ -16,6 +16,7 @@ type CastSendCommand struct {
 	Rpc             string
 	PrivateKey      string
 	Nonce           *uint64
+	Async           bool
 }
 
 func buildCastSendCommand(c *CastSendCommand) string {
@@ -35,6 +36,10 @@ func buildCastSendCommand(c *CastSendCommand) string {
 
 	if c.Nonce != nil {
 		cmd.WriteString(fmt.Sprintf(" --nonce %d", *c.Nonce))
+	}
+
+	if c.Async {
+		cmd.WriteString(" --async")
 	}
 
 	return cmd.String()

--- a/pkg/stress/stress.go
+++ b/pkg/stress/stress.go
@@ -27,6 +27,7 @@ func StressIdentityUpdates(
 	logger *zap.Logger,
 	n int,
 	contractAddress, rpc, privateKey string,
+	async bool,
 ) error {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -70,6 +71,7 @@ func StressIdentityUpdates(
 				Rpc:             rpc,
 				PrivateKey:      privateKey,
 				Nonce:           &nonce,
+				Async:           async,
 			}
 
 			startTime := time.Now()

--- a/pkg/stress/watcher.go
+++ b/pkg/stress/watcher.go
@@ -1,0 +1,174 @@
+package stress
+
+import (
+	"context"
+	"math/big"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"go.uber.org/zap"
+)
+
+type Watcher struct {
+	logger          *zap.Logger
+	ethClient       *ethclient.Client
+	fromBlock       *big.Int
+	watchedContract common.Address
+}
+
+func NewWatcher(
+	ctx context.Context,
+	rpcURL string,
+	watchedContract common.Address,
+) (*Watcher, error) {
+	logger := zap.NewExample()
+
+	ethClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := ethClient.BlockByNumber(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Watcher{
+		logger:          logger,
+		ethClient:       ethClient,
+		fromBlock:       block.Number(),
+		watchedContract: watchedContract,
+	}, nil
+}
+
+func (w *Watcher) Listen(ctx context.Context) error {
+	ctxwc, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	w.logger.Info("subscribing to logs")
+	newDone, logCh, err := w.watch(ctxwc)
+	if err != nil {
+		w.logger.Error("failed to subscribe and process new logs.")
+		return err
+	}
+
+	w.logger.Info("subscribed to logs")
+	processingDone := w.process(ctxwc, logCh)
+
+	select {
+	case <-ctxwc.Done():
+		w.logger.Info("received shutdown signal")
+	case <-newDone:
+		w.logger.Info("subscription ended")
+	case <-processingDone:
+		w.logger.Info("log processing ended")
+	}
+
+	return nil
+}
+
+func (w *Watcher) setupFilterQuery(fromBlock, toBlock *big.Int) ethereum.FilterQuery {
+	return ethereum.FilterQuery{
+		Addresses: []common.Address{w.watchedContract},
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Topics:    [][]common.Hash{},
+	}
+}
+
+func (w *Watcher) watch(
+	ctx context.Context,
+) (<-chan struct{}, <-chan types.Log, error) {
+	query := w.setupFilterQuery(w.fromBlock, nil)
+	logCh := make(chan types.Log)
+	done := make(chan struct{})
+
+	sub, err := w.ethClient.SubscribeFilterLogs(ctx, query, logCh)
+	if err != nil {
+		w.logger.Error(
+			"unexpected error while creating subscription",
+			zap.String("err", err.Error()),
+		)
+		return nil, nil, err
+	}
+
+	go func() {
+		defer close(done)
+		defer close(logCh)
+		defer sub.Unsubscribe()
+
+		for {
+			select {
+			case err := <-sub.Err():
+				if err != nil {
+					w.logger.Error("subscription error: %s", zap.String("err", err.Error()))
+					sub.Unsubscribe()
+
+					success := false
+					for try := range 10 {
+						sub, err = w.ethClient.SubscribeFilterLogs(ctx, query, logCh)
+						if err == nil {
+							w.logger.Info("subscription successfully recreated.")
+							success = true
+
+							break
+						}
+
+						time.Sleep(time.Second * time.Duration(try))
+					}
+
+					if !success {
+						w.logger.Error(
+							"failed to recreate subscription after retries: shutting down watcher.",
+						)
+						return
+					}
+				}
+
+			case <-ctx.Done():
+				w.logger.Debug("shutting down subscription")
+				return
+			}
+		}
+	}()
+
+	return done, logCh, nil
+}
+
+func (w *Watcher) process(
+	ctx context.Context,
+	newLog <-chan types.Log,
+) <-chan struct{} {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for {
+			select {
+			case log, open := <-newLog:
+				if !open {
+					w.logger.Info("log channel closed")
+					return
+				}
+				w.logger.Info("received log",
+					zap.String("time", time.Now().Format(time.RFC3339)),
+					zap.String("address", log.Address.Hex()),
+					zap.Uint64("blockNumber", log.BlockNumber),
+					zap.String("txHash", log.TxHash.Hex()),
+				)
+
+			case <-ctx.Done():
+				w.logger.Info("context cancelled, stopping log processing")
+				return
+			}
+		}
+	}()
+
+	return done
+}

--- a/pkg/stress/watcher.go
+++ b/pkg/stress/watcher.go
@@ -32,7 +32,10 @@ func NewWatcher(
 		return nil, err
 	}
 
-	block, err := ethClient.BlockByNumber(ctx, nil)
+	ctxwt, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	block, err := ethClient.BlockByNumber(ctxwt, nil)
 	if err != nil {
 		ethClient.Close()
 		return nil, err

--- a/pkg/stress/watcher.go
+++ b/pkg/stress/watcher.go
@@ -110,7 +110,7 @@ func (w *Watcher) watch(
 			select {
 			case err := <-sub.Err():
 				if err != nil {
-					w.logger.Error("subscription error: %s", zap.String("err", err.Error()))
+					w.logger.Error("subscription error", zap.String("err", err.Error()))
 					sub.Unsubscribe()
 
 					success := false


### PR DESCRIPTION
### Add blockchain event monitoring functionality by implementing a chain watcher in the CLI
Implements a new blockchain event monitoring system through:

* A new `Watcher` struct in [watcher.go](https://github.com/xmtp/xmtpd/pull/747/files#diff-8c5bb32cd63bc651358b6d5047c19e39d5cc1502ae827aed32519f5bccf45fb5) that connects to Ethereum nodes via WebSocket and monitors contract events with retry logic
* Extended CLI functionality in [main.go](https://github.com/xmtp/xmtpd/pull/747/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) with a new `start-watcher` command that initializes the watcher
* New configuration options in [cliOptions.go](https://github.com/xmtp/xmtpd/pull/747/files#diff-8405561572b34bc30144dc45f17a7b17be5cbc74d653efdeb4caef1092301f5c) for specifying contract addresses and WebSocket URLs

#### 📍Where to Start
Start with the `startChainWatcher` function in [main.go](https://github.com/xmtp/xmtpd/pull/747/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) which shows how the watcher is initialized and integrated into the CLI, then move to the core watcher implementation in [watcher.go](https://github.com/xmtp/xmtpd/pull/747/files#diff-8c5bb32cd63bc651358b6d5047c19e39d5cc1502ae827aed32519f5bccf45fb5).

----

_[Macroscope](https://app.macroscope.com) summarized eb3e7c5._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command to start a blockchain watcher that monitors events for a specified contract address.
  - Added options to specify the contract address and WebSocket URL via command-line flags.
  - The watcher provides real-time logging of contract events and supports graceful shutdown.
  - Added an option to send transactions asynchronously during identity update stress tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->