### PR TITLE
Validate hex addresses

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func ValidateServerOptions(options *ServerOptions) error {
@@ -93,7 +95,7 @@ func validateBlockchainConfig(
 	validateSettlementChainConfig(options, missingSet, customSet)
 
 	if options.Replication.Enable || options.Sync.Enable {
-		validateField(
+		validateHexAddress(
 			options.Contracts.SettlementChain.RateRegistryAddress,
 			"contracts.settlement-chain.rate-registry-address",
 			missingSet,
@@ -121,12 +123,12 @@ func validateAppChainConfig(
 		"contracts.app-chain.chain-id",
 		customSet,
 	)
-	validateField(
+	validateHexAddress(
 		options.Contracts.AppChain.GroupMessageBroadcasterAddress,
 		"contracts.app-chain.group-message-broadcaster-address",
 		missingSet,
 	)
-	validateField(
+	validateHexAddress(
 		options.Contracts.AppChain.IdentityUpdateBroadcasterAddress,
 		"contracts.app-chain.identity-update-broadcaster-address",
 		missingSet,
@@ -153,7 +155,7 @@ func validateSettlementChainConfig(
 		"contracts.settlement-chain.chain-id",
 		customSet,
 	)
-	validateField(
+	validateHexAddress(
 		options.Contracts.SettlementChain.NodeRegistryAddress,
 		"contracts.settlement-chain.node-registry-address",
 		missingSet,
@@ -213,5 +215,14 @@ func validateField(value interface{}, fieldName string, set map[string]struct{})
 		if v <= 0 {
 			set[fmt.Sprintf("--%s must be greater than 0", fieldName)] = struct{}{}
 		}
+	}
+}
+
+func validateHexAddress(address string, fieldName string, set map[string]struct{}) {
+	if address == "" {
+		set[fmt.Sprintf("--%s is required", fieldName)] = struct{}{}
+	}
+	if !common.IsHexAddress(address) || common.HexToAddress(address) == (common.Address{}) {
+		set[fmt.Sprintf("--%s is invalid", fieldName)] = struct{}{}
 	}
 }


### PR DESCRIPTION
### Add Ethereum address validation to ensure valid hex and non-zero contract addresses in configuration validation
Introduces a new `validateHexAddress()` function in [validation.go](https://github.com/xmtp/xmtpd/pull/801/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b) that performs hex address validation for contract addresses. The function validates that addresses are non-empty, valid hex format, and not zero addresses using the `go-ethereum/common` package. This validation is applied to `RateRegistryAddress`, `GroupMessageBroadcasterAddress`, `IdentityUpdateBroadcasterAddress`, and `NodeRegistryAddress` configuration fields.

#### 📍Where to Start
Start with the new `validateHexAddress()` function in [validation.go](https://github.com/xmtp/xmtpd/pull/801/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b) which contains the core validation logic for Ethereum addresses.

----

_[Macroscope](https://app.macroscope.com) summarized 11a7665._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for Ethereum contract addresses in configuration to better detect missing, invalid, or zero addresses. 

- **Chores**
  - Enhanced internal address validation logic for more robust configuration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->