### PR TITLE
Add more debug info to duplicate inserts

### DIFF
--- a/pkg/api/message/publishWorker.go
+++ b/pkg/api/message/publishWorker.go
@@ -191,7 +191,7 @@ func (p *publishWorker) publishStagedEnvelope(stagedEnv queries.StagedOriginator
 		return false
 	} else if inserted == 0 {
 		// Envelope was already inserted by another worker
-		logger.Debug("Envelope already inserted")
+		logger.Debug("Envelope already inserted", zap.Int32("originatorID", originatorID), zap.Int64("sequenceID", stagedEnv.ID))
 	}
 
 	// Try to delete the row regardless of if the gateway envelope was inserted elsewhere

--- a/pkg/sync/originatorStream.go
+++ b/pkg/sync/originatorStream.go
@@ -193,7 +193,11 @@ func (s *originatorStream) validateEnvelope(
 
 	if env.OriginatorSequenceID() != lastSequenceID+1 || env.OriginatorNs() < lastNs {
 		// TODO(rich) Submit misbehavior report and continue
-		s.log.Error("Received out of order envelope")
+		s.log.Error(
+			"Received out of order envelope",
+			zap.Any("envelope", env),
+			zap.Any("lastEnvelope", s.lastEnvelope),
+		)
 	}
 
 	if env.OriginatorSequenceID() > lastSequenceID {
@@ -270,7 +274,7 @@ func (s *originatorStream) storeEnvelope(env *envUtils.OriginatorEnvelope) error
 		return err
 	} else if inserted == 0 {
 		// Envelope was already inserted by another worker
-		s.log.Info("Envelope already inserted")
+		s.log.Debug("Envelope already inserted", zap.Uint32("originatorID", env.OriginatorNodeID()), zap.Uint64("sequenceID", env.OriginatorSequenceID()))
 		return nil
 	}
 


### PR DESCRIPTION
### Add more debug info to duplicate inserts in message publishing and originator stream logging
- Adds originator ID and sequence ID context to debug log messages when envelopes are already inserted in [publishWorker.go](https://github.com/xmtp/xmtpd/pull/882/files#diff-cd2a58705d7eacdaf32fc6b4148beb71638e391186b9682bd0c678a91362ce7b)
- Adds envelope and lastEnvelope details to error logs for out-of-order envelopes and changes log level from Info to Debug for duplicate envelope messages while adding originator ID and sequence ID context in [originatorStream.go](https://github.com/xmtp/xmtpd/pull/882/files#diff-ef2c8eedfaea0d04082c5ce6c5835dc2a0886632e5eb547ca5c79e01b12cd6a2)

#### 📍Where to Start
Start with the logging changes in [publishWorker.go](https://github.com/xmtp/xmtpd/pull/882/files#diff-cd2a58705d7eacdaf32fc6b4148beb71638e391186b9682bd0c678a91362ce7b) where the duplicate envelope detection occurs.

----

_[Macroscope](https://app.macroscope.com) summarized 8f78efb._