### PR TITLE
Skip DD test report upload for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           export PATH="${PATH}:${GOPATH}/bin"
           go test -v ./... -race
       - uses: datadog/junit-upload-github-action@v2
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.ref == 'refs/heads/main'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           service: xmtp-node-go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           export PATH="${PATH}:${GOPATH}/bin"
           go test -v ./... -race
       - uses: datadog/junit-upload-github-action@v2
-        if: github.ref == 'refs/heads/main'
+        if: github.repository == 'xmtp/xmtpd' && github.ref == 'refs/heads/main'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           service: xmtp-node-go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
           export PATH="${PATH}:${GOPATH}/bin"
           go test -v ./... -race
       - uses: datadog/junit-upload-github-action@v2
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           service: xmtp-node-go


### PR DESCRIPTION
This should fix #883. Edit: it actually makes no sense to report CI success on branches. Only do this for main. And only if this is on a non-fork.