### PR TITLE
Add GetReaderNode payer API endpoint

### DIFF
--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -1,27 +1,29 @@
-| Name | Type | Description | File |
-|------|------|-------------|------|
-| `xmtp_api_failed_grpc_requests_counter` | `Counter` | Number of failed GRPC requests by code | `pkg/metrics/api.go` |
-| `xmtp_api_incoming_node_connection_by_version_gauge` | `Gauge` | Number of incoming node connections by version | `pkg/metrics/api.go` |
-| `xmtp_api_node_connection_requests_by_version_counter` | `Counter` | Number of incoming node connections by version | `pkg/metrics/api.go` |
-| `xmtp_api_open_connections_gauge` | `Gauge` | Number of open API connections | `pkg/metrics/api.go` |
-| `xmtp_blockchain_publish_payload_seconds` | `Histogram` | Time to publish a payload to the blockchain | `pkg/metrics/blockchain.go` |
-| `xmtp_blockchain_wait_for_transaction_seconds` | `Histogram` | Time spent waiting for transaction receipt | `pkg/metrics/blockchain.go` |
-| `xmtp_indexer_log_processing_time_seconds` | `Histogram` | Time to process a blockchain log | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_log_streamer_block_lag` | `Gauge` | Lag between current block and max block | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_log_streamer_current_block` | `Gauge` | Current block being processed by the log streamer | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_log_streamer_get_logs_duration` | `Histogram` | Duration of the get logs call | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_log_streamer_get_logs_requests` | `Counter` | Number of get logs requests | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_log_streamer_logs` | `Counter` | Number of logs found by the log streamer | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_log_streamer_max_block` | `Gauge` | Max block on the chain to be processed by the log streamer | `pkg/metrics/indexer.go` |
-| `xmtp_indexer_retryable_storage_error_count` | `Counter` | Number of retryable storage errors | `pkg/metrics/indexer.go` |
-| `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist | `pkg/metrics/payer.go` |
-| `xmtp_payer_lru_nonce` | `Gauge` | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go` |
-| `xmtp_payer_messages_originated` | `Counter` | Number of messages originated by the payer. | `pkg/metrics/payer.go` |
-| `xmtp_payer_node_publish_duration_seconds` | `Histogram` | Duration of the node publish call | `pkg/metrics/payer.go` |
-| `xmtp_payer_read_own_commit_in_time_seconds` | `Histogram` | Read your own commit duration in seconds | `pkg/metrics/payer.go` |
-| `xmtp_sync_failed_outgoing_sync_connections` | `Gauge` | Gauge of current failed outgoing sync connections | `pkg/metrics/sync.go` |
-| `xmtp_sync_failed_outgoing_sync_connections_counter` | `Counter` | Counter of total number of failed outgoing sync connection attempts | `pkg/metrics/sync.go` |
-| `xmtp_sync_messages_received_count` | `Counter` | Count of messages received from the originator | `pkg/metrics/sync.go` |
-| `xmtp_sync_messages_received_error_count` | `Counter` | Count of failed/errored messages received from the originator | `pkg/metrics/sync.go` |
-| `xmtp_sync_originator_sequence_id` | `Gauge` | Last synced sequence id of the originator | `pkg/metrics/sync.go` |
-| `xmtp_sync_outgoing_sync_connections` | `Gauge` | Gauge of open outgoing sync connections | `pkg/metrics/sync.go` |
+| Name                                                        | Type        | Description                                                                                 | File                        |
+| ----------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------- | --------------------------- |
+| `xmtp_api_failed_grpc_requests_counter`                     | `Counter`   | Number of failed GRPC requests by code                                                      | `pkg/metrics/api.go`        |
+| `xmtp_api_incoming_node_connection_by_version_gauge`        | `Gauge`     | Number of incoming node connections by version                                              | `pkg/metrics/api.go`        |
+| `xmtp_api_node_connection_requests_by_version_counter`      | `Counter`   | Number of incoming node connections by version                                              | `pkg/metrics/api.go`        |
+| `xmtp_api_open_connections_gauge`                           | `Gauge`     | Number of open API connections                                                              | `pkg/metrics/api.go`        |
+| `xmtp_blockchain_publish_payload_seconds`                   | `Histogram` | Time to publish a payload to the blockchain                                                 | `pkg/metrics/blockchain.go` |
+| `xmtp_blockchain_wait_for_transaction_seconds`              | `Histogram` | Time spent waiting for transaction receipt                                                  | `pkg/metrics/blockchain.go` |
+| `xmtp_indexer_log_processing_time_seconds`                  | `Histogram` | Time to process a blockchain log                                                            | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_log_streamer_block_lag`                       | `Gauge`     | Lag between current block and max block                                                     | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_log_streamer_current_block`                   | `Gauge`     | Current block being processed by the log streamer                                           | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_log_streamer_get_logs_duration`               | `Histogram` | Duration of the get logs call                                                               | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_log_streamer_get_logs_requests`               | `Counter`   | Number of get logs requests                                                                 | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_log_streamer_logs`                            | `Counter`   | Number of logs found by the log streamer                                                    | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_log_streamer_max_block`                       | `Gauge`     | Max block on the chain to be processed by the log streamer                                  | `pkg/metrics/indexer.go`    |
+| `xmtp_indexer_retryable_storage_error_count`                | `Counter`   | Number of retryable storage errors                                                          | `pkg/metrics/indexer.go`    |
+| `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist                                  | `pkg/metrics/payer.go`      |
+| `xmtp_payer_lru_nonce`                                      | `Gauge`     | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go`      |
+| `xmtp_payer_messages_originated`                            | `Counter`   | Number of messages originated by the payer.                                                 | `pkg/metrics/payer.go`      |
+| `xmtp_payer_node_publish_duration_seconds`                  | `Histogram` | Duration of the node publish call                                                           | `pkg/metrics/payer.go`      |
+| `xmtp_payer_read_own_commit_in_time_seconds`                | `Histogram` | Read your own commit duration in seconds                                                    | `pkg/metrics/payer.go`      |
+| `xmtp_payer_get_reader_node_duration_seconds`               | `Histogram` | Duration of the GetReaderNode call                                                          | `pkg/metrics/payer.go`      |
+| `xmtp_payer_get_reader_node_available_nodes`                | `Gauge`     | Number of currently available nodes for reader selection                                    | `pkg/metrics/payer.go`      |
+| `xmtp_sync_failed_outgoing_sync_connections`                | `Gauge`     | Gauge of current failed outgoing sync connections                                           | `pkg/metrics/sync.go`       |
+| `xmtp_sync_failed_outgoing_sync_connections_counter`        | `Counter`   | Counter of total number of failed outgoing sync connection attempts                         | `pkg/metrics/sync.go`       |
+| `xmtp_sync_messages_received_count`                         | `Counter`   | Count of messages received from the originator                                              | `pkg/metrics/sync.go`       |
+| `xmtp_sync_messages_received_error_count`                   | `Counter`   | Count of failed/errored messages received from the originator                               | `pkg/metrics/sync.go`       |
+| `xmtp_sync_originator_sequence_id`                          | `Gauge`     | Last synced sequence id of the originator                                                   | `pkg/metrics/sync.go`       |
+| `xmtp_sync_outgoing_sync_connections`                       | `Gauge`     | Gauge of open outgoing sync connections                                                     | `pkg/metrics/sync.go`       |

--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -16,7 +16,6 @@
 | `xmtp_indexer_retryable_storage_error_count` | `Counter` | Number of retryable storage errors | `pkg/metrics/indexer.go` |
 | `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist | `pkg/metrics/payer.go` |
 | `xmtp_payer_get_reader_node_available_nodes` | `Gauge` | Number of currently available nodes for reader selection | `pkg/metrics/payer.go` |
-| `xmtp_payer_get_reader_node_duration_seconds` | `Histogram` | Duration of the GetReaderNode call | `pkg/metrics/payer.go` |
 | `xmtp_payer_lru_nonce` | `Gauge` | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go` |
 | `xmtp_payer_messages_originated` | `Counter` | Number of messages originated by the payer. | `pkg/metrics/payer.go` |
 | `xmtp_payer_node_publish_duration_seconds` | `Histogram` | Duration of the node publish call | `pkg/metrics/payer.go` |

--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -1,29 +1,29 @@
-| Name                                                        | Type        | Description                                                                                 | File                        |
-| ----------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------- | --------------------------- |
-| `xmtp_api_failed_grpc_requests_counter`                     | `Counter`   | Number of failed GRPC requests by code                                                      | `pkg/metrics/api.go`        |
-| `xmtp_api_incoming_node_connection_by_version_gauge`        | `Gauge`     | Number of incoming node connections by version                                              | `pkg/metrics/api.go`        |
-| `xmtp_api_node_connection_requests_by_version_counter`      | `Counter`   | Number of incoming node connections by version                                              | `pkg/metrics/api.go`        |
-| `xmtp_api_open_connections_gauge`                           | `Gauge`     | Number of open API connections                                                              | `pkg/metrics/api.go`        |
-| `xmtp_blockchain_publish_payload_seconds`                   | `Histogram` | Time to publish a payload to the blockchain                                                 | `pkg/metrics/blockchain.go` |
-| `xmtp_blockchain_wait_for_transaction_seconds`              | `Histogram` | Time spent waiting for transaction receipt                                                  | `pkg/metrics/blockchain.go` |
-| `xmtp_indexer_log_processing_time_seconds`                  | `Histogram` | Time to process a blockchain log                                                            | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_log_streamer_block_lag`                       | `Gauge`     | Lag between current block and max block                                                     | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_log_streamer_current_block`                   | `Gauge`     | Current block being processed by the log streamer                                           | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_log_streamer_get_logs_duration`               | `Histogram` | Duration of the get logs call                                                               | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_log_streamer_get_logs_requests`               | `Counter`   | Number of get logs requests                                                                 | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_log_streamer_logs`                            | `Counter`   | Number of logs found by the log streamer                                                    | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_log_streamer_max_block`                       | `Gauge`     | Max block on the chain to be processed by the log streamer                                  | `pkg/metrics/indexer.go`    |
-| `xmtp_indexer_retryable_storage_error_count`                | `Counter`   | Number of retryable storage errors                                                          | `pkg/metrics/indexer.go`    |
-| `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist                                  | `pkg/metrics/payer.go`      |
-| `xmtp_payer_lru_nonce`                                      | `Gauge`     | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go`      |
-| `xmtp_payer_messages_originated`                            | `Counter`   | Number of messages originated by the payer.                                                 | `pkg/metrics/payer.go`      |
-| `xmtp_payer_node_publish_duration_seconds`                  | `Histogram` | Duration of the node publish call                                                           | `pkg/metrics/payer.go`      |
-| `xmtp_payer_read_own_commit_in_time_seconds`                | `Histogram` | Read your own commit duration in seconds                                                    | `pkg/metrics/payer.go`      |
-| `xmtp_payer_get_reader_node_duration_seconds`               | `Histogram` | Duration of the GetReaderNode call                                                          | `pkg/metrics/payer.go`      |
-| `xmtp_payer_get_reader_node_available_nodes`                | `Gauge`     | Number of currently available nodes for reader selection                                    | `pkg/metrics/payer.go`      |
-| `xmtp_sync_failed_outgoing_sync_connections`                | `Gauge`     | Gauge of current failed outgoing sync connections                                           | `pkg/metrics/sync.go`       |
-| `xmtp_sync_failed_outgoing_sync_connections_counter`        | `Counter`   | Counter of total number of failed outgoing sync connection attempts                         | `pkg/metrics/sync.go`       |
-| `xmtp_sync_messages_received_count`                         | `Counter`   | Count of messages received from the originator                                              | `pkg/metrics/sync.go`       |
-| `xmtp_sync_messages_received_error_count`                   | `Counter`   | Count of failed/errored messages received from the originator                               | `pkg/metrics/sync.go`       |
-| `xmtp_sync_originator_sequence_id`                          | `Gauge`     | Last synced sequence id of the originator                                                   | `pkg/metrics/sync.go`       |
-| `xmtp_sync_outgoing_sync_connections`                       | `Gauge`     | Gauge of open outgoing sync connections                                                     | `pkg/metrics/sync.go`       |
+| Name | Type | Description | File |
+|------|------|-------------|------|
+| `xmtp_api_failed_grpc_requests_counter` | `Counter` | Number of failed GRPC requests by code | `pkg/metrics/api.go` |
+| `xmtp_api_incoming_node_connection_by_version_gauge` | `Gauge` | Number of incoming node connections by version | `pkg/metrics/api.go` |
+| `xmtp_api_node_connection_requests_by_version_counter` | `Counter` | Number of incoming node connections by version | `pkg/metrics/api.go` |
+| `xmtp_api_open_connections_gauge` | `Gauge` | Number of open API connections | `pkg/metrics/api.go` |
+| `xmtp_blockchain_publish_payload_seconds` | `Histogram` | Time to publish a payload to the blockchain | `pkg/metrics/blockchain.go` |
+| `xmtp_blockchain_wait_for_transaction_seconds` | `Histogram` | Time spent waiting for transaction receipt | `pkg/metrics/blockchain.go` |
+| `xmtp_indexer_log_processing_time_seconds` | `Histogram` | Time to process a blockchain log | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_log_streamer_block_lag` | `Gauge` | Lag between current block and max block | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_log_streamer_current_block` | `Gauge` | Current block being processed by the log streamer | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_log_streamer_get_logs_duration` | `Histogram` | Duration of the get logs call | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_log_streamer_get_logs_requests` | `Counter` | Number of get logs requests | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_log_streamer_logs` | `Counter` | Number of logs found by the log streamer | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_log_streamer_max_block` | `Gauge` | Max block on the chain to be processed by the log streamer | `pkg/metrics/indexer.go` |
+| `xmtp_indexer_retryable_storage_error_count` | `Counter` | Number of retryable storage errors | `pkg/metrics/indexer.go` |
+| `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist | `pkg/metrics/payer.go` |
+| `xmtp_payer_get_reader_node_available_nodes` | `Gauge` | Number of currently available nodes for reader selection | `pkg/metrics/payer.go` |
+| `xmtp_payer_get_reader_node_duration_seconds` | `Histogram` | Duration of the GetReaderNode call | `pkg/metrics/payer.go` |
+| `xmtp_payer_lru_nonce` | `Gauge` | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go` |
+| `xmtp_payer_messages_originated` | `Counter` | Number of messages originated by the payer. | `pkg/metrics/payer.go` |
+| `xmtp_payer_node_publish_duration_seconds` | `Histogram` | Duration of the node publish call | `pkg/metrics/payer.go` |
+| `xmtp_payer_read_own_commit_in_time_seconds` | `Histogram` | Read your own commit duration in seconds | `pkg/metrics/payer.go` |
+| `xmtp_sync_failed_outgoing_sync_connections` | `Gauge` | Gauge of current failed outgoing sync connections | `pkg/metrics/sync.go` |
+| `xmtp_sync_failed_outgoing_sync_connections_counter` | `Counter` | Counter of total number of failed outgoing sync connection attempts | `pkg/metrics/sync.go` |
+| `xmtp_sync_messages_received_count` | `Counter` | Count of messages received from the originator | `pkg/metrics/sync.go` |
+| `xmtp_sync_messages_received_error_count` | `Counter` | Count of failed/errored messages received from the originator | `pkg/metrics/sync.go` |
+| `xmtp_sync_originator_sequence_id` | `Gauge` | Last synced sequence id of the originator | `pkg/metrics/sync.go` |
+| `xmtp_sync_outgoing_sync_connections` | `Gauge` | Gauge of open outgoing sync connections | `pkg/metrics/sync.go` |

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -114,7 +114,8 @@ func (s *Service) GetReaderNode(
 }
 
 func getReaderNodeRandom(nodes []registry.Node) (string, []string) {
-	primaryIndex := rand.Intn(len(nodes))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	primaryIndex := r.Intn(len(nodes))
 
 	primaryUrl := nodes[primaryIndex].HttpAddress
 

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -82,17 +82,9 @@ func (s *Service) GetReaderNode(
 	ctx context.Context,
 	req *payer_api.GetReaderNodeRequest,
 ) (resp *payer_api.GetReaderNodeResponse, err error) {
-	var (
-		start       = time.Now()
-		queryStatus = "success"
-		nodes       []registry.Node
-	)
+	var nodes []registry.Node
 
 	defer func() {
-		if err != nil {
-			queryStatus = "error"
-		}
-		metrics.EmitPayerGetReaderNodeDuration(time.Since(start).Seconds(), queryStatus)
 		metrics.EmitPayerGetReaderNodeAvailableNodes(len(nodes))
 	}()
 

--- a/pkg/api/payer/service_test.go
+++ b/pkg/api/payer/service_test.go
@@ -1,0 +1,87 @@
+package payer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api"
+	"github.com/xmtp/xmtpd/pkg/registry"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetReaderNode(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodes         []registry.Node
+		registryError error
+		wantErr       bool
+		checkResponse func(t *testing.T, resp *payer_api.GetReaderNodeResponse)
+	}{
+		{
+			name: "success with multiple nodes",
+			nodes: []registry.Node{
+				testutils.GetHealthyNode(100),
+				testutils.GetHealthyNode(101),
+				testutils.GetHealthyNode(102),
+				testutils.GetHealthyNode(103),
+			},
+			wantErr: false,
+			checkResponse: func(t *testing.T, resp *payer_api.GetReaderNodeResponse) {
+				require.NotEmpty(t, resp.ReaderNodeUrl)
+				require.Len(t, resp.BackupNodeUrls, 3)
+
+				for _, backup := range resp.BackupNodeUrls {
+					require.NotEqual(t, resp.ReaderNodeUrl, backup)
+				}
+			},
+		},
+		{
+			name:    "no nodes available",
+			nodes:   []registry.Node{},
+			wantErr: true,
+		},
+		{
+			name:          "registry error",
+			nodes:         nil,
+			registryError: status.Errorf(codes.Unavailable, "registry unavailable"),
+			wantErr:       true,
+		},
+		{
+			name: "single node",
+			nodes: []registry.Node{
+				testutils.GetHealthyNode(100),
+			},
+			wantErr: false,
+			checkResponse: func(t *testing.T, resp *payer_api.GetReaderNodeResponse) {
+				require.NotEmpty(t, resp.ReaderNodeUrl)
+				require.Empty(t, resp.BackupNodeUrls)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			svc, _, registryMocks, _, cleanup := buildPayerService(t)
+			defer cleanup()
+
+			registryMocks.On("GetNodes").Return(tt.nodes, tt.registryError)
+
+			resp, err := svc.GetReaderNode(ctx, &payer_api.GetReaderNodeRequest{})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				if tt.checkResponse != nil {
+					tt.checkResponse(t, resp)
+				}
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -90,7 +90,6 @@ func registerCollectors(reg prometheus.Registerer) {
 		apiFailedGRPCRequestsCounter,
 		blockchainWaitForTransaction,
 		blockchainPublishPayload,
-		payerGetReaderNodeDuration,
 		payerGetReaderNodeAvailableNodes,
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -90,6 +90,8 @@ func registerCollectors(reg prometheus.Registerer) {
 		apiFailedGRPCRequestsCounter,
 		blockchainWaitForTransaction,
 		blockchainPublishPayload,
+		payerGetReaderNodeDuration,
+		payerGetReaderNodeAvailableNodes,
 	}
 
 	for _, col := range cols {

--- a/pkg/metrics/payer.go
+++ b/pkg/metrics/payer.go
@@ -71,19 +71,6 @@ func EmitPayerMessageOriginated(originatorId uint32, count int) {
 		Add(float64(count))
 }
 
-var payerGetReaderNodeDuration = prometheus.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Name: "xmtp_payer_get_reader_node_duration_seconds",
-		Help: "Duration of the GetReaderNode call",
-	},
-	[]string{"status"},
-)
-
-func EmitPayerGetReaderNodeDuration(duration float64, status string) {
-	payerGetReaderNodeDuration.With(prometheus.Labels{"status": status}).
-		Observe(duration)
-}
-
 var payerGetReaderNodeAvailableNodes = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Name: "xmtp_payer_get_reader_node_available_nodes",

--- a/pkg/metrics/payer.go
+++ b/pkg/metrics/payer.go
@@ -70,3 +70,27 @@ func EmitPayerMessageOriginated(originatorId uint32, count int) {
 	payerMessagesOriginated.With(prometheus.Labels{"originator_id": strconv.Itoa(int(originatorId))}).
 		Add(float64(count))
 }
+
+var payerGetReaderNodeDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name: "xmtp_payer_get_reader_node_duration_seconds",
+		Help: "Duration of the GetReaderNode call",
+	},
+	[]string{"status"},
+)
+
+func EmitPayerGetReaderNodeDuration(duration float64, status string) {
+	payerGetReaderNodeDuration.With(prometheus.Labels{"status": status}).
+		Observe(duration)
+}
+
+var payerGetReaderNodeAvailableNodes = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "xmtp_payer_get_reader_node_available_nodes",
+		Help: "Number of currently available nodes for reader selection",
+	},
+)
+
+func EmitPayerGetReaderNodeAvailableNodes(count int) {
+	payerGetReaderNodeAvailableNodes.Set(float64(count))
+}

--- a/pkg/testutils/contractRegistry.go
+++ b/pkg/testutils/contractRegistry.go
@@ -1,12 +1,17 @@
 package testutils
 
-import "github.com/xmtp/xmtpd/pkg/registry"
+import (
+	"fmt"
+
+	"github.com/xmtp/xmtpd/pkg/registry"
+)
 
 func GetHealthyNode(nodeID uint32) registry.Node {
 	return registry.Node{
 		NodeID:             nodeID,
 		InCanonicalNetwork: true,
 		IsValidConfig:      true,
+		HttpAddress:        fmt.Sprintf("http://localhost:%d", nodeID),
 	}
 }
 
@@ -15,5 +20,6 @@ func GetUnhealthyNode(nodeID uint32) registry.Node {
 		NodeID:             nodeID,
 		InCanonicalNetwork: false,
 		IsValidConfig:      false,
+		HttpAddress:        fmt.Sprintf("http://localhost:%d", nodeID),
 	}
 }


### PR DESCRIPTION
### Add `GetReaderNode` endpoint to payer API service to enable random node selection from registry
Implements a new `GetReaderNode` method in the payer API service that randomly selects and returns a primary reader node URL along with backup node URLs from the registry. The changes include:

* New `GetReaderNode` method in [service.go](https://github.com/xmtp/xmtpd/pull/771/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280) that handles node selection and metrics tracking
* Addition of duration and available nodes metrics in [metrics.go](https://github.com/xmtp/xmtpd/pull/771/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23) and [payer.go](https://github.com/xmtp/xmtpd/pull/771/files#diff-e04f97104acd535b565bd77008777026f0f2dcd545aae4dfd19de19da284b46e)

#### 📍Where to Start
Start with the `GetReaderNode` method implementation in [service.go](https://github.com/xmtp/xmtpd/pull/771/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280), which contains the core logic for node selection and serves as the entry point for this new functionality.

----

_[Macroscope](https://app.macroscope.com) summarized 571ccbb._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an API endpoint to retrieve a primary reader node and backup nodes with random selection and enhanced error handling.
  - Added metrics to monitor the count of available nodes, improving observability.

- **Chores**
  - Registered new Prometheus metrics for monitoring reader node availability.

- **Tests**
  - Added tests covering multiple scenarios for the reader node retrieval API to ensure correct behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->