### PR TITLE
Remove nightly PAT

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           commit-message: Nightly Protos
           title: Update Protos
-          token: ${{ secrets.GH_PAT_NIGHTLY_AUTOMATION }}
           body: |
             - Nightly Proto Update
 


### PR DESCRIPTION
### Remove GH_PAT_NIGHTLY_AUTOMATION token from GitHub workflow to use default GitHub token for authentication
Removes the token parameter that specified `${{ secrets.GH_PAT_NIGHTLY_AUTOMATION }}` from [nightly.yml](https://github.com/xmtp/xmtpd/pull/773/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6), switching the authentication mechanism to use the default GitHub token for the nightly Proto updates workflow.

#### 📍Where to Start
Start by reviewing the authentication configuration changes in [nightly.yml](https://github.com/xmtp/xmtpd/pull/773/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6).

----

_[Macroscope](https://app.macroscope.com) summarized 726f9d1._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated nightly automation workflow to use default authentication for creating pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->