### PR TITLE
Honor start at deployment blocks

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -20,34 +20,32 @@ type ContractsOptions struct {
 type AppChainOptions struct {
 	// RpcURL is deprecated, use WssURL instead.
 	// TODO: For now, we only validate RpcURL, until deployments are migrated to WssURL.
-	RpcURL                              string        `long:"rpc-url"                                 env:"XMTPD_APP_CHAIN_RPC_URL"                               description:"Blockchain RPC URL"`
-	WssURL                              string        `long:"wss-url"                                 env:"XMTPD_APP_CHAIN_WSS_URL"                               description:"Blockchain WSS URL"`
-	ChainID                             int           `long:"chain-id"                                env:"XMTPD_APP_CHAIN_CHAIN_ID"                              description:"Chain ID for the application chain"                           default:"31337"`
-	MaxChainDisconnectTime              time.Duration `long:"max-chain-disconnect-time"               env:"XMTPD_APP_CHAIN_MAX_CHAIN_DISCONNECT_TIME"             description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
-	BackfillBlockSize                   uint64        `long:"backfill-block-size"                     env:"XMTPD_APP_CHAIN_BACKFILL_BLOCK_SIZE"                   description:"Maximal size of a backfill block"                             default:"500"`
-	GroupMessageBroadcasterAddress      string        `long:"group-message-broadcaster-address"       env:"XMTPD_APP_CHAIN_GROUP_MESSAGE_BROADCAST_ADDRESS"       description:"Group message broadcaster contract address"`
-	GroupMessageBroadcasterStartBlock   uint64        `long:"group-message-broadcaster-start-block"   env:"XMTPD_APP_CHAIN_GROUP_MESSAGE_BROADCAST_START_BLOCK"   description:"Start block for the group message broadcaster"                default:"0"`
-	IdentityUpdateBroadcasterAddress    string        `long:"identity-update-broadcaster-address"     env:"XMTPD_APP_CHAIN_IDENTITY_UPDATE_BROADCAST_ADDRESS"     description:"Identity update broadcaster contract address"`
-	IdentityUpdateBroadcasterStartBlock uint64        `long:"identity-update-broadcaster-start-block" env:"XMTPD_APP_CHAIN_IDENTITY_UPDATE_BROADCAST_START_BLOCK" description:"Start block for the identity update broadcaster"              default:"0"`
+	RpcURL                           string        `long:"rpc-url"                             env:"XMTPD_APP_CHAIN_RPC_URL"                           description:"Blockchain RPC URL"`
+	WssURL                           string        `long:"wss-url"                             env:"XMTPD_APP_CHAIN_WSS_URL"                           description:"Blockchain WSS URL"`
+	ChainID                          int           `long:"chain-id"                            env:"XMTPD_APP_CHAIN_CHAIN_ID"                          description:"Chain ID for the application chain"                           default:"31337"`
+	MaxChainDisconnectTime           time.Duration `long:"max-chain-disconnect-time"           env:"XMTPD_APP_CHAIN_MAX_CHAIN_DISCONNECT_TIME"         description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
+	BackfillBlockSize                uint64        `long:"backfill-block-size"                 env:"XMTPD_APP_CHAIN_BACKFILL_BLOCK_SIZE"               description:"Maximal size of a backfill block"                             default:"500"`
+	GroupMessageBroadcasterAddress   string        `long:"group-message-broadcaster-address"   env:"XMTPD_APP_CHAIN_GROUP_MESSAGE_BROADCAST_ADDRESS"   description:"Group message broadcaster contract address"`
+	IdentityUpdateBroadcasterAddress string        `long:"identity-update-broadcaster-address" env:"XMTPD_APP_CHAIN_IDENTITY_UPDATE_BROADCAST_ADDRESS" description:"Identity update broadcaster contract address"`
+	DeploymentBlock                  uint64        `long:"deployment-block"                    env:"XMTPD_APP_CHAIN_DEPLOYMENT_BLOCK"                  description:"Deployment block for the application chain"                   default:"0"`
 }
 
 type SettlementChainOptions struct {
 	// RpcURL is deprecated, use WssURL instead.
 	// TODO: For now, we only validate RpcURL, until deployments are migrated to WssURL.
-	RpcURL                       string        `long:"rpc-url"                          env:"XMTPD_SETTLEMENT_CHAIN_RPC_URL"                          description:"Blockchain RPC URL"`
-	WssURL                       string        `long:"wss-url"                          env:"XMTPD_SETTLEMENT_CHAIN_WSS_URL"                          description:"Blockchain WSS URL"`
-	ChainID                      int           `long:"chain-id"                         env:"XMTPD_SETTLEMENT_CHAIN_CHAIN_ID"                         description:"Chain ID for the settlement chain"                            default:"31337"`
-	MaxChainDisconnectTime       time.Duration `long:"max-chain-disconnect-time"        env:"XMTPD_SETTLEMENT_CHAIN_MAX_CHAIN_DISCONNECT_TIME"        description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
-	BackfillBlockSize            uint64        `long:"backfill-block-size"              env:"XMTPD_SETTLEMENT_CHAIN_BACKFILL_BLOCK_SIZE"              description:"Maximal size of a backfill block"                             default:"500"`
-	NodeRegistryAddress          string        `long:"node-registry-address"            env:"XMTPD_SETTLEMENT_CHAIN_NODE_REGISTRY_ADDRESS"            description:"Node Registry contract address"`
-	NodeRegistryRefreshInterval  time.Duration `long:"node-registry-refresh-interval"   env:"XMTPD_SETTLEMENT_CHAIN_NODE_REGISTRY_REFRESH_INTERVAL"   description:"Refresh interval for the nodes registry"                      default:"60s"`
-	RateRegistryAddress          string        `long:"rate-registry-address"            env:"XMTPD_SETTLEMENT_CHAIN_RATE_REGISTRY_ADDRESS"            description:"Rate registry contract address"`
-	RateRegistryRefreshInterval  time.Duration `long:"rate-registry-refresh-interval"   env:"XMTPD_SETTLEMENT_CHAIN_RATE_REGISTRY_REFRESH_INTERVAL"   description:"Refresh interval for the rate registry"                       default:"300s"`
-	ParameterRegistryAddress     string        `long:"parameter-registry-address"       env:"XMTPD_SETTLEMENT_CHAIN_PARAMETER_REGISTRY_ADDRESS"       description:"Parameter Registry contract address"`
-	PayerRegistryAddress         string        `long:"payer-registry-address"           env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_ADDRESS"           description:"Payer Registry contract address"`
-	PayerRegistryStartBlock      uint64        `long:"payer-registry-start-block"       env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_START_BLOCK"       description:"Start block for the payer registry"`
-	PayerReportManagerAddress    string        `long:"payer-report-manager-address"     env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REPORT_MANAGER_ADDRESS"     description:"Payer Report Manager contract address"`
-	PayerReportManagerStartBlock uint64        `long:"payer-report-manager-start-block" env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REPORT_MANAGER_START_BLOCK" description:"Start block for the payer report manager"`
+	RpcURL                      string        `long:"rpc-url"                        env:"XMTPD_SETTLEMENT_CHAIN_RPC_URL"                        description:"Blockchain RPC URL"`
+	WssURL                      string        `long:"wss-url"                        env:"XMTPD_SETTLEMENT_CHAIN_WSS_URL"                        description:"Blockchain WSS URL"`
+	ChainID                     int           `long:"chain-id"                       env:"XMTPD_SETTLEMENT_CHAIN_CHAIN_ID"                       description:"Chain ID for the settlement chain"                            default:"31337"`
+	MaxChainDisconnectTime      time.Duration `long:"max-chain-disconnect-time"      env:"XMTPD_SETTLEMENT_CHAIN_MAX_CHAIN_DISCONNECT_TIME"      description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
+	BackfillBlockSize           uint64        `long:"backfill-block-size"            env:"XMTPD_SETTLEMENT_CHAIN_BACKFILL_BLOCK_SIZE"            description:"Maximal size of a backfill block"                             default:"500"`
+	NodeRegistryAddress         string        `long:"node-registry-address"          env:"XMTPD_SETTLEMENT_CHAIN_NODE_REGISTRY_ADDRESS"          description:"Node Registry contract address"`
+	NodeRegistryRefreshInterval time.Duration `long:"node-registry-refresh-interval" env:"XMTPD_SETTLEMENT_CHAIN_NODE_REGISTRY_REFRESH_INTERVAL" description:"Refresh interval for the nodes registry"                      default:"60s"`
+	RateRegistryAddress         string        `long:"rate-registry-address"          env:"XMTPD_SETTLEMENT_CHAIN_RATE_REGISTRY_ADDRESS"          description:"Rate registry contract address"`
+	RateRegistryRefreshInterval time.Duration `long:"rate-registry-refresh-interval" env:"XMTPD_SETTLEMENT_CHAIN_RATE_REGISTRY_REFRESH_INTERVAL" description:"Refresh interval for the rate registry"                       default:"300s"`
+	ParameterRegistryAddress    string        `long:"parameter-registry-address"     env:"XMTPD_SETTLEMENT_CHAIN_PARAMETER_REGISTRY_ADDRESS"     description:"Parameter Registry contract address"`
+	PayerRegistryAddress        string        `long:"payer-registry-address"         env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_ADDRESS"         description:"Payer Registry contract address"`
+	PayerReportManagerAddress   string        `long:"payer-report-manager-address"   env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REPORT_MANAGER_ADDRESS"   description:"Payer Report Manager contract address"`
+	DeploymentBlock             uint64        `long:"deployment-block"               env:"XMTPD_SETTLEMENT_CHAIN_DEPLOYMENT_BLOCK"               description:"Deployment block for the settlement chain"                    default:"0"`
 }
 
 type DbOptions struct {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -153,6 +153,9 @@ func fillConfigFromJson(options *ContractsOptions, config *ChainConfig) {
 	if options.AppChain.ChainID == 0 || options.AppChain.ChainID == 31337 {
 		options.AppChain.ChainID = config.AppChainID
 	}
+	if options.AppChain.DeploymentBlock == 0 {
+		options.AppChain.DeploymentBlock = uint64(config.AppChainDeploymentBlock)
+	}
 
 	// SettlementChainOptions
 	if options.SettlementChain.NodeRegistryAddress == "" {
@@ -172,6 +175,9 @@ func fillConfigFromJson(options *ContractsOptions, config *ChainConfig) {
 	}
 	if options.SettlementChain.ChainID == 0 || options.SettlementChain.ChainID == 31337 {
 		options.SettlementChain.ChainID = config.SettlementChainID
+	}
+	if options.SettlementChain.DeploymentBlock == 0 {
+		options.SettlementChain.DeploymentBlock = uint64(config.SettlementChainDeploymentBlock)
 	}
 }
 

--- a/pkg/indexer/app_chain/app_chain.go
+++ b/pkg/indexer/app_chain/app_chain.go
@@ -69,7 +69,7 @@ func NewAppChain(
 		chainLogger,
 		common.HexToAddress(cfg.GroupMessageBroadcasterAddress),
 		cfg.ChainID,
-		cfg.GroupMessageBroadcasterStartBlock,
+		cfg.DeploymentBlock,
 	)
 	if err != nil {
 		cancel()
@@ -87,7 +87,7 @@ func NewAppChain(
 		validationService,
 		common.HexToAddress(cfg.IdentityUpdateBroadcasterAddress),
 		cfg.ChainID,
-		cfg.IdentityUpdateBroadcasterStartBlock,
+		cfg.DeploymentBlock,
 	)
 	if err != nil {
 		cancel()

--- a/pkg/indexer/common/block_tracker_test.go
+++ b/pkg/indexer/common/block_tracker_test.go
@@ -25,8 +25,8 @@ func TestInitialize(t *testing.T) {
 	querier := queries.New(db)
 
 	mockClient := blockchain.NewMockChainClient(t)
-	mockClient.On("BlockByNumber", ctx, big.NewInt(0)).
-		Return(mockBlock, nil)
+	mockClient.On("HeaderByNumber", ctx, big.NewInt(0)).
+		Return(mockBlock.Header(), nil)
 
 	tracker, err := c.NewBlockTracker(ctx, mockClient, address, querier, 0)
 	require.NoError(t, err)
@@ -44,8 +44,8 @@ func TestUpdateLatestBlock(t *testing.T) {
 	querier := queries.New(db)
 
 	mockClient := blockchain.NewMockChainClient(t)
-	mockClient.On("BlockByNumber", ctx, big.NewInt(0)).
-		Return(mockBlock, nil)
+	mockClient.On("HeaderByNumber", ctx, big.NewInt(0)).
+		Return(mockBlock.Header(), nil)
 
 	tracker, err := c.NewBlockTracker(ctx, mockClient, address, querier, 0)
 	require.NoError(t, err)
@@ -88,8 +88,8 @@ func TestConcurrentUpdates(t *testing.T) {
 	querier := queries.New(db)
 	mockClient := blockchain.NewMockChainClient(t)
 
-	mockClient.On("BlockByNumber", ctx, big.NewInt(0)).
-		Return(mockBlock, nil)
+	mockClient.On("HeaderByNumber", ctx, big.NewInt(0)).
+		Return(mockBlock.Header(), nil)
 
 	tracker, err := c.NewBlockTracker(ctx, mockClient, address, querier, 0)
 	require.NoError(t, err)
@@ -153,8 +153,8 @@ func TestMultipleContractAddresses(t *testing.T) {
 	address2 := common.HexToAddress("0x0000000000000000000000000000000000000002")
 
 	mockClient := blockchain.NewMockChainClient(t)
-	mockClient.On("BlockByNumber", ctx, big.NewInt(0)).
-		Return(mockBlock, nil)
+	mockClient.On("HeaderByNumber", ctx, big.NewInt(0)).
+		Return(mockBlock.Header(), nil)
 
 	tracker1, err := c.NewBlockTracker(ctx, mockClient, address1, querier, 0)
 	require.NoError(t, err)

--- a/pkg/indexer/settlement_chain/settlement_chain.go
+++ b/pkg/indexer/settlement_chain/settlement_chain.go
@@ -61,7 +61,7 @@ func NewSettlementChain(
 		chainLogger,
 		common.HexToAddress(cfg.PayerRegistryAddress),
 		cfg.ChainID,
-		cfg.PayerRegistryStartBlock,
+		cfg.DeploymentBlock,
 	)
 	if err != nil {
 		cancel()
@@ -78,7 +78,7 @@ func NewSettlementChain(
 		chainLogger,
 		common.HexToAddress(cfg.PayerReportManagerAddress),
 		cfg.ChainID,
-		cfg.PayerReportManagerStartBlock,
+		cfg.DeploymentBlock,
 	)
 	if err != nil {
 		cancel()


### PR DESCRIPTION
### Replace contract-specific start block fields with single DeploymentBlock field in AppChainOptions and SettlementChainOptions configuration structs
The configuration system now uses a single `DeploymentBlock` field instead of multiple contract-specific start block fields for blockchain indexing initialization. Key changes include:

• Removal of `GroupMessageBroadcasterStartBlock`, `IdentityUpdateBroadcasterStartBlock`, `PayerRegistryStartBlock`, and `PayerReportManagerStartBlock` fields from configuration structs in [pkg/config/options.go](https://github.com/xmtp/xmtpd/pull/873/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c)
• Addition of `DeploymentBlock` fields to both `AppChainOptions` and `SettlementChainOptions` structs with default value of 0
• Updates to validation logic in [pkg/config/validation.go](https://github.com/xmtp/xmtpd/pull/873/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b) to populate `DeploymentBlock` from JSON configuration values
• Modification of indexer initialization in [pkg/indexer/app_chain/app_chain.go](https://github.com/xmtp/xmtpd/pull/873/files#diff-a7396f85c51783c1d2690996fe8f2f2497869b03255b30a029cea4ec0eb1e7b3) and [pkg/indexer/settlement_chain/settlement_chain.go](https://github.com/xmtp/xmtpd/pull/873/files#diff-8b9b2747589f71d073557eb548618c3d85483288b54c070c4827567dee7c0257) to use the unified `DeploymentBlock` parameter
• Refactoring of `NewBlockTracker` function in [pkg/indexer/common/block_tracker.go](https://github.com/xmtp/xmtpd/pull/873/files#diff-aa0df6d23e98955a5264943762019f757169978104afd2b940c60eafed334314) to use `deploymentBlock` parameter and `HeaderByNumber` instead of `BlockByNumber`

#### 📍Where to Start
Start with the configuration struct changes in [pkg/config/options.go](https://github.com/xmtp/xmtpd/pull/873/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c) to understand how the `DeploymentBlock` fields replace the contract-specific start block fields.

----

_[Macroscope](https://app.macroscope.com) summarized fcbc041._