### PR TITLE
Teach CLI the get rates command

### DIFF
--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -52,6 +52,8 @@ type AddRatesOptions struct {
 	DelayDays       uint   `long:"delay-days"        description:"Delay the rates going into effect for N days"    default:"0"`
 }
 
+type GetRatesOptions struct{}
+
 type RegisterNodeOptions struct {
 	AdminOptions              NodeRegistryAdminOptions `group:"Admin Options" namespace:"admin"`
 	HttpAddress               string                   `                                        long:"http-address"                  description:"HTTP address to register for the node"                            required:"true"`


### PR DESCRIPTION
### Add `get-rates` command to CLI to retrieve current rates from rates manager
Implements a new CLI command `get-rates` with supporting infrastructure:

* Adds new `GetRatesOptions` struct in [cliOptions.go](https://github.com/xmtp/xmtpd/pull/748/files#diff-8405561572b34bc30144dc45f17a7b17be5cbc74d653efdeb4caef1092301f5c)
* Extends CLI struct and options parsing in [main.go](https://github.com/xmtp/xmtpd/pull/748/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) to support the new command
* Implements `getRates` function that creates and starts a contract rates fetcher to retrieve current rates
* Groups `add-rates` with other admin commands for better organization

#### 📍Where to Start
Start with the `getRates` function implementation in [main.go](https://github.com/xmtp/xmtpd/pull/748/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) which contains the core logic for fetching rates using the contract rates fetcher.

----

_[Macroscope](https://app.macroscope.com) summarized a947cbd._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "get-rates" command in the CLI to fetch and display current rates from the rates manager contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->