### PR TITLE
chore: update infrastructure repo link to xmtp/xmtpd-infrastructure

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -77,7 +77,7 @@ And you should get something along these lines:
 
 ## Deploy XMTPD nodes
 
-Node deployment is currently fully handled by [Ephemera](https://github.com/ephemeraHQ/infrastructure) and only members of @ephemerahq/backend have access to it.
+Node deployment is currently fully handled by [Ephemera](https://github.com/xmtp/xmtpd-infrastructure) and only members of @ephemerahq/backend have access to it.
 
 There are currently two nodes running:
 


### PR DESCRIPTION
**Description**
Replaces the obsolete `ephemeraHQ/infrastructure` URL (now 404) with the current repository location `https://github.com/xmtp/xmtpd-infrastructure`.  
No functional code changes—just fixes the broken link to restore docs and build scripts that reference the infra repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the deployment guide to correct the URL for the infrastructure repository used for node deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->