### PR TITLE
Backfill size per chain

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -26,8 +26,6 @@ type ContractsOptions struct {
 	MaxChainDisconnectTime         time.Duration `long:"max-chain-disconnect-time" env:"XMTPD_CONTRACTS_MAX_CHAIN_DISCONNECT_TIME" description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
 	NodesContract                  NodesContractOption
 
-	BackfillBlockSize uint64 `long:"backfill-block-size" env:"XMTPD_CONTRACTS_BACKFILL_BLOCK_SIZE" description:"Maximal size of a backfill block" default:"500"`
-
 	// New options for app and settlement chains multi-chain deployments.
 	AppChain        AppChainOptions        `group:"Application Chain Options" namespace:"app-chain"`
 	SettlementChain SettlementChainOptions `group:"Settlement Chain Options"  namespace:"settlement-chain"`
@@ -37,6 +35,7 @@ type AppChainOptions struct {
 	RpcURL                           string        `long:"rpc-url"                             env:"XMTPD_APP_CHAIN_RPC_URL"                           description:"Blockchain RPC URL"`
 	ChainID                          int           `long:"chain-id"                            env:"XMTPD_APP_CHAIN_CHAIN_ID"                          description:"Chain ID for the application chain"                           default:"31337"`
 	MaxChainDisconnectTime           time.Duration `long:"max-chain-disconnect-time"           env:"XMTPD_APP_CHAIN_MAX_CHAIN_DISCONNECT_TIME"         description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
+	BackfillBlockSize                uint64        `long:"backfill-block-size"                 env:"XMTPD_APP_CHAIN_BACKFILL_BLOCK_SIZE"               description:"Maximal size of a backfill block"                             default:"500"`
 	GroupMessageBroadcasterAddress   string        `long:"group-message-broadcaster-address"   env:"XMTPD_APP_CHAIN_GROUP_MESSAGE_BROADCAST_ADDRESS"   description:"Group message broadcaster contract address"`
 	IdentityUpdateBroadcasterAddress string        `long:"identity-update-broadcaster-address" env:"XMTPD_APP_CHAIN_IDENTITY_UPDATE_BROADCAST_ADDRESS" description:"Identity update broadcaster contract address"`
 }
@@ -44,13 +43,14 @@ type AppChainOptions struct {
 type SettlementChainOptions struct {
 	RpcURL                      string        `long:"rpc-url"                        env:"XMTPD_SETTLEMENT_CHAIN_RPC_URL"                        description:"Blockchain RPC URL"`
 	ChainID                     int           `long:"chain-id"                       env:"XMTPD_SETTLEMENT_CHAIN_CHAIN_ID"                       description:"Chain ID for the settlement chain"                            default:"31337"`
+	MaxChainDisconnectTime      time.Duration `long:"max-chain-disconnect-time"      env:"XMTPD_SETTLEMENT_CHAIN_MAX_CHAIN_DISCONNECT_TIME"      description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
+	BackfillBlockSize           uint64        `long:"backfill-block-size"            env:"XMTPD_SETTLEMENT_CHAIN_BACKFILL_BLOCK_SIZE"            description:"Maximal size of a backfill block"                             default:"500"`
 	NodeRegistryAddress         string        `long:"node-registry-address"          env:"XMTPD_SETTLEMENT_CHAIN_NODE_REGISTRY_ADDRESS"          description:"Node Registry contract address"`
 	NodeRegistryRefreshInterval time.Duration `long:"node-registry-refresh-interval" env:"XMTPD_SETTLEMENT_CHAIN_NODE_REGISTRY_REFRESH_INTERVAL" description:"Refresh interval for the nodes registry"                      default:"60s"`
 	RateRegistryAddress         string        `long:"rate-registry-address"          env:"XMTPD_SETTLEMENT_CHAIN_RATE_REGISTRY_ADDRESS"          description:"Rate registry contract address"`
 	RateRegistryRefreshInterval time.Duration `long:"rate-registry-refresh-interval" env:"XMTPD_SETTLEMENT_CHAIN_RATE_REGISTRY_REFRESH_INTERVAL" description:"Refresh interval for the rate registry"                       default:"300s"`
 	ParameterRegistryAddress    string        `long:"parameter-registry-address"     env:"XMTPD_SETTLEMENT_CHAIN_PARAMETER_REGISTRY_ADDRESS"     description:"Parameter Registry contract address"`
 	PayerRegistryAddress        string        `long:"payer-registry-address"         env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_ADDRESS"         description:"Payer Registry contract address"`
-	MaxChainDisconnectTime      time.Duration `long:"max-chain-disconnect-time"      env:"XMTPD_SETTLEMENT_CHAIN_MAX_CHAIN_DISCONNECT_TIME"      description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
 }
 
 type DbOptions struct {

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -52,7 +52,6 @@ type SettlementChainOptions struct {
 	ParameterRegistryAddress    string        `long:"parameter-registry-address"     env:"XMTPD_SETTLEMENT_CHAIN_PARAMETER_REGISTRY_ADDRESS"     description:"Parameter Registry contract address"`
 	PayerRegistryAddress        string        `long:"payer-registry-address"         env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_ADDRESS"         description:"Payer Registry contract address"`
 	PayerReportManagerAddress   string        `long:"payer-report-manager-address"   env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REPORT_MANAGER_ADDRESS"   description:"Payer Report Manager contract address"`
-	MaxChainDisconnectTime      time.Duration `long:"max-chain-disconnect-time"      env:"XMTPD_SETTLEMENT_CHAIN_MAX_CHAIN_DISCONNECT_TIME"      description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
 }
 
 type DbOptions struct {

--- a/pkg/indexer/app_chain/app_chain.go
+++ b/pkg/indexer/app_chain/app_chain.go
@@ -41,7 +41,6 @@ func NewAppChain(
 	cfg config.AppChainOptions,
 	db *sql.DB,
 	validationService mlsvalidate.MLSValidationService,
-	blockSize uint64,
 ) (*AppChain, error) {
 	ctxwc, cancel := context.WithCancel(ctxwc)
 
@@ -114,7 +113,7 @@ func NewAppChain(
 				MaxDisconnectTime: cfg.MaxChainDisconnectTime,
 			},
 		),
-		blockchain.WithBackfillBlockSize(blockSize),
+		blockchain.WithBackfillBlockSize(cfg.BackfillBlockSize),
 	)
 	if err != nil {
 		cancel()

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -38,7 +38,6 @@ func NewIndexer(
 		cfg.AppChain,
 		db,
 		validationService,
-		cfg.BackfillBlockSize,
 	)
 	if err != nil {
 		cancel()
@@ -50,7 +49,6 @@ func NewIndexer(
 		indexerLogger,
 		cfg.SettlementChain,
 		db,
-		cfg.BackfillBlockSize,
 	)
 	if err != nil {
 		cancel()

--- a/pkg/indexer/settlement_chain/settlement_chain.go
+++ b/pkg/indexer/settlement_chain/settlement_chain.go
@@ -108,7 +108,7 @@ func NewSettlementChain(
 				MaxDisconnectTime: cfg.MaxChainDisconnectTime,
 			},
 		),
-		blockchain.WithBackfillBlockSize(blockSize),
+		blockchain.WithBackfillBlockSize(cfg.BackfillBlockSize),
 	)
 	if err != nil {
 		cancel()

--- a/pkg/indexer/settlement_chain/settlement_chain.go
+++ b/pkg/indexer/settlement_chain/settlement_chain.go
@@ -38,7 +38,6 @@ func NewSettlementChain(
 	log *zap.Logger,
 	cfg config.SettlementChainOptions,
 	db *sql.DB,
-	blockSize uint64,
 ) (*SettlementChain, error) {
 	ctxwc, cancel := context.WithCancel(ctxwc)
 
@@ -84,7 +83,7 @@ func NewSettlementChain(
 				MaxDisconnectTime: cfg.MaxChainDisconnectTime,
 			},
 		),
-		blockchain.WithBackfillBlockSize(blockSize),
+		blockchain.WithBackfillBlockSize(cfg.BackfillBlockSize),
 	)
 	if err != nil {
 		cancel()

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -30,6 +30,7 @@ func NewContractsOptions(rpcUrl string) config.ContractsOptions {
 			MaxChainDisconnectTime:           10 * time.Second,
 			GroupMessageBroadcasterAddress:   GROUP_MESSAGE_BROADCAST_ADDRESS,
 			IdentityUpdateBroadcasterAddress: IDENTITY_UPDATE_BROADCAST_ADDRESS,
+			BackfillBlockSize:                500,
 		},
 		SettlementChain: config.SettlementChainOptions{
 			RpcURL:                      rpcUrl,
@@ -41,8 +42,8 @@ func NewContractsOptions(rpcUrl string) config.ContractsOptions {
 			ParameterRegistryAddress:    PARAMETER_REGISTRY_ADDRESS,
 			PayerRegistryAddress:        PAYER_REGISTRY_ADDRESS,
 			MaxChainDisconnectTime:      10 * time.Second,
+			BackfillBlockSize:           500,
 		},
-		BackfillBlockSize: 500,
 	}
 }
 


### PR DESCRIPTION
Different RPC might have different block page sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Backfill block size configuration is now available separately for each chain type, allowing more granular control for both app chains and settlement chains.
  - Added a new setting for maximum chain disconnect time in settlement chain options.

- **Chores**
  - Updated internal configuration handling to remove the global backfill block size setting and move it to individual chain configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->