### PR TITLE
Upgrade to golangci-lint-v2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-  "go.lintTool": "golangci-lint",
-  "go.lintFlags": ["--fast"],
+  "go.lintTool": "golangci-lint-v2",
+  "go.lintFlags": ["--path-mode=abs", "--fast-only"],
   "go.formatTool": "custom",
   "go.alternateTools": {
-    "customFormatter": "golangci-lint"
+    "customFormatter": "golangci-lint-v2"
   },
   "go.formatFlags": ["fmt", "--stdin"],
   "[sql]": {


### PR DESCRIPTION
### TL;DR

Updated VS Code settings to use golangci-lint-v2 with improved linting configuration.

I was having flakiness with the older formatter setup, where it would fail silently. This seems much better.

## Notes

You may need to upgrade to the preview version of the Go extension, and you definitely will need to run `Go: Install/Update Tools` in VSCode

### What changed?

- Changed the linting tool from `golangci-lint` to `golangci-lint-v2`
- Updated lint flags to include `--path-mode=abs` and changed `--fast` to `--fast-only`
- Updated the custom formatter tool reference to use `golangci-lint-v2`

### How to test?

1. Open the project in VS Code
2. Ensure golangci-lint-v2 is installed on your system
3. Open a Go file and verify that linting works correctly
4. Make a formatting change and verify that the formatter works as expected

### Why make this change?

This update improves the development experience by using the newer version of golangci-lint with more appropriate flags. The `--path-mode=abs` flag helps with resolving paths correctly, and `--fast-only` optimizes the linting process for better performance during development.