### PR TITLE
Add header to metrics catalog

### DIFF
--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -1,3 +1,7 @@
+# xmptd OpenMetrics catalog
+
+This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/open_metrics_spec/) instrumentation for xmptd.
+
 | Name | Type | Description | File |
 |------|------|-------------|------|
 | `xmtp_api_failed_grpc_requests_counter` | `Counter` | Number of failed GRPC requests by code | `pkg/metrics/api.go` |

--- a/pkg/metrics/docs/generator.go
+++ b/pkg/metrics/docs/generator.go
@@ -72,6 +72,8 @@ func dumpToMarkdown(metrics []Metric) {
 	})
 
 	var sb strings.Builder
+	sb.WriteString("# xmptd OpenMetrics catalog\n\n")
+	sb.WriteString("This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/open_metrics_spec/) instrumentation for xmptd.\n\n")
 	sb.WriteString("| Name | Type | Description | File |\n")
 	sb.WriteString("|------|------|-------------|------|\n")
 

--- a/pkg/metrics/docs/generator.go
+++ b/pkg/metrics/docs/generator.go
@@ -73,7 +73,9 @@ func dumpToMarkdown(metrics []Metric) {
 
 	var sb strings.Builder
 	sb.WriteString("# xmptd OpenMetrics catalog\n\n")
-	sb.WriteString("This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/open_metrics_spec/) instrumentation for xmptd.\n\n")
+	sb.WriteString(
+		"This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/open_metrics_spec/) instrumentation for xmptd.\n\n",
+	)
 	sb.WriteString("| Name | Type | Description | File |\n")
 	sb.WriteString("|------|------|-------------|------|\n")
 


### PR DESCRIPTION
### Add title and introductory text to xmptd OpenMetrics catalog documentation
Updates documentation generation by modifying the `dumpToMarkdown` function in [generator.go](https://github.com/xmtp/xmtpd/pull/825/files#diff-3b7e158857c4d43acbfbd55becdce9ba9afff64d4ce7524cf4b7f71afecdead3) to include a header and introduction in the metrics catalog. The changes affect both the generated [metrics_catalog.md](https://github.com/xmtp/xmtpd/pull/825/files#diff-76ce58ca7626239d9d1fcf2571f79d0337a091f72961c3ef6113b2f5fe06a994) and the documentation generation code.

#### 📍Where to Start
Start with the `dumpToMarkdown` function in [generator.go](https://github.com/xmtp/xmtpd/pull/825/files#diff-3b7e158857c4d43acbfbd55becdce9ba9afff64d4ce7524cf4b7f71afecdead3) which contains the core changes to the documentation generation logic.

----

_[Macroscope](https://app.macroscope.com) summarized 381b72e._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an introductory section with a title and description to the metrics catalog, including a link to the OpenMetrics specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->