### PR TITLE
Test pruner and refactor newDB

### DIFF
--- a/pkg/blockchain/nonceManager_test.go
+++ b/pkg/blockchain/nonceManager_test.go
@@ -95,8 +95,7 @@ func (tm *TestNonceManager) Replenish(ctx context.Context, nonce big.Int) error 
 func TestGetNonce_Simple(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
@@ -115,8 +114,7 @@ func TestGetNonce_Simple(t *testing.T) {
 func TestGetNonce_RevertMany(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
@@ -136,8 +134,7 @@ func TestGetNonce_RevertMany(t *testing.T) {
 func TestGetNonce_ConsumeMany(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
@@ -158,8 +155,7 @@ func TestGetNonce_ConsumeMany(t *testing.T) {
 func TestGetNonce_ConsumeManyConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)

--- a/pkg/db/congestion_test.go
+++ b/pkg/db/congestion_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/xmtp/xmtpd/pkg/testutils"
 )
 
-func setupTest(t *testing.T) (context.Context, *queries.Queries, func()) {
+func setupTest(t *testing.T) (context.Context, *queries.Queries) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
-	return ctx, querier, cleanup
+	return ctx, querier
 }
 
 func incrementCongestion(
@@ -34,8 +34,7 @@ func incrementCongestion(
 }
 
 func TestGet5MinutesOfCongestion(t *testing.T) {
-	ctx, querier, cleanup := setupTest(t)
-	defer cleanup()
+	ctx, querier := setupTest(t)
 
 	originatorID := testutils.RandomInt32()
 	endMinute := testutils.RandomInt32()
@@ -55,8 +54,7 @@ func TestGet5MinutesOfCongestion(t *testing.T) {
 }
 
 func TestMultipleIncrements(t *testing.T) {
-	ctx, querier, cleanup := setupTest(t)
-	defer cleanup()
+	ctx, querier := setupTest(t)
 
 	originatorID := testutils.RandomInt32()
 	endMinute := testutils.RandomInt32()
@@ -76,8 +74,7 @@ func TestMultipleIncrements(t *testing.T) {
 }
 
 func TestNoCongestion(t *testing.T) {
-	ctx, querier, cleanup := setupTest(t)
-	defer cleanup()
+	ctx, querier := setupTest(t)
 
 	originatorID := testutils.RandomInt32()
 	endMinute := testutils.RandomInt32()

--- a/pkg/db/gatewayEnvelope_test.go
+++ b/pkg/db/gatewayEnvelope_test.go
@@ -39,8 +39,7 @@ func buildParams(
 
 func TestInsertAndIncrement(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 	// Create a payer
@@ -77,8 +76,7 @@ func TestInsertAndIncrement(t *testing.T) {
 
 func TestPayerMustExist(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	payerID := testutils.RandomInt32()
 	originatorID := testutils.RandomInt32()
@@ -97,8 +95,7 @@ func TestPayerMustExist(t *testing.T) {
 
 func TestInsertAndIncrementParallel(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 	// Create a payer
@@ -152,8 +149,7 @@ func TestInsertAndIncrementParallel(t *testing.T) {
 
 func TestInsertAndIncrementWithOutOfOrderSequenceID(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 

--- a/pkg/db/queries_test.go
+++ b/pkg/db/queries_test.go
@@ -32,8 +32,7 @@ func getAddressLogState(
 
 func TestInsertAddressLog(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 	address := testutils.RandomString(20)
@@ -87,8 +86,7 @@ func TestInsertAddressLog(t *testing.T) {
 
 func TestRevokeAddressLog(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -139,8 +137,7 @@ func TestRevokeAddressLog(t *testing.T) {
 
 func TestFindOrCreatePayer(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 

--- a/pkg/db/sequences_test.go
+++ b/pkg/db/sequences_test.go
@@ -17,8 +17,7 @@ import (
 
 func TestFillRows(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -31,8 +30,7 @@ func TestFillRows(t *testing.T) {
 
 func TestEmptyRows(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 	_, err := querier.GetNextAvailableNonce(ctx)
@@ -86,8 +84,7 @@ func failNextPayerSequence(t *testing.T, ctx context.Context, db *sql.DB) (int64
 
 func TestConcurrentReads(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -139,8 +136,7 @@ func TestConcurrentReads(t *testing.T) {
 
 func TestRequestsUnused(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -165,8 +161,7 @@ func TestRequestsUnused(t *testing.T) {
 
 func TestRequestsUsed(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -191,8 +186,7 @@ func TestRequestsUsed(t *testing.T) {
 
 func TestRequestsFailed(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -219,8 +213,7 @@ func TestRequestsFailed(t *testing.T) {
 
 func TestFillerCanProceedWithOpenTxn(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -256,8 +249,7 @@ func TestFillerCanProceedWithOpenTxn(t *testing.T) {
 
 func TestFillerRerun(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -278,8 +270,7 @@ func TestFillerRerun(t *testing.T) {
 
 func TestAbandonNonces(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -300,8 +291,7 @@ func TestAbandonNonces(t *testing.T) {
 
 func TestAbandonCanProceedWithOpenTxn(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -339,8 +329,7 @@ func TestAbandonCanProceedWithOpenTxn(t *testing.T) {
 
 func TestAbandonSkipsOpenTxn(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -383,8 +372,7 @@ func TestAbandonSkipsOpenTxn(t *testing.T) {
 
 func TestAbandonConcurrently(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 
@@ -417,8 +405,7 @@ func TestAbandonConcurrently(t *testing.T) {
 
 func TestAbandonConcurrentlyWithOpenTransaction(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 

--- a/pkg/db/subscription_test.go
+++ b/pkg/db/subscription_test.go
@@ -17,13 +17,13 @@ import (
 
 var topicA = topic.NewTopic(topic.TOPIC_KIND_GROUP_MESSAGES_V1, []byte("topicA")).Bytes()
 
-func setup(t *testing.T) (*sql.DB, *zap.Logger, func()) {
+func setup(t *testing.T) (*sql.DB, *zap.Logger) {
 	ctx := context.Background()
-	store, _, storeCleanup := testutils.NewDB(t, ctx)
+	store, _ := testutils.NewDB(t, ctx)
 	log, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
-	return store, log, storeCleanup
+	return store, log
 }
 
 func insertInitialRows(t *testing.T, store *sql.DB) {
@@ -119,8 +119,7 @@ func flakyEnvelopesQuery(
 }
 
 func TestIntervalSubscription(t *testing.T) {
-	store, log, cleanup := setup(t)
-	defer cleanup()
+	store, log := setup(t)
 
 	insertInitialRows(t, store)
 
@@ -144,8 +143,7 @@ func TestIntervalSubscription(t *testing.T) {
 }
 
 func TestNotifiedSubscription(t *testing.T) {
-	store, log, cleanup := setup(t)
-	defer cleanup()
+	store, log := setup(t)
 
 	insertInitialRows(t, store)
 
@@ -171,8 +169,7 @@ func TestNotifiedSubscription(t *testing.T) {
 }
 
 func TestTemporaryDBError(t *testing.T) {
-	store, log, cleanup := setup(t)
-	defer cleanup()
+	store, log := setup(t)
 
 	insertInitialRows(t, store)
 

--- a/pkg/db/unsettledUsage_test.go
+++ b/pkg/db/unsettledUsage_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestIncrementUnsettledUsage(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 	payerId := testutils.RandomInt32()
@@ -55,8 +54,7 @@ func TestIncrementUnsettledUsage(t *testing.T) {
 
 func TestGetUnsettledUsage(t *testing.T) {
 	ctx := context.Background()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 
 	querier := queries.New(db)
 	payerId := testutils.RandomInt32()

--- a/pkg/fees/calculator_test.go
+++ b/pkg/fees/calculator_test.go
@@ -71,8 +71,7 @@ func TestCalculateBaseFee(t *testing.T) {
 
 func TestCalculateCongestionFee(t *testing.T) {
 	calculator := setupCalculator()
-	db, _, cleanup := testutils.NewDB(t, context.Background())
-	defer cleanup()
+	db, _ := testutils.NewDB(t, context.Background())
 
 	ctx := context.Background()
 	querier := queries.New(db)

--- a/pkg/indexer/blockTracker_test.go
+++ b/pkg/indexer/blockTracker_test.go
@@ -18,8 +18,7 @@ const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000"
 func TestInitialize(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
 	tracker, err := indexer.NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
@@ -34,8 +33,7 @@ func TestInitialize(t *testing.T) {
 func TestUpdateLatestBlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
 	tracker, err := indexer.NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
@@ -76,8 +74,7 @@ func TestUpdateLatestBlock(t *testing.T) {
 func TestConcurrentUpdates(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
 	tracker, err := indexer.NewBlockTracker(ctx, CONTRACT_ADDRESS, querier)
@@ -125,8 +122,7 @@ func TestConcurrentUpdates(t *testing.T) {
 func TestMultipleContractAddresses(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	db, _, cleanup := testutils.NewDB(t, ctx)
-	defer cleanup()
+	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
 	address1 := "0x0000000000000000000000000000000000000001"

--- a/pkg/indexer/e2e_test.go
+++ b/pkg/indexer/e2e_test.go
@@ -26,7 +26,7 @@ func startIndexing(
 ) (*sql.DB, *queries.Queries, config.ContractsOptions, context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger := testutils.NewLog(t)
-	db, _, cleanup := testutils.NewDB(t, ctx)
+	db, _ := testutils.NewDB(t, ctx)
 
 	rpcUrl, anvilCleanup := anvil.StartAnvil(t, false)
 	cfg := testutils.NewContractsOptions(rpcUrl)
@@ -47,7 +47,6 @@ func startIndexing(
 
 	return db, queries.New(db), cfg, ctx, func() {
 		defer anvilCleanup()
-		cleanup()
 		cancel()
 	}
 }

--- a/pkg/indexer/storer/groupMessage_test.go
+++ b/pkg/indexer/storer/groupMessage_test.go
@@ -20,7 +20,7 @@ import (
 
 func buildGroupMessageStorer(t *testing.T) (*GroupMessageStorer, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
-	db, _, cleanup := testutils.NewDB(t, ctx)
+	db, _ := testutils.NewDB(t, ctx)
 	queryImpl := queries.New(db)
 	rpcUrl, anvilCleanup := anvil.StartAnvil(t, false)
 	config := testutils.NewContractsOptions(rpcUrl)
@@ -42,7 +42,6 @@ func buildGroupMessageStorer(t *testing.T) (*GroupMessageStorer, func()) {
 	return storer, func() {
 		defer anvilCleanup()
 		cancel()
-		cleanup()
 	}
 }
 

--- a/pkg/indexer/storer/identityUpdate_test.go
+++ b/pkg/indexer/storer/identityUpdate_test.go
@@ -25,7 +25,7 @@ func buildIdentityUpdateStorer(
 	t *testing.T,
 ) (*IdentityUpdateStorer, *mlsvalidateMock.MockMLSValidationService, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
-	db, _, cleanup := testutils.NewDB(t, ctx)
+	db, _ := testutils.NewDB(t, ctx)
 	rpcUrl, anvilCleanup := anvil.StartAnvil(t, false)
 	config := testutils.NewContractsOptions(rpcUrl)
 	config.AppChain.IdentityUpdateBroadcasterAddress = testutils.DeployIdentityUpdatesContract(
@@ -47,7 +47,6 @@ func buildIdentityUpdateStorer(
 	return storer, validationService, func() {
 		defer anvilCleanup()
 		cancel()
-		cleanup()
 	}
 }
 

--- a/pkg/payerreport/manager_test.go
+++ b/pkg/payerreport/manager_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func setup(t *testing.T) (*sql.DB, *PayerReportManager) {
-	db, _, cleanup := testutils.NewDB(t, context.Background())
-	t.Cleanup(cleanup)
+	db, _ := testutils.NewDB(t, context.Background())
 
 	generator := NewPayerReportManager(testutils.NewLog(t), queries.New(db))
 

--- a/pkg/prune/prune_test.go
+++ b/pkg/prune/prune_test.go
@@ -1,0 +1,228 @@
+package prune_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xmtp/xmtpd/pkg/config"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/prune"
+)
+
+const (
+	DEFAULT_EXPIRED_CNT = 10
+	DEFAULT_VALID_CNT   = 5
+)
+
+func setupTestData(t *testing.T, db *sql.DB, expired int, valid int) {
+	q := queries.New(db)
+	ctx := context.Background()
+
+	// Insert expired envelopes
+	for i := 0; i < expired; i++ {
+		_, err := q.InsertGatewayEnvelope(ctx, queries.InsertGatewayEnvelopeParams{
+			OriginatorNodeID:     1,
+			OriginatorSequenceID: int64(i),
+			Topic:                []byte("topic"),
+			OriginatorEnvelope:   []byte("payload"),
+			PayerID:              sql.NullInt32{Valid: false},
+			GatewayTime:          time.Now(),
+			Expiry: sql.NullInt64{
+				Int64: time.Now().Add(-1 * time.Hour).Unix(),
+				Valid: true,
+			},
+		})
+		assert.NoError(t, err)
+	}
+
+	// Insert non-expired envelopes
+	for i := 0; i < valid; i++ {
+		_, err := q.InsertGatewayEnvelope(ctx, queries.InsertGatewayEnvelopeParams{
+			OriginatorNodeID:     1,
+			OriginatorSequenceID: int64(i + expired),
+			Topic:                []byte("topic"),
+			OriginatorEnvelope:   []byte("payload"),
+			PayerID:              sql.NullInt32{Valid: false},
+			GatewayTime:          time.Now(),
+			Expiry: sql.NullInt64{
+				Int64: time.Now().Add(1 * time.Hour).Unix(),
+				Valid: true,
+			},
+		})
+		assert.NoError(t, err)
+	}
+}
+
+func makeTestExecutor(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	config *config.PruneConfig,
+) *prune.Executor {
+	return prune.NewPruneExecutor(
+		ctx,
+		testutils.NewLog(t),
+		db,
+		config,
+	)
+}
+
+func TestExecutor_PrunesExpired(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+
+	setupTestData(t, db, DEFAULT_EXPIRED_CNT, DEFAULT_VALID_CNT)
+
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    false,
+		MaxCycles: 5,
+	})
+	err := exec.Run()
+	assert.NoError(t, err)
+
+	q := queries.New(db)
+	cnt, err := q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, cnt, "All expired envelopes should be deleted")
+
+	// Ensure non-expired remain
+	var total int64
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_envelopes`)
+	err = row.Scan(&total)
+	assert.NoError(t, err)
+	assert.EqualValues(t, DEFAULT_VALID_CNT, total, "Only non-expired envelopes should remain")
+}
+
+func TestExecutor_DryRun_NoPrune(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+
+	setupTestData(t, db, DEFAULT_EXPIRED_CNT, DEFAULT_VALID_CNT)
+
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    true,
+		MaxCycles: 5,
+	})
+	err := exec.Run()
+	assert.NoError(t, err)
+
+	q := queries.New(db)
+	cnt, err := q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, DEFAULT_EXPIRED_CNT, cnt, "DryRun should not prune any envelopes")
+
+	var total int64
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_envelopes`)
+	err = row.Scan(&total)
+	assert.NoError(t, err)
+	assert.EqualValues(
+		t,
+		DEFAULT_VALID_CNT+DEFAULT_EXPIRED_CNT,
+		total,
+		"All envelopes should still be present",
+	)
+}
+
+func openAndHoldLock(t *testing.T, ctx context.Context, db *sql.DB) *sql.Tx {
+	// Begin a transaction and lock sequence_id = 1
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `
+		SELECT * FROM gateway_envelopes 
+		WHERE originator_sequence_id = 1 
+		FOR UPDATE
+	`)
+	require.NoError(t, err)
+
+	return tx
+}
+
+func TestExecutor_PrunesExpired_WithConcurrentLock(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+	q := queries.New(db)
+
+	setupTestData(t, db, DEFAULT_EXPIRED_CNT, 0)
+
+	tx := openAndHoldLock(t, ctx, db)
+
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    false,
+		MaxCycles: 5,
+	})
+	err := exec.Run()
+	assert.NoError(t, err)
+
+	remainingIDs := getRemainingSequenceIds(t, ctx, db)
+
+	assert.Contains(t, remainingIDs, int64(1), "Locked row should still exist after pruning")
+	assert.Len(t, remainingIDs, 1, "Only locked row should remain during lock")
+
+	// Commit the lock transaction
+	require.NoError(t, tx.Commit())
+
+	err = exec.Run()
+	assert.NoError(t, err)
+
+	// Confirm DB is empty now
+	cnt, err := q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, cnt, "All expired envelopes should now be deleted")
+}
+
+func getRemainingSequenceIds(t *testing.T, ctx context.Context, db *sql.DB) []int64 {
+	var remainingIDs []int64
+	rows, err := db.QueryContext(ctx, `
+		SELECT originator_sequence_id FROM gateway_envelopes
+	`)
+	require.NoError(t, err)
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	for rows.Next() {
+		var seqID int64
+		require.NoError(t, rows.Scan(&seqID))
+		remainingIDs = append(remainingIDs, seqID)
+	}
+	return remainingIDs
+}
+
+func TestExecutor_PrunesExpired_LargePayload(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+
+	const KEEP_THIS_MANY = 10
+
+	setupTestData(t, db, 1000+KEEP_THIS_MANY, 0)
+
+	// only allow for 1 cycle, which deletes at most 1000 envelopes
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    false,
+		MaxCycles: 1,
+	})
+	err := exec.Run()
+	assert.NoError(t, err)
+
+	q := queries.New(db)
+	cnt, err := q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, KEEP_THIS_MANY, cnt)
+
+	// 2nd cycle should finish off
+	err = exec.Run()
+	assert.NoError(t, err)
+	cnt, err = q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, cnt, "All expired envelopes should be deleted")
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -73,8 +73,7 @@ func NewTestServer(
 func TestCreateServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	dbs, dbCleanup := testutils.NewDBs(t, ctx, 2)
-	defer dbCleanup()
+	dbs := testutils.NewDBs(t, ctx, 2)
 	privateKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	privateKey2, err := crypto.GenerateKey()
@@ -217,8 +216,7 @@ func TestCreateServer(t *testing.T) {
 func TestReadOwnWritesGuarantee(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	dbs, dbCleanup := testutils.NewDBs(t, ctx, 1)
-	defer dbCleanup()
+	dbs := testutils.NewDBs(t, ctx, 1)
 	privateKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	server1Port := networkTestUtils.FindFreePort(t)

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -102,7 +102,7 @@ type ApiServerMocks struct {
 func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	log := testutils.NewLog(t)
-	db, _, dbCleanup := testutils.NewDB(t, ctx)
+	db, _ := testutils.NewDB(t, ctx)
 	privKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	privKeyStr := "0x" + utils.HexEncode(crypto.FromECDSA(privKey))
@@ -207,7 +207,6 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks, fu
 	return svr, db, allMocks, func() {
 		cancel()
 		svr.Close(0)
-		dbCleanup()
 	}
 }
 


### PR DESCRIPTION
### Refactor database cleanup handling in tests to use testing framework's t.Cleanup() mechanism instead of explicit cleanup functions
* Removes explicit cleanup function calls across multiple test files, replacing them with the testing framework's built-in `t.Cleanup()` mechanism in [store.go](https://github.com/xmtp/xmtpd/pull/788/files#diff-fbecfe40a6d8b7119c2decd97bed268d7e39a1ff5cef452265a5f2e5406597ed)
* Modifies `NewDB` and `NewDBs` functions in [store.go](https://github.com/xmtp/xmtpd/pull/788/files#diff-fbecfe40a6d8b7119c2decd97bed268d7e39a1ff5cef452265a5f2e5406597ed) to no longer return cleanup functions
* Adds comprehensive test suite for pruning functionality in [prune_test.go](https://github.com/xmtp/xmtpd/pull/788/files#diff-4017c4c995dfb20aa0d7f3e4f7714a2b1c542d31dddf2555425e840c9105a4fb), covering expired envelopes, dry run mode, concurrent locks, and large payload scenarios

#### 📍Where to Start
Start with the core changes to database cleanup handling in [store.go](https://github.com/xmtp/xmtpd/pull/788/files#diff-fbecfe40a6d8b7119c2decd97bed268d7e39a1ff5cef452265a5f2e5406597ed), particularly the `openDB` function which now registers cleanup with `t.Cleanup()` instead of returning a cleanup function.

----

_[Macroscope](https://app.macroscope.com) summarized d1a4b2a._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test setup and teardown procedures to simplify resource management by relying on automatic cleanup, removing explicit cleanup function calls across multiple test files.
  - Refactored helper and setup functions in tests to streamline usage and reduce manual cleanup handling.
  - Added comprehensive new unit tests for database pruning functionality, including scenarios for concurrency, dry-run mode, and large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->