### PR TITLE
DBChainClient

### DIFF
--- a/pkg/blockchain/interface.go
+++ b/pkg/blockchain/interface.go
@@ -2,6 +2,7 @@ package blockchain
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -26,10 +27,18 @@ type LogStreamer interface {
 }
 
 type ChainClient interface {
-	ethereum.BlockNumberReader
-	ethereum.LogFilterer
-	ethereum.ChainIDReader
-	ethereum.ChainReader
+	// From ethereum.BlockNumberReader
+	BlockNumber(ctx context.Context) (uint64, error)
+   
+	// From ethereum.LogFilterer
+	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
+	SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
+	
+	// From ethereum.ChainIDReader
+	ChainID(ctx context.Context) (*big.Int, error)
+	
+	// Only the BlockByNumber method from ethereum.ChainReader
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
 }
 
 type TransactionSigner interface {


### PR DESCRIPTION
### Refactor `ChainClient` interface in `blockchain/interface.go` to explicitly declare required Ethereum methods instead of embedding interfaces
The `ChainClient` interface in [interface.go](https://github.com/xmtp/xmtpd/pull/786/files#diff-2d8a10cff85740a839a47ef7fb539903b32178300379aa947d59c1cb136377c5) has been refactored to replace embedded Ethereum interfaces with explicit method declarations. The interface now directly specifies only the required methods:

* `BlockNumber` from `ethereum.BlockNumberReader`
* `FilterLogs` and `SubscribeFilterLogs` from `ethereum.LogFilterer`
* `ChainID` from `ethereum.ChainIDReader`
* `BlockByNumber` from `ethereum.ChainReader`

#### 📍Where to Start
Start with the `ChainClient` interface definition in [interface.go](https://github.com/xmtp/xmtpd/pull/786/files#diff-2d8a10cff85740a839a47ef7fb539903b32178300379aa947d59c1cb136377c5) which contains the core interface changes.

----

_[Macroscope](https://app.macroscope.com) summarized 1dd39ef._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the blockchain client interface to only include essential methods, resulting in a more focused and simplified interface for interacting with blockchain data. No changes to visible features or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->