### PR TITLE
Validate provided chains with chainID

### DIFF
--- a/dev/docker/up
+++ b/dev/docker/up
@@ -15,7 +15,7 @@ fi
 docker compose \
   -f dev/docker/docker-compose.yml \
   --env-file dev/local.env \
-  --profile ${profile} \
+  --profile "${profile}" \
   -p "xmtpd" \
   up -d \
   --remove-orphans \
@@ -24,7 +24,7 @@ docker compose \
 docker compose \
   -f dev/docker/docker-compose-register.yml \
   --env-file dev/local.env \
-  --profile ${profile} \
+  --profile "${profile}" \
   -p "xmtpd_register_nodes" \
   up \
   --build \

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/ethereum/go-ethereum v1.15.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang-migrate/migrate/v4 v4.18.2
-	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1
 	github.com/jackc/pgx/v5 v5.7.2
@@ -90,6 +89,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect


### PR DESCRIPTION
### Validate provided chains with chainID by adding chain ID verification to websocket URL validation in pkg/config/validation.go
The `validateWebsocketURL` function in [pkg/config/validation.go](https://github.com/xmtp/xmtpd/pull/887/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b) now accepts a `chainID` parameter and establishes an actual connection to Ethereum nodes to verify the chain ID matches the expected value. The function performs URL parsing validation, checks for proper websocket schemes (`ws` or `wss`), connects using `ethclient`, and confirms the node's chain ID. Additionally, the Docker Compose script receives proper quoting for profile variables, and the `gorilla/websocket` dependency changes from direct to indirect status in [go.mod](https://github.com/xmtp/xmtpd/pull/887/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6).

#### 📍Where to Start
Start with the `validateWebsocketURL` function in [pkg/config/validation.go](https://github.com/xmtp/xmtpd/pull/887/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b) to understand the new chain ID validation logic.

----

_[Macroscope](https://app.macroscope.com) summarized 6323382._