### PR TITLE
Speed up generation by removing all cruft from builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,6 @@
 # Allow tools
 !tools/
 !tooks/**
+
+# Ignore all test files
+**/*_test.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,7 @@
 
 # Allow tools
 !tools/
-!tooks/**
+!tools/**
 
 # Ignore all test files
 **/*_test.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,30 +1,18 @@
-# Ignore Git files
-.git
-.gitignore
-.github
+# Ignore everything
+**
 
-# Ignore IDE/editor files
-.idea/
-.vscode/
-*.swp
-*.swo
+# Allow Go module files
+!go.mod
+!go.sum
 
-# Ignore Go test executables and other compiled files
-*.test
-*.out
-*.exe
-*.o
-*.a
-*.so
+# Allow source code
+!*.go
+!*/**/*.go
 
-# Ignore build directories
-build/
-bin/
+# Allow pkg directory
+!pkg/
+!pkg/**
 
-# Ignore all test files
-**/*_test.go
-
-doc/
-
-LICENSE
-README.md
+# Allow tools
+!tools/
+!tooks/**

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN go mod download
 
 COPY . .
 
-# Build the final node binary
 ARG VERSION=unknown
 RUN go build -ldflags="-X 'main.Version=$VERSION'" -o bin/xmtpd cmd/replication/main.go
 

--- a/dev/docker/Dockerfile-cli
+++ b/dev/docker/Dockerfile-cli
@@ -13,7 +13,6 @@ RUN go mod download
 
 COPY . .
 
-# Build the final node binary
 ARG VERSION=unknown
 RUN go build -ldflags="-X 'main.Version=$VERSION'" -o bin/xmtpd-cli cmd/cli/main.go
 


### PR DESCRIPTION
### Optimize Docker build context by implementing whitelist-based file inclusion in [.dockerignore](https://github.com/xmtp/xmtpd/pull/821/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) to speed up generation
Changes the Docker build context configuration from a blacklist to a whitelist approach in [.dockerignore](https://github.com/xmtp/xmtpd/pull/821/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5). The file now ignores everything by default and selectively includes only:
* Go module files (`go.mod`, `go.sum`)
* Go source files (`*.go`, excluding test files)
* `pkg` directory and contents
* `tools` directory and contents

Minor cleanup in [Dockerfile](https://github.com/xmtp/xmtpd/pull/821/files#diff-ef6e0b2762fa2bb50b8ecd178326a38602d2a4fd2ea0b76946d3455741c9409f) and [Dockerfile-cli](https://github.com/xmtp/xmtpd/pull/821/files#diff-7ba181f7299cb01b22c0d7b5d47a24cf54cccac2f9a997476d4ba95d31403853) removing redundant comments.

#### 📍Where to Start
Start with the [.dockerignore](https://github.com/xmtp/xmtpd/pull/821/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) file which contains the core changes to the build context configuration.

----

_[Macroscope](https://app.macroscope.com) summarized 19f5a93._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the `.dockerignore` file to use a whitelist approach for included files and directories.
  - Removed redundant comment lines from Docker build files for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->