### PR TITLE
Add Payer Service interfaces

### DIFF
--- a/pkg/config/payer.go
+++ b/pkg/config/payer.go
@@ -1,0 +1,11 @@
+package config
+
+type PayerConfig struct {
+	API       ApiOptions       `group:"API Options"            namespace:"api"`
+	DB        DbOptions        `group:"Database Options"       namespace:"db"`
+	Contracts ContractsOptions `group:"Contracts Options"      namespace:"contracts"`
+	Log       LogOptions       `group:"Log Options"            namespace:"log"`
+	Metrics   MetricsOptions   `group:"Metrics Options"        namespace:"metrics"`
+	Payer     PayerOptions     `group:"Payer Options"          namespace:"payer"`
+	Tracing   TracingOptions   `group:"DD APM Tracing Options" namespace:"tracing"`
+}

--- a/pkg/payer/builder..go
+++ b/pkg/payer/builder..go
@@ -1,0 +1,55 @@
+package payer
+
+import (
+	"errors"
+
+	"github.com/xmtp/xmtpd/pkg/config"
+)
+
+var (
+	ErrMissingConfig = errors.New("config must be provided and not nil")
+	ErrUnauthorized  = errors.New("unauthorized")
+)
+
+type PayerServiceBuilder struct {
+	identityFn  IdentityFn
+	authorizers []AuthorizePublishFn
+	config      *config.PayerConfig
+}
+
+func NewPayerServiceBuilder(config *config.PayerConfig) IPayerServiceBuilder {
+	return &PayerServiceBuilder{
+		config: config,
+	}
+}
+
+func (b *PayerServiceBuilder) WithIdentityFn(identityFn IdentityFn) IPayerServiceBuilder {
+	b.identityFn = identityFn
+	return b
+}
+
+func (b *PayerServiceBuilder) WithAuthorizers(
+	authorizers ...AuthorizePublishFn,
+) IPayerServiceBuilder {
+	b.authorizers = authorizers
+	return b
+}
+
+func (b *PayerServiceBuilder) Build() (PayerService, error) {
+	if b.config == nil {
+		return nil, ErrMissingConfig
+	}
+
+	if b.identityFn == nil {
+		b.identityFn = IPIdentityFn
+	}
+
+	// Create a new PayerService with the configured options
+	service := &payerServiceImpl{
+		identityFn:  b.identityFn,
+		authorizers: b.authorizers,
+		config:      b.config,
+	}
+
+	return service, nil
+}

--- a/pkg/payer/error.go
+++ b/pkg/payer/error.go
@@ -1,0 +1,63 @@
+package payer
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+)
+
+type PayerServiceError interface {
+	error
+	Code() codes.Code
+	ClientMessage() string
+}
+
+type PermissionDeniedError struct {
+	msg string
+	err error
+}
+
+func (e PermissionDeniedError) Error() string {
+	if e.err == nil {
+		return e.msg
+	}
+
+	return fmt.Sprintf("%s: %s", e.msg, e.err.Error())
+}
+
+func (e PermissionDeniedError) ClientMessage() string {
+	return e.msg
+}
+
+func (e PermissionDeniedError) Code() codes.Code {
+	return codes.PermissionDenied
+}
+
+func NewPermissionDeniedError(msg string, err error) *PermissionDeniedError {
+	return &PermissionDeniedError{msg: msg, err: err}
+}
+
+type UnauthenticatedError struct {
+	msg string
+	err error
+}
+
+func (e UnauthenticatedError) Error() string {
+	if e.err == nil {
+		return e.msg
+	}
+
+	return fmt.Sprintf("%s: %s", e.msg, e.err.Error())
+}
+
+func (e UnauthenticatedError) ClientMessage() string {
+	return e.msg
+}
+
+func (e UnauthenticatedError) Code() codes.Code {
+	return codes.Unauthenticated
+}
+
+func NewUnauthenticatedError(msg string, err error) *UnauthenticatedError {
+	return &UnauthenticatedError{msg: msg, err: err}
+}

--- a/pkg/payer/examples/basic/main.go
+++ b/pkg/payer/examples/basic/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"slices"
+
+	"github.com/xmtp/xmtpd/pkg/payer"
+)
+
+func main() {
+	payerService, err := payer.NewPayerServiceBuilder(payer.MustLoadConfig()).
+		WithAuthorizers(func(ctx context.Context, identity payer.Identity, req payer.PublishRequest) (bool, error) {
+			// A simple authorization function that allows only the IP 127.0.0.1
+			allowedIPs := []string{"127.0.0.1"}
+			if !slices.Contains(allowedIPs, identity.Identity) {
+				return false, payer.ErrUnauthorized
+			}
+			return true, nil
+		}).
+		Build() // This will gather all the config from environment variables and flags
+	if err != nil {
+		log.Fatalf("Failed to build payer service: %v", err)
+	}
+
+	err = payerService.Serve(context.Background())
+	if err != nil {
+		log.Fatalf("Failed to serve payer service: %v", err)
+	}
+}

--- a/pkg/payer/examples/jwt/main.go
+++ b/pkg/payer/examples/jwt/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/xmtp/xmtpd/pkg/payer"
+)
+
+const EXPECTED_ISSUER = "my-app.com"
+
+var (
+	ErrMissingToken     = errors.New("missing JWT token")
+	ErrInvalidToken     = errors.New("invalid JWT token")
+	ErrInvalidSignature = errors.New("invalid token signature")
+)
+
+// jwtIdentityFn creates an identity function that verifies JWTs
+func jwtIdentityFn(publicKey []byte) payer.IdentityFn {
+	return func(ctx context.Context) (payer.Identity, error) {
+		authHeader := payer.AuthorizationHeaderFromContext(ctx)
+		if authHeader == "" {
+			return payer.Identity{}, payer.NewUnauthenticatedError(
+				"Missing JWT token",
+				ErrMissingToken,
+			)
+		}
+
+		// Parse and verify the token
+		token, err := jwt.ParseWithClaims(
+			authHeader,
+			&jwt.RegisteredClaims{},
+			func(token *jwt.Token) (interface{}, error) {
+				// Verify signing method
+				if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+					return nil, payer.NewPermissionDeniedError(
+						"Invalid signing method",
+						ErrInvalidSignature,
+					)
+				}
+				return publicKey, nil
+			},
+			jwt.WithIssuer(EXPECTED_ISSUER),
+		)
+		if err != nil {
+			return payer.Identity{}, payer.NewPermissionDeniedError("failed to validate token", err)
+		}
+
+		// Extract claims
+		claims, ok := token.Claims.(*jwt.RegisteredClaims)
+		if !ok || !token.Valid {
+			return payer.Identity{}, payer.NewPermissionDeniedError(
+				"failed to validate token",
+				ErrInvalidToken,
+			)
+		}
+
+		userID, err := claims.GetSubject()
+		if err != nil {
+			return payer.Identity{}, payer.NewPermissionDeniedError(
+				"failed to get subject from token",
+				err,
+			)
+		}
+
+		// Return identity based on JWT claims
+		return payer.NewUserIdentity(userID), nil
+	}
+}
+
+func main() {
+	// In a real application, this would be a secure key loaded from environment/config
+	publicKey := []byte("your-applications-public-key")
+
+	payerService, err := payer.NewPayerServiceBuilder(payer.MustLoadConfig()).
+		WithIdentityFn(jwtIdentityFn(publicKey)).
+		Build()
+	if err != nil {
+		log.Fatalf("Failed to build payer service: %v", err)
+	}
+
+	err = payerService.Serve(context.Background())
+	if err != nil {
+		log.Fatalf("Failed to serve payer service: %v", err)
+	}
+}

--- a/pkg/payer/examples/simpleRateLimiter/main.go
+++ b/pkg/payer/examples/simpleRateLimiter/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/xmtp/xmtpd/pkg/payer"
+)
+
+func main() {
+	cfg := payer.MustLoadConfig()
+
+	payerService, err := payer.NewPayerServiceBuilder(cfg).
+		// Rate limit to allow 50 requests per minute and 10,000 requests per day
+		WithAuthorizers(payer.NewRateLimitAuthorizer(cfg, payer.RateLimit{
+			MaxRequests: 50,
+			Window:      time.Minute,
+		}), payer.NewRateLimitAuthorizer(cfg, payer.RateLimit{
+			MaxRequests: 10000,
+			Window:      time.Hour * 24,
+		})).
+		Build()
+	if err != nil {
+		log.Fatalf("Failed to build payer service: %v", err)
+	}
+
+	err = payerService.Serve(context.Background())
+	if err != nil {
+		log.Fatalf("Failed to serve payer service: %v", err)
+	}
+}

--- a/pkg/payer/helpers.go
+++ b/pkg/payer/helpers.go
@@ -1,0 +1,58 @@
+package payer
+
+import (
+	"context"
+	"log"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/xmtp/xmtpd/pkg/config"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"google.golang.org/grpc/metadata"
+)
+
+func IPIdentityFn(ctx context.Context) (Identity, error) {
+	return Identity{
+		Kind:     IdentityKindIP,
+		Identity: ClientIPFromContext(ctx),
+	}, nil
+}
+
+func NewUserIdentity(userID string) Identity {
+	return Identity{
+		Kind:     IdentityKindUserDefined,
+		Identity: userID,
+	}
+}
+
+func LoadConfigFromEnv() (*config.PayerConfig, error) {
+	var cfg config.PayerConfig
+	_, err := flags.Parse(&cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func MustLoadConfig() *config.PayerConfig {
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load config from environment: %v", err)
+	}
+	return cfg
+}
+
+func ClientIPFromContext(ctx context.Context) string {
+	return utils.ClientIPFromContext(ctx)
+}
+
+func AuthorizationHeaderFromContext(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	auth := md.Get("authorization")
+	if len(auth) == 0 {
+		return ""
+	}
+	return auth[0]
+}

--- a/pkg/payer/interface.go
+++ b/pkg/payer/interface.go
@@ -1,0 +1,44 @@
+package payer
+
+import (
+	"context"
+
+	"github.com/xmtp/xmtpd/pkg/currency"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api"
+)
+
+type PublishRequest *payer_api.PublishClientEnvelopesRequest
+
+type IdentityKind string
+
+const (
+	IdentityKindIP          IdentityKind = "ip"
+	IdentityKindUserDefined IdentityKind = "user"
+)
+
+type Identity struct {
+	Kind     IdentityKind
+	Identity string
+}
+
+type PublishRequestSummary struct {
+	TotalEnvelopes       int
+	OffchainCostEstimate currency.PicoDollar
+	OnchainCostEstimate  currency.PicoDollar
+	TotalCostEstimate    currency.PicoDollar
+}
+
+type IdentityFn func(ctx context.Context) (Identity, error)
+
+type AuthorizePublishFn func(ctx context.Context, identity Identity, req PublishRequest) (bool, error)
+
+type IPayerServiceBuilder interface {
+	WithIdentityFn(identityFn IdentityFn) IPayerServiceBuilder
+	WithAuthorizers(authorizers ...AuthorizePublishFn) IPayerServiceBuilder
+	Build() (PayerService, error)
+}
+
+type PayerService interface {
+	Serve(ctx context.Context) error
+	ServeUntilShutdown() error
+}

--- a/pkg/payer/ratelimiter.go
+++ b/pkg/payer/ratelimiter.go
@@ -1,0 +1,20 @@
+package payer
+
+import (
+	"context"
+	"time"
+
+	"github.com/xmtp/xmtpd/pkg/config"
+)
+
+type RateLimit struct {
+	MaxRequests int
+	Window      time.Duration
+}
+
+func NewRateLimitAuthorizer(config *config.PayerConfig, rateLimit RateLimit) AuthorizePublishFn {
+	return func(ctx context.Context, identity Identity, req PublishRequest) (bool, error) {
+		// TODO:(nm) Actual implementation
+		return true, nil
+	}
+}

--- a/pkg/payer/server.go
+++ b/pkg/payer/server.go
@@ -1,0 +1,21 @@
+package payer
+
+import (
+	"context"
+
+	"github.com/xmtp/xmtpd/pkg/config"
+)
+
+type payerServiceImpl struct {
+	identityFn  IdentityFn
+	authorizers []AuthorizePublishFn
+	config      *config.PayerConfig
+}
+
+func (s *payerServiceImpl) Serve(ctx context.Context) error {
+	return nil
+}
+
+func (s *payerServiceImpl) ServeUntilShutdown() error {
+	return s.Serve(context.Background())
+}

--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func ClientIPFromContext(ctx context.Context) string {
+	md, _ := metadata.FromIncomingContext(ctx)
+	vals := md.Get("x-forwarded-for")
+	if len(vals) == 0 {
+		p, ok := peer.FromContext(ctx)
+		if ok {
+			host, _, err := net.SplitHostPort(p.Addr.String())
+			if err != nil {
+				// If SplitHostPort fails, fall back to the original string splitting
+				ipAndPort := strings.Split(p.Addr.String(), ":")
+				return ipAndPort[0]
+			}
+			return host
+		} else {
+			return ""
+		}
+	}
+	// There are potentially multiple comma separated IPs bundled in that first value
+	ips := strings.Split(vals[0], ",")
+	return strings.TrimSpace(ips[0])
+}


### PR DESCRIPTION
### TL;DR

Added a new payer service package with authentication, authorization, and rate limiting capabilities.

### What changed?

- Created a new `payer` package with interfaces and implementations for a payer service
- Added error handling for authentication and authorization
- Implemented identity functions for IP-based and JWT-based authentication
- Added rate limiting functionality for request authorization
- Created example implementations demonstrating different use cases:
  - Basic example with IP-based authorization
  - JWT authentication example
  - Simple rate limiter example
- Added utility functions for extracting client IP from context
- Created configuration structures for the payer service

### How to test?

1. Run the minimal example:
   ```
   go run pkg/payer/minimal/main.go
   ```

2. Try the basic example with IP-based authorization:
   ```
   go run pkg/payer/examples/basic/main.go
   ```

3. Test the JWT authentication example:
   ```
   go run pkg/payer/examples/jwt/main.go
   ```

4. Test the rate limiting example:
   ```
   go run pkg/payer/examples/simpleRateLimiter/main.go
   ```

### Why make this change?

This change introduces a flexible payer service that can be configured with different authentication and authorization strategies. The service provides a foundation for implementing custom payment and authorization logic for XMTP message publishing, allowing for IP-based identification, JWT authentication, and rate limiting capabilities. This modular approach enables developers to easily customize the service to their specific requirements.