### PR TITLE
Add go formatter options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,16 @@
 {
   "go.lintTool": "golangci-lint",
   "go.lintFlags": ["--fast"],
+  "go.formatTool": "custom",
+  "go.alternateTools": {
+    "customFormatter": "golangci-lint"
+  },
+  "go.formatFlags": ["fmt", "--stdin"],
   "[sql]": {
     "editor.defaultFormatter": "mtxr.sqltools",
     "editor.formatOnSave": true
   },
+  "go.useLanguageServer": true,
   "sqltools.highlightQuery": false,
   "sqltools.format": {
     "linesBetweenQueries": 2,


### PR DESCRIPTION
### tl;dr

- Our CI is using a stricter formatter than VSCode

### Configure VSCode to use Go language server and gofumpt formatter in [.vscode/settings.json](https://github.com/xmtp/xmtpd/pull/765/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357)
Updates VSCode editor configuration to:
* Enable the Go language server (`gopls`)
* Configure `gopls` to use `gofumpt` for code formatting

#### 📍Where to Start
Review the configuration changes in [.vscode/settings.json](https://github.com/xmtp/xmtpd/pull/765/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357), which contains the new VSCode settings for the Go language server and formatter.

----

_[Macroscope](https://app.macroscope.com) summarized 95612e1._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated editor settings to enable Go language server support and apply stricter Go code formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->