### PR TITLE
Add prune release to rel from tag

### DIFF
--- a/.github/workflows/release-from-tag.yml
+++ b/.github/workflows/release-from-tag.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker Image to GitHub Packages
     strategy:
       matrix:
-        image: [ "xmtpd", "xmtpd-cli" ]
+        image: [ "xmtpd", "xmtpd-cli", "xmtpd-prune" ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +33,8 @@ jobs:
           echo "dockerfile=Dockerfile" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.image }}" == "xmtpd-cli" ]]; then
           echo "dockerfile=Dockerfile-cli" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.image }}" == "xmtpd-prune" ]]; then
+          echo "dockerfile=Dockerfile-prune" >> $GITHUB_OUTPUT
           else
           echo "Unknown image: ${{ matrix.image }}"
           exit 1


### PR DESCRIPTION
### Add `xmtpd-prune` Docker image build support to GitHub Actions release workflow
The GitHub Actions workflow in [release-from-tag.yml](https://github.com/xmtp/xmtpd/pull/791/files#diff-cee4eadd46d2585fd337f530116877504920be9ec452bdbfb915b95857438208) is updated to build and push a new `xmtpd-prune` Docker image using `Dockerfile-prune`. The workflow matrix now includes three images: `xmtpd`, `xmtpd-cli`, and `xmtpd-prune`.

#### 📍Where to Start
Start with the workflow configuration in [release-from-tag.yml](https://github.com/xmtp/xmtpd/pull/791/files#diff-cee4eadd46d2585fd337f530116877504920be9ec452bdbfb915b95857438208) which contains the matrix configuration and build conditions for the Docker images.

----

_[Macroscope](https://app.macroscope.com) summarized 988813c._