### PR TITLE
Speed up CLI container construction in dev/up

### DIFF
--- a/dev/docker/docker-compose-register.yml
+++ b/dev/docker/docker-compose-register.yml
@@ -1,9 +1,12 @@
+x-cli-image: &cli-image
+  build:
+    context: ../../
+    dockerfile: ./dev/docker/Dockerfile-cli
+  image: ghcr.io/xmtp/xmtpd-cli:dev
+
 services:
   register-node-1:
-    platform: linux/amd64
-    build:
-      dockerfile: ./dev/docker/Dockerfile-cli
-      context: ../../
+    <<: *cli-image
     profiles: ["single", "dual"]
     env_file:
       - ../local.env
@@ -19,10 +22,7 @@ services:
     network_mode: host
 
   enable-node-1:
-    platform: linux/amd64
-    build:
-      dockerfile: ./dev/docker/Dockerfile-cli
-      context: ../../
+    <<: *cli-image
     profiles: ["single", "dual"]
     env_file:
       - ../local.env
@@ -39,10 +39,7 @@ services:
     network_mode: host
 
   register-node-2:
-    platform: linux/amd64
-    build:
-      dockerfile: ./dev/docker/Dockerfile-cli
-      context: ../../
+    <<: *cli-image
     profiles: ["dual"]
     env_file:
       - ../local.env
@@ -61,10 +58,7 @@ services:
     network_mode: host
 
   enable-node-2:
-    platform: linux/amd64
-    build:
-      dockerfile: ./dev/docker/Dockerfile-cli
-      context: ../../
+    <<: *cli-image
     profiles: ["dual"]
     env_file:
       - ../local.env

--- a/dev/docker/up
+++ b/dev/docker/up
@@ -27,6 +27,7 @@ docker compose \
   --profile ${profile} \
   -p "xmtpd_register_nodes" \
   up \
+  --build \
   --remove-orphans
 
 echo


### PR DESCRIPTION
### Reduce CLI container build time by consolidating image configurations and forcing rebuilds in dev environment
* Consolidates duplicate CLI container configurations in [docker-compose-register.yml](https://github.com/xmtp/xmtpd/pull/829/files#diff-a1e7ac7430bed8c9bdd26624200229b35a1eeb5363eb27128ae4eb71bad7f83c) using YAML anchors with a shared `x-cli-image` definition
* Adds `--build` flag to `docker compose up` command in [up](https://github.com/xmtp/xmtpd/pull/829/files#diff-c4a1f6ed02b85cec2e690a289e7810fd5639c9abf2f205bba12519957bb06f99) script to ensure containers use latest code changes

#### 📍Where to Start
Start with the YAML anchor definition `x-cli-image` in [docker-compose-register.yml](https://github.com/xmtp/xmtpd/pull/829/files#diff-a1e7ac7430bed8c9bdd26624200229b35a1eeb5363eb27128ae4eb71bad7f83c) which defines the common build configuration now used across all CLI services.

----

_[Macroscope](https://app.macroscope.com) summarized a6e4b25._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker Compose configuration for register node services to reduce redundancy.
  - Updated the startup script to ensure Docker images are rebuilt before launching register node services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->