### PR TITLE
Set payer expiration all the way through from client to XMTPD database

### DIFF
--- a/dev/gen/protos
+++ b/dev/gen/protos
@@ -6,7 +6,7 @@ repo_root=$(realpath "${script_dir}/../../")
 cd "${repo_root}"
 
 rm -rf pkg/proto/**/*.pb.go pkg/proto/**/*.pb.gw.go pkg/proto/**/*.swagger.json
-if ! go tool -modfile=tools/go.mod buf generate https://github.com/xmtp/proto.git#subdir=proto,branch=main; then
+if ! go tool -modfile=tools/go.mod buf generate https://github.com/xmtp/proto.git#subdir=proto,branch=mkysel/expiry2; then
     echo "Failed to generate protobuf definitions"
     exit 1
 fi

--- a/dev/gen/protos
+++ b/dev/gen/protos
@@ -6,7 +6,7 @@ repo_root=$(realpath "${script_dir}/../../")
 cd "${repo_root}"
 
 rm -rf pkg/proto/**/*.pb.go pkg/proto/**/*.pb.gw.go pkg/proto/**/*.swagger.json
-if ! go tool -modfile=tools/go.mod buf generate https://github.com/xmtp/proto.git#subdir=proto,branch=mkysel/expiry2; then
+if ! go tool -modfile=tools/go.mod buf generate https://github.com/xmtp/proto.git#subdir=proto,branch=main; then
     echo "Failed to generate protobuf definitions"
     exit 1
 fi

--- a/pkg/api/message/publishWorker.go
+++ b/pkg/api/message/publishWorker.go
@@ -122,7 +122,12 @@ func (p *publishWorker) publishStagedEnvelope(stagedEnv queries.StagedOriginator
 		return false
 	}
 
-	originatorEnv, err := p.registrant.SignStagedEnvelope(stagedEnv, baseFee, congestionFee, retentionDays)
+	originatorEnv, err := p.registrant.SignStagedEnvelope(
+		stagedEnv,
+		baseFee,
+		congestionFee,
+		retentionDays,
+	)
 	if err != nil {
 		logger.Error(
 			"Failed to sign staged envelope",
@@ -168,7 +173,9 @@ func (p *publishWorker) publishStagedEnvelope(stagedEnv queries.StagedOriginator
 			OriginatorEnvelope:   originatorBytes,
 			PayerID:              db.NullInt32(payerId),
 			GatewayTime:          stagedEnv.OriginatorTime,
-			Expiry:               db.NullInt64(int64(validatedEnvelope.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime())),
+			Expiry: db.NullInt64(
+				int64(validatedEnvelope.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime()),
+			),
 		},
 		queries.IncrementUnsettledUsageParams{
 			PayerID:           payerId,

--- a/pkg/api/message/publishWorker.go
+++ b/pkg/api/message/publishWorker.go
@@ -109,12 +109,12 @@ func (p *publishWorker) start() {
 func (p *publishWorker) publishStagedEnvelope(stagedEnv queries.StagedOriginatorEnvelope) bool {
 	logger := p.log.With(zap.Int64("sequenceID", stagedEnv.ID))
 
-	env, err := envelopes.NewUnsignedOriginatorEnvelopeFromBytes(stagedEnv.PayerEnvelope)
+	env, err := envelopes.NewPayerEnvelopeFromBytes(stagedEnv.PayerEnvelope)
 	if err != nil {
 		logger.Warn("Failed to unmarshall originator envelope", zap.Error(err))
 		return false
 	}
-	retentionDays := env.PayerEnvelope.Proto().GetMessageRetentionDays()
+	retentionDays := env.RetentionDays()
 
 	baseFee, congestionFee, err := p.calculateFees(&stagedEnv, retentionDays)
 	if err != nil {

--- a/pkg/api/message/publish_test.go
+++ b/pkg/api/message/publish_test.go
@@ -2,6 +2,7 @@ package message_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -346,4 +347,86 @@ func TestPublishEnvelopeFees(t *testing.T) {
 		originatorEnv.UnsignedOriginatorEnvelope.CongestionFee(),
 		returnedEnv.UnsignedOriginatorEnvelope.CongestionFee(),
 	)
+}
+
+func TestPublishEnvelopeWithVarExpirations(t *testing.T) {
+	api, _, _, cleanup := apiTestUtils.NewTestReplicationAPIClient(t)
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		expiry      uint32
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:        "0 expiry",
+			expiry:      0,
+			wantErr:     true,
+			expectedErr: "invalid expiry retention days",
+		},
+		{
+			name:        "short expiry",
+			expiry:      1,
+			wantErr:     true,
+			expectedErr: "invalid expiry retention days",
+		},
+		{
+			name:    "minimal expiry",
+			expiry:  2,
+			wantErr: false,
+		},
+		{
+			name:    "1 week expiry",
+			expiry:  7,
+			wantErr: false,
+		},
+		{
+			name:    "30 day expiry",
+			expiry:  30,
+			wantErr: false,
+		},
+		{
+			name:    "90 day expiry",
+			expiry:  90,
+			wantErr: false,
+		},
+		{
+			name:        "5 year expiry",
+			expiry:      5 * 365,
+			wantErr:     true,
+			expectedErr: "invalid expiry retention days",
+		},
+		{
+			name:    "infinite expiry",
+			expiry:  math.MaxUint32,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payerEnvelope := envelopeTestUtils.CreatePayerEnvelopeWithExpiration(
+				t,
+				envelopeTestUtils.DefaultClientEnvelopeNodeId,
+				tt.expiry,
+			)
+
+			_, err := api.PublishPayerEnvelopes(
+				context.Background(),
+				&message_api.PublishPayerEnvelopesRequest{
+					PayerEnvelopes: []*envelopes.PayerEnvelope{payerEnvelope},
+				},
+			)
+			if tt.wantErr {
+				if tt.expectedErr == "" {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, tt.expectedErr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/xmtp/xmtpd/pkg/config"
@@ -517,7 +518,7 @@ func (s *Service) validateExpiry(payerEnv *envelopes.PayerEnvelope) error {
 	}
 
 	// more than a ~year sounds like a mistake
-	if !payerEnv.ClientEnvelope.Aad().IsCommit && payerEnv.RetentionDays() > 365 {
+	if payerEnv.RetentionDays() != math.MaxUint32 && payerEnv.RetentionDays() > 365 {
 		return status.Errorf(codes.InvalidArgument, "invalid expiry retention days. Must be <= 365")
 
 	}

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -378,12 +378,20 @@ func (s *Service) PublishPayerEnvelopes(
 	}
 	s.publishWorker.notifyStagedPublish()
 
-	baseFee, congestionFee, err := s.publishWorker.calculateFees(&stagedEnv, payerEnv.Proto().GetMessageRetentionDays())
+	baseFee, congestionFee, err := s.publishWorker.calculateFees(
+		&stagedEnv,
+		payerEnv.Proto().GetMessageRetentionDays(),
+	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not calculate fees: %v", err)
 	}
 
-	originatorEnv, err := s.registrant.SignStagedEnvelope(stagedEnv, baseFee, congestionFee, payerEnv.Proto().GetMessageRetentionDays())
+	originatorEnv, err := s.registrant.SignStagedEnvelope(
+		stagedEnv,
+		baseFee,
+		congestionFee,
+		payerEnv.Proto().GetMessageRetentionDays(),
+	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not sign envelope: %v", err)
 	}
@@ -511,7 +519,6 @@ func (s *Service) validatePayerEnvelope(
 }
 
 func (s *Service) validateExpiry(payerEnv *envelopes.PayerEnvelope) error {
-
 	// the payload should be valid for at least for 2 days
 	if payerEnv.RetentionDays() < 2 {
 		return status.Errorf(codes.InvalidArgument, "invalid expiry retention days. Must be >= 2")
@@ -520,7 +527,6 @@ func (s *Service) validateExpiry(payerEnv *envelopes.PayerEnvelope) error {
 	// more than a ~year sounds like a mistake
 	if payerEnv.RetentionDays() != math.MaxUint32 && payerEnv.RetentionDays() > 365 {
 		return status.Errorf(codes.InvalidArgument, "invalid expiry retention days. Must be <= 365")
-
 	}
 
 	return nil

--- a/pkg/api/payer/publish_test.go
+++ b/pkg/api/payer/publish_test.go
@@ -3,6 +3,7 @@ package payer_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -212,4 +213,18 @@ func TestPublishToNodes(t *testing.T) {
 
 	targetOriginator := parsedOriginatorEnvelope.UnsignedOriginatorEnvelope.PayerEnvelope.TargetOriginator
 	require.EqualValues(t, 100, targetOriginator)
+
+	expiryTime := parsedOriginatorEnvelope.UnsignedOriginatorEnvelope.PayerEnvelope.Proto().
+		GetExpiryUnixtime()
+	assertTimestampIsReasonable(t, expiryTime)
+}
+
+func assertTimestampIsReasonable(t *testing.T, timestamp int64) {
+	// expiry is in the future
+	now := time.Now().Unix()
+	require.GreaterOrEqual(t, timestamp, now)
+
+	// expiry is less than 90 days + some test fuzzing
+	future := time.Now().Add(time.Hour * 24 * 90).Add(time.Minute * 30).Unix()
+	require.Less(t, timestamp, future)
 }

--- a/pkg/api/payer/publish_test.go
+++ b/pkg/api/payer/publish_test.go
@@ -3,7 +3,6 @@ package payer_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -213,18 +212,4 @@ func TestPublishToNodes(t *testing.T) {
 
 	targetOriginator := parsedOriginatorEnvelope.UnsignedOriginatorEnvelope.PayerEnvelope.TargetOriginator
 	require.EqualValues(t, 100, targetOriginator)
-
-	expiryTime := parsedOriginatorEnvelope.UnsignedOriginatorEnvelope.PayerEnvelope.Proto().
-		GetExpiryUnixtime()
-	assertTimestampIsReasonable(t, expiryTime)
-}
-
-func assertTimestampIsReasonable(t *testing.T, timestamp int64) {
-	// expiry is in the future
-	now := time.Now().Unix()
-	require.GreaterOrEqual(t, timestamp, now)
-
-	// expiry is less than 90 days + some test fuzzing
-	future := time.Now().Add(time.Hour * 24 * 90).Add(time.Minute * 30).Unix()
-	require.Less(t, timestamp, future)
 }

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -3,8 +3,8 @@ package payer
 import (
 	"context"
 	"crypto/ecdsa"
-	"math/rand"
 	"math"
+	"math/rand"
 	"time"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -498,10 +498,10 @@ func (s *Service) signClientEnvelope(originatorID uint32,
 		return nil, err
 	}
 
-	expiry := int64(math.MaxInt64)
+	retentionDays := uint32(math.MaxUint32)
 
 	if !clientEnvelope.Aad().IsCommit {
-		expiry = time.Now().Add(time.Hour * 24 * 90).Unix()
+		retentionDays = constants.DEFAULT_STORAGE_DURATION_DAYS
 	}
 
 	return &envelopesProto.PayerEnvelope{
@@ -509,8 +509,8 @@ func (s *Service) signClientEnvelope(originatorID uint32,
 		PayerSignature: &associations.RecoverableEcdsaSignature{
 			Bytes: payerSignature,
 		},
-		TargetOriginator: originatorID,
-		ExpiryUnixtime:   expiry,
+		TargetOriginator:     originatorID,
+		MessageRetentionDays: retentionDays,
 	}, nil
 }
 

--- a/pkg/envelopes/payer.go
+++ b/pkg/envelopes/payer.go
@@ -73,3 +73,7 @@ func (p *PayerEnvelope) RecoverSigner() (*common.Address, error) {
 func (p *PayerEnvelope) TargetTopic() topic.Topic {
 	return p.ClientEnvelope.TargetTopic()
 }
+
+func (p *PayerEnvelope) RetentionDays() uint32 {
+	return p.proto.MessageRetentionDays
+}

--- a/pkg/fees/calculator.go
+++ b/pkg/fees/calculator.go
@@ -22,7 +22,7 @@ func NewFeeCalculator(ratesFetcher IRatesFetcher) *FeeCalculator {
 func (c *FeeCalculator) CalculateBaseFee(
 	messageTime time.Time,
 	messageSize int64,
-	storageDurationDays int64,
+	storageDurationDays uint32,
 ) (currency.PicoDollar, error) {
 	if messageSize <= 0 {
 		return 0, fmt.Errorf("messageSize must be greater than 0, got %d", messageSize)

--- a/pkg/fees/calculator_test.go
+++ b/pkg/fees/calculator_test.go
@@ -58,7 +58,11 @@ func TestCalculateBaseFee(t *testing.T) {
 	messageSize := int64(100)
 	storageDurationDays := int64(1)
 
-	baseFee, err := calculator.CalculateBaseFee(messageTime, messageSize, storageDurationDays)
+	baseFee, err := calculator.CalculateBaseFee(
+		messageTime,
+		messageSize,
+		uint32(storageDurationDays),
+	)
 	require.NoError(t, err)
 
 	expectedFee := RATE_MESSAGE_FEE + (RATE_STORAGE_FEE * messageSize * storageDurationDays)
@@ -100,7 +104,7 @@ func TestOverflow(t *testing.T) {
 	_, err := calculator.CalculateBaseFee(
 		messageTime,
 		int64(messageSize),
-		int64(storageDurationDays),
+		uint32(storageDurationDays),
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "storage fee calculation overflow")

--- a/pkg/fees/interface.go
+++ b/pkg/fees/interface.go
@@ -27,7 +27,7 @@ type IFeeCalculator interface {
 	CalculateBaseFee(
 		messageTime time.Time,
 		messageSize int64,
-		storageDurationDays int64,
+		storageDurationDays uint32,
 	) (currency.PicoDollar, error)
 	CalculateCongestionFee(
 		ctx context.Context,

--- a/pkg/indexer/storer/groupMessage.go
+++ b/pkg/indexer/storer/groupMessage.go
@@ -2,7 +2,9 @@ package storer
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"math"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	gm "github.com/xmtp/xmtpd/pkg/abi/groupmessagebroadcaster"
@@ -95,6 +97,7 @@ func (s *GroupMessageStorer) StoreLog(
 		OriginatorSequenceID: int64(msgSent.SequenceId),
 		Topic:                topicStruct.Bytes(),
 		OriginatorEnvelope:   originatorEnvelopeBytes,
+		Expiry:               sql.NullInt64{Int64: math.MaxInt64, Valid: true},
 	}); err != nil {
 		s.logger.Error("Error inserting envelope from smart contract", zap.Error(err))
 		return NewRetryableLogStorageError(err)

--- a/pkg/indexer/storer/identityUpdate.go
+++ b/pkg/indexer/storer/identityUpdate.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -181,6 +182,7 @@ func (s *IdentityUpdateStorer) StoreLog(
 				OriginatorSequenceID: int64(msgSent.SequenceId),
 				Topic:                messageTopic.Bytes(),
 				OriginatorEnvelope:   originatorEnvelopeBytes,
+				Expiry:               sql.NullInt64{Int64: math.MaxInt64, Valid: true},
 			}); err != nil {
 				s.logger.Error("Error inserting envelope from smart contract", zap.Error(err))
 				return NewRetryableLogStorageError(err)

--- a/pkg/registrant/registrant.go
+++ b/pkg/registrant/registrant.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -80,6 +81,7 @@ func (r *Registrant) SignStagedEnvelope(
 	stagedEnv queries.StagedOriginatorEnvelope,
 	baseFee currency.PicoDollar,
 	congestionFee currency.PicoDollar,
+	retentionDays uint32,
 ) (*envelopes.OriginatorEnvelope, error) {
 	unsignedEnv := envelopes.UnsignedOriginatorEnvelope{
 		OriginatorNodeId:         r.record.NodeID,
@@ -88,6 +90,7 @@ func (r *Registrant) SignStagedEnvelope(
 		PayerEnvelopeBytes:       stagedEnv.PayerEnvelope,
 		BaseFeePicodollars:       uint64(baseFee),
 		CongestionFeePicodollars: uint64(congestionFee),
+		ExpiryUnixtime:           uint64(time.Now().AddDate(0, 0, int(retentionDays)).Unix()),
 	}
 	unsignedBytes, err := proto.Marshal(&unsignedEnv)
 	if err != nil {

--- a/pkg/registrant/registrant_test.go
+++ b/pkg/registrant/registrant_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/xmtp/xmtpd/pkg/constants"
+
 	"github.com/Masterminds/semver/v3"
 
 	"go.uber.org/zap"
@@ -256,6 +258,7 @@ func TestSignStagedEnvelopeSuccess(t *testing.T) {
 		},
 		0,
 		0,
+		constants.DEFAULT_STORAGE_DURATION_DAYS,
 	)
 
 	require.NoError(t, err)

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/xmtp/xmtpd/pkg/constants"
 	"github.com/xmtp/xmtpd/pkg/currency"
 	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
@@ -540,7 +539,7 @@ func (s *syncWorker) calculateFees(env *envUtils.OriginatorEnvelope) (currency.P
 	baseFee, err := s.feeCalculator.CalculateBaseFee(
 		messageTime,
 		int64(payerEnvelopeLength),
-		constants.DEFAULT_STORAGE_DURATION_DAYS,
+		env.UnsignedOriginatorEnvelope.PayerEnvelope.RetentionDays(),
 	)
 	if err != nil {
 		return 0, err

--- a/pkg/testutils/envelopes/envelopes.go
+++ b/pkg/testutils/envelopes/envelopes.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"github.com/xmtp/xmtpd/pkg/constants"
 	"testing"
 	"time"
 
@@ -105,7 +106,8 @@ func CreatePayerEnvelope(
 		PayerSignature: &associations.RecoverableEcdsaSignature{
 			Bytes: payerSignature,
 		},
-		TargetOriginator: nodeID,
+		TargetOriginator:     nodeID,
+		MessageRetentionDays: constants.DEFAULT_STORAGE_DURATION_DAYS,
 	}
 }
 

--- a/pkg/testutils/envelopes/envelopes.go
+++ b/pkg/testutils/envelopes/envelopes.go
@@ -84,9 +84,10 @@ func CreateIdentityUpdateClientEnvelope(
 	}
 }
 
-func CreatePayerEnvelope(
+func CreatePayerEnvelopeWithExpiration(
 	t *testing.T,
 	nodeID uint32,
+	expirationDays uint32,
 	clientEnv ...*envelopes.ClientEnvelope,
 ) *envelopes.PayerEnvelope {
 	if len(clientEnv) == 0 {
@@ -108,8 +109,20 @@ func CreatePayerEnvelope(
 			Bytes: payerSignature,
 		},
 		TargetOriginator:     nodeID,
-		MessageRetentionDays: constants.DEFAULT_STORAGE_DURATION_DAYS,
+		MessageRetentionDays: expirationDays,
 	}
+}
+
+func CreatePayerEnvelope(
+	t *testing.T,
+	nodeID uint32,
+	clientEnv ...*envelopes.ClientEnvelope,
+) *envelopes.PayerEnvelope {
+	return CreatePayerEnvelopeWithExpiration(
+		t,
+		nodeID,
+		constants.DEFAULT_STORAGE_DURATION_DAYS,
+		clientEnv...)
 }
 
 func CreateOriginatorEnvelopeWithTimestamp(

--- a/pkg/testutils/envelopes/envelopes.go
+++ b/pkg/testutils/envelopes/envelopes.go
@@ -1,9 +1,10 @@
 package testutils
 
 import (
-	"github.com/xmtp/xmtpd/pkg/constants"
 	"testing"
 	"time"
+
+	"github.com/xmtp/xmtpd/pkg/constants"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying message retention duration in payer envelopes.
  - Message expiry is now dynamically set based on the specified retention period.

- **Improvements**
  - Fee calculations and message signing now use the actual retention period from each message instead of a fixed default.
  - Validation ensures retention days are within allowed limits (2–365 days or maximum value).

- **Bug Fixes**
  - Ensured expiry timestamps are explicitly set when storing messages.

- **Tests**
  - Added tests covering publishing messages with various retention durations.
  - Updated existing tests to reflect changes in retention period handling and method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->