### PR TITLE
refactor: replace context.WithCancel with t.Context in tests

### DIFF
--- a/pkg/api/message/subscribe_test.go
+++ b/pkg/api/message/subscribe_test.go
@@ -128,8 +128,7 @@ func TestSubscribeEnvelopesAll(t *testing.T) {
 	client, db, _ := setupTest(t)
 	insertInitialRows(t, db)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	stream, err := client.SubscribeEnvelopes(
 		ctx,
 		&message_api.SubscribeEnvelopesRequest{
@@ -148,8 +147,7 @@ func TestSubscribeEnvelopesByTopic(t *testing.T) {
 	client, store, _ := setupTest(t)
 	insertInitialRows(t, store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	stream, err := client.SubscribeEnvelopes(
 		ctx,
 		&message_api.SubscribeEnvelopesRequest{
@@ -169,8 +167,7 @@ func TestSubscribeEnvelopesByOriginator(t *testing.T) {
 	client, db, _ := setupTest(t)
 	insertInitialRows(t, db)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	stream, err := client.SubscribeEnvelopes(
 		ctx,
 		&message_api.SubscribeEnvelopesRequest{
@@ -190,8 +187,7 @@ func TestSimultaneousSubscriptions(t *testing.T) {
 	client, store, _ := setupTest(t)
 	insertInitialRows(t, store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	stream1, err := client.SubscribeEnvelopes(
 		ctx,
 		&message_api.SubscribeEnvelopesRequest{
@@ -232,8 +228,7 @@ func TestSubscribeEnvelopesFromCursor(t *testing.T) {
 	client, store, _ := setupTest(t)
 	insertInitialRows(t, store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	stream, err := client.SubscribeEnvelopes(
 		ctx,
 		&message_api.SubscribeEnvelopesRequest{
@@ -253,8 +248,7 @@ func TestSubscribeEnvelopesFromEmptyCursor(t *testing.T) {
 	client, store, _ := setupTest(t)
 	insertInitialRows(t, store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	stream, err := client.SubscribeEnvelopes(
 		ctx,
 		&message_api.SubscribeEnvelopesRequest{

--- a/pkg/api/metadata/cursor_test.go
+++ b/pkg/api/metadata/cursor_test.go
@@ -1,7 +1,6 @@
 package metadata_test
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -106,8 +105,7 @@ func TestGetCursorBasic(t *testing.T) {
 	client, db, _ := setupTest(t)
 	insertInitialRows(t, db)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	cursor, err := client.GetSyncCursor(ctx, &metadata_api.GetSyncCursorRequest{})
 
@@ -146,8 +144,7 @@ func TestSubscribeSyncCursorBasic(t *testing.T) {
 	client, db, _ := setupTest(t)
 	insertInitialRows(t, db)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := client.SubscribeSyncCursor(ctx, &metadata_api.GetSyncCursorRequest{})
 	require.NoError(t, err)

--- a/pkg/blockchain/nonceManager_test.go
+++ b/pkg/blockchain/nonceManager_test.go
@@ -93,8 +93,7 @@ func (tm *TestNonceManager) Replenish(ctx context.Context, nonce big.Int) error 
 }
 
 func TestGetNonce_Simple(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
@@ -112,8 +111,7 @@ func TestGetNonce_Simple(t *testing.T) {
 }
 
 func TestGetNonce_RevertMany(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
@@ -132,8 +130,7 @@ func TestGetNonce_RevertMany(t *testing.T) {
 }
 
 func TestGetNonce_ConsumeMany(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()
@@ -153,8 +150,7 @@ func TestGetNonce_ConsumeMany(t *testing.T) {
 }
 
 func TestGetNonce_ConsumeManyConcurrent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 
 	logger, err := zap.NewDevelopment()

--- a/pkg/indexer/blockTracker_test.go
+++ b/pkg/indexer/blockTracker_test.go
@@ -1,7 +1,6 @@
 package indexer_test
 
 import (
-	"context"
 	"sync"
 	"testing"
 
@@ -16,8 +15,7 @@ import (
 const CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 func TestInitialize(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
@@ -31,8 +29,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestUpdateLatestBlock(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
@@ -72,8 +69,7 @@ func TestUpdateLatestBlock(t *testing.T) {
 }
 
 func TestConcurrentUpdates(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 
@@ -120,8 +116,7 @@ func TestConcurrentUpdates(t *testing.T) {
 }
 
 func TestMultipleContractAddresses(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, _ := testutils.NewDB(t, ctx)
 	querier := queries.New(db)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -70,8 +70,7 @@ func NewTestServer(
 }
 
 func TestCreateServer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dbs := testutils.NewDBs(t, ctx, 2)
 	privateKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -176,8 +175,7 @@ func TestCreateServer(t *testing.T) {
 }
 
 func TestReadOwnWritesGuarantee(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dbs := testutils.NewDBs(t, ctx, 1)
 	privateKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)


### PR DESCRIPTION
Optimize code using a more modern writing style.   Official support from Go, for more details visit https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Simplified context management in various test cases by using the test framework's built-in context, improving consistency and reducing manual context cancellation. No changes to test logic or outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->