### PR TITLE
Add scaffolding for XMTPD DB prune / data retention

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -12,7 +12,7 @@ jobs:
   push_to_registry:
     strategy:
       matrix:
-        image: ["xmtpd", "xmtpd-cli"]
+        image: ["xmtpd", "xmtpd-cli", "xmtpd-prune"]
     name: Push Docker Images to GitHub Packages
     runs-on: ubuntu-latest
     permissions:
@@ -52,6 +52,8 @@ jobs:
           echo "dockerfile=Dockerfile" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.image }}" == "xmtpd-cli" ]]; then
           echo "dockerfile=Dockerfile-cli" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.image }}" == "xmtpd-prune" ]]; then
+          echo "dockerfile=Dockerfile-prune" >> $GITHUB_OUTPUT
           else
           echo "Unknown image: ${{ matrix.image }}"
           exit 1

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/jessevdk/go-flags"
 	"github.com/xmtp/xmtpd/pkg/config"
 	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/prune"
 	"github.com/xmtp/xmtpd/pkg/utils"
-	"log"
-	"os"
 )
 
 var Version string
@@ -53,7 +54,6 @@ func main() {
 		options.DB.ReadTimeout,
 		options.DB.NameOverride,
 	)
-
 	if err != nil {
 		fatal("Could not connect to DB: %s", err)
 	}

--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/jessevdk/go-flags"
+	"github.com/xmtp/xmtpd/pkg/config"
+	"github.com/xmtp/xmtpd/pkg/db"
+	"github.com/xmtp/xmtpd/pkg/prune"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"log"
+	"os"
+)
+
+var Version string
+
+var options config.PruneOptions
+
+func main() {
+	_, err := flags.Parse(&options)
+	if err != nil {
+		if err, ok := err.(*flags.Error); !ok || err.Type != flags.ErrHelp {
+			fatal("Could not parse options: %s", err)
+		}
+		return
+	}
+
+	if Version == "" {
+		Version = os.Getenv("VERSION")
+		if Version == "" {
+			fatal("Could not determine version")
+		}
+	}
+
+	err = config.ValidatePruneOptions(options)
+	if err != nil {
+		fatal("Could not validate options: %s", err)
+	}
+
+	logger, _, err := utils.BuildLogger(options.Log)
+	if err != nil {
+		fatal("Could not build logger: %s", err)
+	}
+	logger = logger.Named("prune")
+
+	logger.Info(fmt.Sprintf("Version: %s", Version))
+
+	ctx := context.Background()
+
+	dbInstance, err := db.ConnectToDB(ctx, logger,
+		options.DB.WriterConnectionString,
+		options.DB.WaitForDB,
+		options.DB.ReadTimeout,
+		options.DB.NameOverride,
+	)
+
+	if err != nil {
+		fatal("Could not connect to DB: %s", err)
+	}
+
+	pruneExecutor := prune.NewPruneExecutor(ctx, logger, dbInstance)
+
+	err = pruneExecutor.Run()
+	if err != nil {
+		fatal("Could not execute prune: %s", err)
+	}
+}
+
+func fatal(msg string, args ...any) {
+	log.Fatalf(msg, args...)
+}

--- a/dev/docker/Dockerfile-prune
+++ b/dev/docker/Dockerfile-prune
@@ -1,0 +1,34 @@
+# BUILD IMAGE --------------------------------------------------------
+ARG GO_VERSION=1.24
+FROM golang:${GO_VERSION}-alpine AS builder
+
+# Get build tools and required header files
+RUN apk add --no-cache build-base
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=unknown
+RUN go build -ldflags="-X 'main.Version=$VERSION'" -o bin/xmtpd-prune cmd/prune/main.go
+
+# ACTUAL IMAGE -------------------------------------------------------
+
+FROM alpine:3.21
+
+LABEL maintainer="eng@ephemerahq.com"
+LABEL source="https://github.com/xmtp/xmtpd"
+LABEL description="XMTPD CLI"
+
+# color, nocolor, json
+ENV GOLOG_LOG_FMT=nocolor
+
+ENV XMTPD_LOG_ENCODING=json
+
+COPY --from=builder /app/bin/xmtpd-prune /usr/bin/
+
+ENTRYPOINT ["/usr/bin/xmtpd-prune"]

--- a/dev/docker/Dockerfile-prune
+++ b/dev/docker/Dockerfile-prune
@@ -22,7 +22,7 @@ FROM alpine:3.21
 
 LABEL maintainer="eng@ephemerahq.com"
 LABEL source="https://github.com/xmtp/xmtpd"
-LABEL description="XMTPD CLI"
+LABEL description="XMTPD Prune"
 
 # color, nocolor, json
 ENV GOLOG_LOG_FMT=nocolor

--- a/dev/prune
+++ b/dev/prune
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+. dev/local.env
+
+go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/prune/main.go "$@"

--- a/pkg/config/pruneOptions.go
+++ b/pkg/config/pruneOptions.go
@@ -1,0 +1,6 @@
+package config
+
+type PruneOptions struct {
+	DB  DbOptions  `group:"Database Options"       namespace:"db"`
+	Log LogOptions `group:"Log Options"            namespace:"log"`
+}

--- a/pkg/config/pruneOptions.go
+++ b/pkg/config/pruneOptions.go
@@ -1,6 +1,6 @@
 package config
 
 type PruneOptions struct {
-	DB  DbOptions  `group:"Database Options"       namespace:"db"`
-	Log LogOptions `group:"Log Options"            namespace:"log"`
+	DB  DbOptions  `group:"Database Options" namespace:"db"`
+	Log LogOptions `group:"Log Options"      namespace:"log"`
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -94,31 +94,18 @@ func ValidateServerOptions(options ServerOptions) error {
 
 func ValidatePruneOptions(options PruneOptions) error {
 	missingSet := make(map[string]struct{})
-	customSet := make(map[string]struct{})
 
 	if options.DB.WriterConnectionString == "" {
 		missingSet["--DB.WriterConnectionString"] = struct{}{}
 	}
 
-	if len(missingSet) > 0 || len(customSet) > 0 {
-		var errs []string
-		if len(missingSet) > 0 {
+	if len(missingSet) > 0 {
+		var errorMessages []string
+		for err := range missingSet {
+			errorMessages = append(errorMessages, err)
+		}
 
-			var errorMessages []string
-			for err := range missingSet {
-				errorMessages = append(errorMessages, err)
-			}
-			errs = append(
-				errs,
-				fmt.Sprintf("Missing required arguments: %s", strings.Join(errorMessages, ", ")),
-			)
-		}
-		if len(customSet) > 0 {
-			for err := range customSet {
-				errs = append(errs, err)
-			}
-		}
-		return errors.New(strings.Join(errs, "; "))
+		return fmt.Errorf("missing required arguments: %s", strings.Join(errorMessages, ", "))
 	}
 
 	return nil

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -91,3 +91,35 @@ func ValidateServerOptions(options ServerOptions) error {
 
 	return nil
 }
+
+func ValidatePruneOptions(options PruneOptions) error {
+	missingSet := make(map[string]struct{})
+	customSet := make(map[string]struct{})
+
+	if options.DB.WriterConnectionString == "" {
+		missingSet["--DB.WriterConnectionString"] = struct{}{}
+	}
+
+	if len(missingSet) > 0 || len(customSet) > 0 {
+		var errs []string
+		if len(missingSet) > 0 {
+
+			var errorMessages []string
+			for err := range missingSet {
+				errorMessages = append(errorMessages, err)
+			}
+			errs = append(
+				errs,
+				fmt.Sprintf("Missing required arguments: %s", strings.Join(errorMessages, ", ")),
+			)
+		}
+		if len(customSet) > 0 {
+			for err := range customSet {
+				errs = append(errs, err)
+			}
+		}
+		return errors.New(strings.Join(errs, "; "))
+	}
+
+	return nil
+}

--- a/pkg/db/pgx.go
+++ b/pkg/db/pgx.go
@@ -158,6 +158,9 @@ func NewNamespacedDB(
 	return db, nil
 }
 
+// ConnectToDB establishes a connection to an existing database using the provided DSN.
+// Unlike NewNamespacedDB, this function does not create the database or run migrations.
+// If namespace is provided, it overrides the database name in the DSN.
 func ConnectToDB(
 	ctx context.Context,
 	logger *zap.Logger,

--- a/pkg/db/pgx.go
+++ b/pkg/db/pgx.go
@@ -129,7 +129,8 @@ func NewNamespacedDB(
 	logger *zap.Logger,
 	dsn string,
 	namespace string,
-	waitForDB time.Duration, statementTimeout time.Duration,
+	waitForDB time.Duration,
+	statementTimeout time.Duration,
 ) (*sql.DB, error) {
 	// Parse the DSN to get the config
 	config, err := parseConfig(dsn, statementTimeout)
@@ -165,7 +166,9 @@ func ConnectToDB(
 	ctx context.Context,
 	logger *zap.Logger,
 	dsn string,
-	waitForDB time.Duration, statementTimeout time.Duration, namespace string,
+	waitForDB time.Duration,
+	statementTimeout time.Duration,
+	namespace string,
 ) (*sql.DB, error) {
 	config, err := parseConfig(dsn, statementTimeout)
 	if err != nil {

--- a/pkg/db/pgx.go
+++ b/pkg/db/pgx.go
@@ -157,3 +157,28 @@ func NewNamespacedDB(
 
 	return db, nil
 }
+
+func ConnectToDB(
+	ctx context.Context,
+	logger *zap.Logger,
+	dsn string,
+	waitForDB time.Duration, statementTimeout time.Duration, namespace string,
+) (*sql.DB, error) {
+	config, err := parseConfig(dsn, statementTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DSN: %w", err)
+	}
+
+	if namespace != "" {
+		config.ConnConfig.Database = namespace
+	}
+
+	db, err := newPGXDB(ctx, config, waitForDB)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Successfully connected to DB", zap.String("database", config.ConnConfig.Database))
+
+	return db, nil
+}

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -3,6 +3,7 @@ package prune
 import (
 	"context"
 	"database/sql"
+
 	"go.uber.org/zap"
 )
 

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -1,0 +1,29 @@
+package prune
+
+import (
+	"context"
+	"database/sql"
+	"go.uber.org/zap"
+)
+
+type Executor struct {
+	ctx      context.Context
+	log      *zap.Logger
+	writerDB *sql.DB
+}
+
+func NewPruneExecutor(
+	ctx context.Context,
+	log *zap.Logger,
+	writerDB *sql.DB,
+) *Executor {
+	return &Executor{
+		ctx:      ctx,
+		log:      log,
+		writerDB: writerDB,
+	}
+}
+
+func (e *Executor) Run() error {
+	return nil
+}


### PR DESCRIPTION
### Add scaffolding for XMTPD database pruning by implementing prune command-line tool, configuration, and Docker support
* Implements new `xmtpd-prune` command-line tool in [main.go](https://github.com/xmtp/xmtpd/pull/772/files#diff-4039fdc6d104f56ad8d0fb6dbbbabe36a2b635478cc1def051fadd4a868aa524) with configuration and database connection handling
* Adds Docker build support through [Dockerfile-prune](https://github.com/xmtp/xmtpd/pull/772/files#diff-55d3b0c6f04fc5e157f38ef0484f55c69f27bc9ee684c9aca3f1f69f4579313d) and updated [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/772/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9) workflow
* Creates database connection utilities in [pgx.go](https://github.com/xmtp/xmtpd/pull/772/files#diff-61a5fd647b6319a61b4ad6e44829b0fd29d8f14afefa2700f222127028ce36fc) with configurable timeouts and namespace support
* Establishes configuration structures and validation in [pruneOptions.go](https://github.com/xmtp/xmtpd/pull/772/files#diff-fd23a98cbc9c92d896f65d69d65f90028001af86148579c59753f6715cd85e0c) and [validation.go](https://github.com/xmtp/xmtpd/pull/772/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b)
* Sets up placeholder pruning executor in [prune.go](https://github.com/xmtp/xmtpd/pull/772/files#diff-1a9bef57c3cc14ab5b07561eb0aece529ef508cc606a179483dace998beb9eff) for future implementation

#### 📍Where to Start
Start with the main entry point in [main.go](https://github.com/xmtp/xmtpd/pull/772/files#diff-4039fdc6d104f56ad8d0fb6dbbbabe36a2b635478cc1def051fadd4a868aa524) which sets up the command-line interface, configuration parsing, and execution flow for the pruning tool.

----

_[Macroscope](https://app.macroscope.com) summarized 6566e91._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line tool for database pruning operations.
  - Added a Docker image variant for the pruning tool, now available alongside existing images.
  - Provided a Bash script to simplify local development and execution of the pruning tool.

- **Documentation**
  - Updated workflow to build and publish the new pruning tool Docker image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->