### PR TITLE
Enable openmetrics negotiation format

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,8 +43,11 @@ func NewMetricsServer(
 	}
 	registerCollectors(reg)
 	srv := http.Server{
-		Addr:    addr,
-		Handler: promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}),
+		Addr: addr,
+		Handler: promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+			Registry:          reg,
+		}),
 	}
 
 	tracing.GoPanicWrap(s.ctx, &s.wg, "metrics-server", func(ctx context.Context) {


### PR DESCRIPTION
```
 $ curl -H "Accept: application/openmetrics-text" -i localhost:8008/metrics
HTTP/1.1 200 OK
Content-Type: application/openmetrics-text; version=0.0.1; charset=utf-8; escaping=underscores
Date: Mon, 19 May 2025 14:31:59 GMT
Transfer-Encoding: chunked
```

It is almost the same other than the content-type and the EOF at the end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Metrics are now exposed in the OpenMetrics format for improved compatibility with monitoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->