### PR TITLE
Add ILogStreamer interface abstraction

### DIFF
--- a/pkg/indexer/common/interface.go
+++ b/pkg/indexer/common/interface.go
@@ -9,6 +9,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// An ILogStreamer streams logs from a source through a channel.
+type ILogStreamer interface {
+	GetEventChannel(id string) <-chan types.Log
+	Start()
+	Stop()
+}
+
 // Takes a log event and stores it, returning either an error that may be retriable, non-retriable, or nil.
 type ILogStorer interface {
 	StoreLog(ctx context.Context, event types.Log) re.RetryableError

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer_test.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer_test.go
@@ -1,4 +1,4 @@
-package blockchain_test
+package rpc_streamer_test
 
 import (
 	"context"
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/xmtp/xmtpd/pkg/blockchain"
 
+	"github.com/xmtp/xmtpd/pkg/indexer/rpc_streamer"
 	mocks "github.com/xmtp/xmtpd/pkg/mocks/blockchain"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 
@@ -61,7 +61,7 @@ func TestRpcLogStreamer(t *testing.T) {
 	mockClient.On("BlockByNumber", mock.Anything, big.NewInt(int64(backfillToBlock+1))).
 		Return(mockBlock11, nil)
 
-	cfg := blockchain.ContractConfig{
+	cfg := rpc_streamer.ContractConfig{
 		ID:                "testContract",
 		FromBlockNumber:   backfillFromBlock,
 		FromBlockHash:     []byte{},
@@ -70,12 +70,12 @@ func TestRpcLogStreamer(t *testing.T) {
 		MaxDisconnectTime: 5 * time.Minute,
 	}
 
-	streamer, err := blockchain.NewRpcLogStreamer(
+	streamer, err := rpc_streamer.NewRpcLogStreamer(
 		context.Background(),
 		mockClient,
 		testutils.NewLog(t),
-		blockchain.WithContractConfig(cfg),
-		blockchain.WithBackfillBlockSize(9),
+		rpc_streamer.WithContractConfig(cfg),
+		rpc_streamer.WithBackfillBlockSize(9),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Add ILogStreamer interface abstraction to decouple AppChain and SettlementChain from concrete RpcLogStreamer implementation
Creates a new `ILogStreamer` interface in [pkg/indexer/common/interface.go](https://github.com/xmtp/xmtpd/pull/862/files#diff-5cfd089dbe44085371c83acdae4a3de5a7ae9dbda09816f29adf96eafd6f4e34) and moves `RpcLogStreamer` from the blockchain package to a dedicated [pkg/indexer/rpc_streamer](https://github.com/xmtp/xmtpd/pull/862/files#diff-fd861225751f668ffeaae06058a690386c363ad41c0f309dc4778b967455a3e2) package. Updates `AppChain` and `SettlementChain` structs to depend on the `ILogStreamer` interface rather than the concrete `RpcLogStreamer` type, and modifies the `GetEventChannel` method to return a receive-only channel `<-chan types.Log`.

#### 📍Where to Start
Start with the new `ILogStreamer` interface definition in [pkg/indexer/common/interface.go](https://github.com/xmtp/xmtpd/pull/862/files#diff-5cfd089dbe44085371c83acdae4a3de5a7ae9dbda09816f29adf96eafd6f4e34) to understand the abstraction, then review how it's implemented in [pkg/indexer/rpc_streamer/rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/862/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d).

----

_[Macroscope](https://app.macroscope.com) summarized 7aba090._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved modularity and abstraction in blockchain event streaming components.
  - Updated internal interfaces for event streamers to enhance flexibility and maintainability.
- **Tests**
  - Updated and reorganized test files to align with refactored components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->