### PR TITLE
Rework compose up/down

### DIFF
--- a/dev/docker/docker-compose-register.yml
+++ b/dev/docker/docker-compose-register.yml
@@ -1,9 +1,9 @@
-x-xmtpd-cli-image: &xmtpd-cli-image ghcr.io/xmtp/xmtpd-cli:sha-d4e697c
-
 services:
   register-node-1:
     platform: linux/amd64
-    image: *xmtpd-cli-image
+    build:
+      dockerfile: ./dev/docker/Dockerfile-cli
+      context: ../../
     profiles: ["single", "dual"]
     env_file:
       - ../local.env
@@ -20,7 +20,9 @@ services:
 
   enable-node-1:
     platform: linux/amd64
-    image: *xmtpd-cli-image
+    build:
+      dockerfile: ./dev/docker/Dockerfile-cli
+      context: ../../
     profiles: ["single", "dual"]
     env_file:
       - ../local.env
@@ -38,7 +40,9 @@ services:
 
   register-node-2:
     platform: linux/amd64
-    image: *xmtpd-cli-image
+    build:
+      dockerfile: ./dev/docker/Dockerfile-cli
+      context: ../../
     profiles: ["dual"]
     env_file:
       - ../local.env
@@ -58,7 +62,9 @@ services:
 
   enable-node-2:
     platform: linux/amd64
-    image: *xmtpd-cli-image
+    build:
+      dockerfile: ./dev/docker/Dockerfile-cli
+      context: ../../
     profiles: ["dual"]
     env_file:
       - ../local.env

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -3,6 +3,7 @@ x-postgres-image: &x-postgres-image postgres:16
 services:
   db:
     image: *x-postgres-image
+    profiles: ["single", "dual"]
     environment:
       POSTGRES_PASSWORD: xmtp
     ports:
@@ -10,6 +11,7 @@ services:
 
   db2:
     image: *x-postgres-image
+    profiles: ["single"]
     environment:
       POSTGRES_PASSWORD: xmtp
     ports:

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   db2:
     image: *x-postgres-image
-    profiles: ["single"]
+    profiles: ["dual"]
     environment:
       POSTGRES_PASSWORD: xmtp
     ports:

--- a/dev/docker/down
+++ b/dev/docker/down
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-profile=${1:-single}
-
-if [ "$1" = "single" ]; then
+if [ -z "$1" ]; then
   profile="single"
-elif [ "$1" = "dual" ]; then
-  profile="dual"
-else
   echo "No profile provided, defaulting to single"
+elif [ "$1" = "single" ] || [ "$1" = "dual" ]; then
+  profile="$1"
+else
+  echo "Invalid profile '$1', defaulting to single"
+  profile="single"
 fi
 
 docker compose \
   -f dev/docker/docker-compose.yml \
   --env-file dev/local.env \
+  --profile ${profile} \
   -p "xmtpd" \
   down --remove-orphans --volumes
 

--- a/dev/docker/up
+++ b/dev/docker/up
@@ -1,19 +1,21 @@
 #!/bin/bash
 set -eo pipefail
 
-profile=${1:-single}
-
-if [ "$1" = "single" ]; then
+if [ -z "$1" ]; then
   profile="single"
-elif [ "$1" = "dual" ]; then
-  profile="dual"
-else
   echo "No profile provided, defaulting to single"
+elif [ "$1" = "single" ] || [ "$1" = "dual" ]; then
+  profile="$1"
+else
+  echo "Invalid profile '$1', defaulting to single"
+  profile="single"
 fi
+
 
 docker compose \
   -f dev/docker/docker-compose.yml \
   --env-file dev/local.env \
+  --profile ${profile} \
   -p "xmtpd" \
   up -d \
   --remove-orphans \

--- a/dev/down
+++ b/dev/down
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-dev/docker/down
+dev/docker/down "${@}"

--- a/dev/up
+++ b/dev/up
@@ -23,7 +23,7 @@ echo -e "→ Update Go dependencies"
 go mod tidy
 
 echo -e "→ Start docker containers"
-dev/docker/up ${1}
+dev/docker/up "${@}"
 
 echo -e "→ Generating .env"
 dev/generate-env


### PR DESCRIPTION
### Restructure Docker Compose configuration to support profile-based service activation and local CLI image builds
* Updates Docker Compose configuration in [docker-compose-register.yml](https://github.com/xmtp/xmtpd/pull/822/files#diff-a1e7ac7430bed8c9bdd26624200229b35a1eeb5363eb27128ae4eb71bad7f83c) to build `xmtpd-cli` image locally instead of using pre-built image
* Adds profile support in [docker-compose.yml](https://github.com/xmtp/xmtpd/pull/822/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e) to conditionally activate database services based on `single` or `dual` profiles
* Enhances [up](https://github.com/xmtp/xmtpd/pull/822/files#diff-c4a1f6ed02b85cec2e690a289e7810fd5639c9abf2f205bba12519957bb06f99) and [down](https://github.com/xmtp/xmtpd/pull/822/files#diff-7d10e63db3d97298d86fb22d36c4c0fb11bf8aa78cdc8566d33d1bebbb81b51b) scripts with robust profile validation and explicit profile flag usage
* Modifies top-level [dev/up](https://github.com/xmtp/xmtpd/pull/822/files#diff-16426f02e6bce9db2f326db8d2dd685d378a044aaa8b9c456e6426d396837180) and [dev/down](https://github.com/xmtp/xmtpd/pull/822/files#diff-e0b336ad6713feef6a0995439dfa1ea64fda5c5be5e8ef871831003094708e8f) scripts to forward all command-line arguments

#### 📍Where to Start
Start with the profile configuration changes in [docker-compose.yml](https://github.com/xmtp/xmtpd/pull/822/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e), then review the updated build configuration in [docker-compose-register.yml](https://github.com/xmtp/xmtpd/pull/822/files#diff-a1e7ac7430bed8c9bdd26624200229b35a1eeb5363eb27128ae4eb71bad7f83c).

----

_[Macroscope](https://app.macroscope.com) summarized 21ae2d1._