### PR TITLE
Allow operator defined backfill block size

### DIFF
--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -116,6 +116,7 @@ func NewRpcLogStreamer(
 		wg:                  sync.WaitGroup{},
 		watchers:            make(map[string]ContractConfig),
 		lagFromHighestBlock: 0,
+		backfillBlockSize:   500,
 	}
 
 	for _, option := range options {

--- a/pkg/blockchain/rpcLogStreamer.go
+++ b/pkg/blockchain/rpcLogStreamer.go
@@ -43,6 +43,10 @@ func WithLagFromHighestBlock(lagFromHighestBlock uint8) RpcLogStreamerOption {
 
 func WithBackfillBlockSize(backfillBlockSize uint64) RpcLogStreamerOption {
 	return func(streamer *RpcLogStreamer) error {
+		if backfillBlockSize == 0 {
+			return fmt.Errorf("backfillBlockSize must be > 0, got %d", backfillBlockSize)
+		}
+
 		streamer.backfillBlockSize = backfillBlockSize
 		return nil
 	}

--- a/pkg/blockchain/rpcLogStreamer_test.go
+++ b/pkg/blockchain/rpcLogStreamer_test.go
@@ -54,7 +54,6 @@ func TestRpcLogStreamer(t *testing.T) {
 		testutils.NewLog(t),
 		1,
 		blockchain.WithContractConfig(cfg),
-		blockchain.WithBackfillBlockSize(500),
 	)
 	require.NoError(t, err)
 

--- a/pkg/blockchain/rpcLogStreamer_test.go
+++ b/pkg/blockchain/rpcLogStreamer_test.go
@@ -54,6 +54,7 @@ func TestRpcLogStreamer(t *testing.T) {
 		testutils.NewLog(t),
 		1,
 		blockchain.WithContractConfig(cfg),
+		blockchain.WithBackfillBlockSize(500),
 	)
 	require.NoError(t, err)
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -26,6 +26,8 @@ type ContractsOptions struct {
 	MaxChainDisconnectTime         time.Duration `long:"max-chain-disconnect-time" env:"XMTPD_CONTRACTS_MAX_CHAIN_DISCONNECT_TIME" description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
 	NodesContract                  NodesContractOption
 
+	BackfillBlockSize uint64 `long:"backfill-block-size" env:"XMTPD_CONTRACTS_BACKFILL_BLOCK_SIZE" description:"Maximal size of a backfill block" default:"500"`
+
 	// New options for app and settlement chains multi-chain deployments.
 	AppChain        AppChainOptions        `group:"Application Chain Options" namespace:"app-chain"`
 	SettlementChain SettlementChainOptions `group:"Settlement Chain Options"  namespace:"settlement-chain"`

--- a/pkg/indexer/app_chain/app_chain.go
+++ b/pkg/indexer/app_chain/app_chain.go
@@ -41,6 +41,7 @@ func NewAppChain(
 	cfg config.AppChainOptions,
 	db *sql.DB,
 	validationService mlsvalidate.MLSValidationService,
+	blockSize uint64,
 ) (*AppChain, error) {
 	ctxwc, cancel := context.WithCancel(ctxwc)
 
@@ -113,6 +114,7 @@ func NewAppChain(
 				MaxDisconnectTime: cfg.MaxChainDisconnectTime,
 			},
 		),
+		blockchain.WithBackfillBlockSize(blockSize),
 	)
 	if err != nil {
 		cancel()

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -36,6 +36,7 @@ func NewIndexer(
 		cfg.AppChain,
 		db,
 		validationService,
+		cfg.BackfillBlockSize,
 	)
 	if err != nil {
 		cancel()

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -39,6 +39,7 @@ func NewContractsOptions(rpcUrl string) config.ContractsOptions {
 			NodeRegistryAddress:         NODE_REGISTRY_ADDRESS,
 			ParameterRegistryAddress:    PARAMETER_REGISTRY_ADDRESS,
 		},
+		BackfillBlockSize: 500,
 	}
 }
 


### PR DESCRIPTION
### Replace hardcoded 1000-block backfill size with configurable block size parameter in `RpcLogStreamer`
Introduces configurable block size for blockchain log backfilling through:
* Adds `backfillBlockSize` field to `RpcLogStreamer` in [rpcLogStreamer.go](https://github.com/xmtp/xmtpd/pull/834/files#diff-7c09882fdc2ca1e5719483f613a8646adbf3750ccba69267c09948639d406ebd) with new `WithBackfillBlockSize` option function
* Adds `BackfillBlockSize` configuration option in [options.go](https://github.com/xmtp/xmtpd/pull/834/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c) with CLI flag and environment variable support
* Modifies `NewAppChain` in [app_chain.go](https://github.com/xmtp/xmtpd/pull/834/files#diff-a7396f85c51783c1d2690996fe8f2f2497869b03255b30a029cea4ec0eb1e7b3) to accept block size parameter
* Updates `GetNextPage` method to use configurable block size instead of hardcoded 1000-block constant

#### 📍Where to Start
Start with the `RpcLogStreamer` struct and `WithBackfillBlockSize` option function changes in [rpcLogStreamer.go](https://github.com/xmtp/xmtpd/pull/834/files#diff-7c09882fdc2ca1e5719483f613a8646adbf3750ccba69267c09948639d406ebd), which define the core functionality for configurable block sizes.

----

_[Macroscope](https://app.macroscope.com) summarized db8f348._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for configuring the backfill block size for blockchain log streaming, allowing users to customize this value via command-line options or environment variables.

- **Chores**
	- Updated default backfill block size to 500 and ensured consistent configuration across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->