### PR TITLE
Update docker-compose-register.yml to use latest xmtpd-cli version (sha-a96bf04)

### DIFF
--- a/dev/docker/docker-compose-register.yml
+++ b/dev/docker/docker-compose-register.yml
@@ -1,7 +1,7 @@
 services:
   register-node-1:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-7e2f18f
+    image: ghcr.io/xmtp/xmtpd-cli:sha-a96bf04
     profiles: ["single", "dual"]
     env_file:
       - ../local.env
@@ -18,7 +18,7 @@ services:
 
   enable-node-1:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-7e2f18f
+    image: ghcr.io/xmtp/xmtpd-cli:sha-a96bf04
     profiles: ["single", "dual"]
     env_file:
       - ../local.env
@@ -36,7 +36,7 @@ services:
 
   register-node-2:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-7e2f18f
+    image: ghcr.io/xmtp/xmtpd-cli:sha-a96bf04
     profiles: ["dual"]
     env_file:
       - ../local.env
@@ -56,7 +56,7 @@ services:
 
   enable-node-2:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-7e2f18f
+    image: ghcr.io/xmtp/xmtpd-cli:sha-a96bf04
     profiles: ["dual"]
     env_file:
       - ../local.env


### PR DESCRIPTION
I made changes for xmtpd-cli latest version in docker-compose-register.yml file :
- Updated image tag for register-node-1 service
- Updated image tag for enable-node-1 service
- Updated image tag for register-node-2 service
- Updated image tag for enable-node-2 service

this update ensures all node registration services are using the latest version of the xmtpd-cli tool, which includes recent improvements and bug fixes. 
#762  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container image version for several services in the Docker Compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->