### PR TITLE
Update metrics on subscription

### DIFF
--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -238,6 +238,9 @@ backfillLoop:
 		}
 	}
 
+	// from now on we are operating on the subscription, and we no longer check what the highest block is
+	metrics.EmitIndexerCurrentBlockLag(cfg.Address.Hex(), 0)
+
 	for {
 		select {
 		case <-r.ctx.Done():
@@ -254,6 +257,10 @@ backfillLoop:
 				"Received log from subscription channel",
 				zap.Uint64("blockNumber", log.BlockNumber),
 			)
+
+			metrics.EmitIndexerCurrentBlock(cfg.Address.Hex(), log.BlockNumber)
+			metrics.EmitIndexerNumLogsFound(cfg.Address.Hex(), 1)
+			metrics.EmitIndexerMaxBlock(cfg.Address.Hex(), log.BlockNumber)
 
 			// TODO: Implement timelocking for logs in chains with lagFromHighestBlock > 0.
 


### PR DESCRIPTION
### Add metrics tracking to RPC log streamer subscription phase in pkg/indexer/rpc_streamer/rpc_log_streamer.go
The RPC log streamer now emits metrics during the subscription phase to track indexing progress. When transitioning from backfill to subscription mode, the code sets the current block lag to 0 using `metrics.EmitIndexerCurrentBlockLag`. For each log received from the subscription channel, three metrics are emitted: current block number via `metrics.EmitIndexerCurrentBlock`, log count increment via `metrics.EmitIndexerNumLogsFound`, and maximum block processed via `metrics.EmitIndexerMaxBlock`. All metrics are associated with the indexed address using `cfg.Address.Hex()` as the identifier. The changes are contained within [pkg/indexer/rpc_streamer/rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/889/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d).

#### 📍Where to Start
Start with the subscription phase logic in [pkg/indexer/rpc_streamer/rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/889/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) where the new metrics emissions are added.

----

_[Macroscope](https://app.macroscope.com) summarized 0ae58d9._