### PR TITLE
Make shellcheck happy

### DIFF
--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  lint-spellcheck:
-    name: Lint Spellcheck
+  lint-shellcheck:
+    name: Lint Shellcheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -1,4 +1,4 @@
-name: Lint Spellcheck
+name: Lint Shellcheck
 on:
   push:
     branches:

--- a/dev/cmd/register-local-node-1
+++ b/dev/cmd/register-local-node-1
@@ -13,12 +13,12 @@ export NODE_OPERATOR_PRIVATE_KEY=$ANVIL_ACC_1_PRIVATE_KEY
 
 NODE_ID=$(dev/cmd/cli register-node \
     --http-address=http://localhost:5050 \
-    --node-owner-address=$NODE_ADDRESS \
-    --admin.private-key=$PRIVATE_KEY \
-    --node-signing-key-pub=$XMTPD_SIGNER_PUBLIC_KEY | jq -r '.node_id')
+    --node-owner-address="$NODE_ADDRESS" \
+    --admin.private-key="$PRIVATE_KEY" \
+    --node-signing-key-pub="$XMTPD_SIGNER_PUBLIC_KEY" | jq -r '.node_id')
 
 dev/cmd/cli add-node-to-network \
-    --admin.private-key=${PRIVATE_KEY} \
-    --node-id=${NODE_ID}
+    --admin.private-key="${PRIVATE_KEY}" \
+    --node-id="${NODE_ID}"
 
 echo -e "\033[32m✔\033[0m Node with ID $NODE_ID has been registered and enabled\n"

--- a/dev/cmd/register-local-node-2
+++ b/dev/cmd/register-local-node-2
@@ -14,12 +14,12 @@ export NODE_OPERATOR_PRIVATE_KEY=$ANVIL_ACC_2_PRIVATE_KEY
 
 NODE_ID=$(dev/cmd/cli register-node \
     --http-address=http://localhost:5051 \
-    --node-owner-address=$NODE_ADDRESS \
-    --admin.private-key=$PRIVATE_KEY \
-    --node-signing-key-pub=$XMTPD_SIGNER_PUBLIC_KEY | jq -r '.node_id')
+    --node-owner-address="$NODE_ADDRESS" \
+    --admin.private-key="$PRIVATE_KEY" \
+    --node-signing-key-pub="$XMTPD_SIGNER_PUBLIC_KEY" | jq -r '.node_id')
 
 dev/cmd/cli add-node-to-network \
-    --admin.private-key=${PRIVATE_KEY} \
-    --node-id=${NODE_ID}
+    --admin.private-key="${PRIVATE_KEY}" \
+    --node-id="${NODE_ID}"
 
 echo -e "\033[32m✔\033[0m Node with ID $NODE_ID has been registered and enabled"

--- a/dev/docker/down
+++ b/dev/docker/down
@@ -14,13 +14,13 @@ fi
 docker compose \
   -f dev/docker/docker-compose.yml \
   --env-file dev/local.env \
-  --profile ${profile} \
+  --profile "${profile}" \
   -p "xmtpd" \
   down --remove-orphans --volumes
 
 docker compose \
   -f dev/docker/docker-compose-register.yml \
   --env-file dev/local.env \
-  --profile ${profile} \
+  --profile "${profile}" \
   -p "xmtpd_register_nodes" \
   down --remove-orphans --volumes

--- a/dev/docker/up
+++ b/dev/docker/up
@@ -15,7 +15,7 @@ fi
 docker compose \
   -f dev/docker/docker-compose.yml \
   --env-file dev/local.env \
-  --profile ${profile} \
+  --profile "${profile}" \
   -p "xmtpd" \
   up -d \
   --remove-orphans \
@@ -24,7 +24,7 @@ docker compose \
 docker compose \
   -f dev/docker/docker-compose-register.yml \
   --env-file dev/local.env \
-  --profile ${profile} \
+  --profile "${profile}" \
   -p "xmtpd_register_nodes" \
   up \
   --build \


### PR DESCRIPTION
### Fix shell script variable quoting to satisfy shellcheck linting requirements
Adds double quotes around variable references in shell scripts to prevent word splitting and globbing issues, and renames the GitHub workflow from spellcheck to shellcheck. The changes affect multiple shell scripts:

- Renames [.github/workflows/lint-spellcheck.yml](https://github.com/xmtp/xmtpd/pull/890/files#diff-cbd3901c3e303473edf0ca1d9c26f0261f224b92a8ea719558a9c5d5f73f4d2a) to `lint-shellcheck.yml` and updates workflow name and job name
- Adds quotes around variable references in [dev/cmd/register-local-node-1](https://github.com/xmtp/xmtpd/pull/890/files#diff-bb71ba35eb76b858e97a2478cdb558d8107d1019fd90a42dad3dfe703c280bc2) for `NODE_ADDRESS`, `PRIVATE_KEY`, `XMTPD_SIGNER_PUBLIC_KEY`, and `NODE_ID` variables
- Adds quotes around variable references in [dev/cmd/register-local-node-2](https://github.com/xmtp/xmtpd/pull/890/files#diff-0863bcbde23a524191b8523f8062cb91adb80e6adb67e1fd484d42c2cd400822) for the same variables
- Adds quotes around `profile` variable references in [dev/docker/down](https://github.com/xmtp/xmtpd/pull/890/files#diff-7d10e63db3d97298d86fb22d36c4c0fb11bf8aa78cdc8566d33d1bebbb81b51b) and [dev/docker/up](https://github.com/xmtp/xmtpd/pull/890/files#diff-c4a1f6ed02b85cec2e690a289e7810fd5639c9abf2f205bba12519957bb06f99) scripts

#### 📍Where to Start
Start with the renamed GitHub workflow file [.github/workflows/lint-shellcheck.yml](https://github.com/xmtp/xmtpd/pull/890/files#diff-ee89a7cf8bb0f0f51d507c86b5a7a22adb375a92ffcb7006c9c3c890328cc161) to understand the change from spellcheck to shellcheck linting.

----

_[Macroscope](https://app.macroscope.com) summarized ae13aac._