### PR TITLE
Propagate ctx cancellation to IndexLogs

### DIFF
--- a/pkg/indexer/app_chain/contracts/group_message.go
+++ b/pkg/indexer/app_chain/contracts/group_message.go
@@ -57,7 +57,6 @@ func NewGroupMessageBroadcaster(
 	}
 
 	logger = logger.Named("group-message-broadcaster").
-		With(zap.Int("chainID", chainID)).
 		With(zap.String("contractAddress", address.Hex()))
 
 	groupMessageStorer := NewGroupMessageStorer(querier, logger, contract)

--- a/pkg/indexer/app_chain/contracts/identity_update.go
+++ b/pkg/indexer/app_chain/contracts/identity_update.go
@@ -62,7 +62,6 @@ func NewIdentityUpdateBroadcaster(
 	}
 
 	logger = logger.Named("identity-update-broadcaster").
-		With(zap.Int("chainID", chainID)).
 		With(zap.String("contractAddress", address.Hex()))
 
 	identityUpdateStorer := NewIdentityUpdateStorer(db, logger, contract, validationService)


### PR DESCRIPTION
- Propagate cancellation to `IndexLogs.retry()`.
- Delete duplicated chainID fields, populate it once at app_chain.go level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved retry logic to support cancellation, allowing operations to be stopped promptly when requested.

- **Refactor**
	- Updated logging to remove the display of chain identifiers, simplifying log output for group message and identity update broadcasters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->