### PR TITLE
Close timing gap in socket discovery

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -129,11 +129,17 @@ func main() {
 		if err != nil {
 			logger.Fatal("initializing grpc listener", zap.Error(err))
 		}
+		defer func() {
+			_ = grpcListener.Close()
+		}()
 
 		httpListener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", options.API.HTTPPort))
 		if err != nil {
 			logger.Fatal("initializing http listener", zap.Error(err))
 		}
+		defer func() {
+			_ = httpListener.Close()
+		}()
 
 		s, err := server.NewReplicationServer(
 			server.WithContext(ctx),

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -236,20 +236,10 @@ func (s *ApiServer) Close(timeout time.Duration) {
 			s.grpcServer.Stop()
 		}
 	}
-	if s.grpcListener != nil {
-		if err := s.grpcListener.Close(); err != nil && !isErrUseOfClosedConnection(err) {
-			s.log.Error("Error while closing grpc listener", zap.Error(err))
-		}
-		s.grpcListener = nil
-	}
 
-	if s.httpListener != nil {
-		err := s.httpListener.Close()
-		if err != nil {
-			s.log.Error("Error while closing http listener", zap.Error(err))
-		}
-		s.httpListener = nil
-	}
+	// Important: Do not close grpcListener or httpListener here.
+	// Their ownership and lifecycle are managed by the caller (e.g., main).
+	// This method only stops the gRPC server and waits for internal routines to complete.
 
 	s.wg.Wait()
 	s.log.Debug("closed")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -236,10 +236,13 @@ func (s *ApiServer) Close(timeout time.Duration) {
 			s.grpcServer.Stop()
 		}
 	}
+	if s.grpcListener != nil {
+		_ = s.grpcListener.Close()
+	}
 
-	// Important: Do not close grpcListener or httpListener here.
-	// Their ownership and lifecycle are managed by the caller (e.g., main).
-	// This method only stops the gRPC server and waits for internal routines to complete.
+	if s.httpListener != nil {
+		_ = s.httpListener.Close()
+	}
 
 	s.wg.Wait()
 	s.log.Debug("closed")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -287,7 +287,7 @@ func TestGRPCAndHTTPHealthEndpoints(t *testing.T) {
 	defer server.Shutdown(0)
 
 	t.Run("HTTP /healthz should return SERVING", func(t *testing.T) {
-		url := fmt.Sprintf("http://localhost:%d/healthz", httpPort)
+		url := fmt.Sprintf("http://localhost:%d/healthz", httpPort.Addr().(*net.TCPAddr).Port)
 
 		require.Eventually(t, func() bool {
 			resp, err := http.Get(url)
@@ -310,7 +310,7 @@ func TestGRPCAndHTTPHealthEndpoints(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			conn, err := grpc.NewClient(
-				fmt.Sprintf("dns:///localhost:%d", grpcPort),
+				fmt.Sprintf("dns:///localhost:%d", grpcPort.Addr().(*net.TCPAddr).Port),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,15 +42,23 @@ func TestCreateServer(t *testing.T) {
 	privateKey2, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	server1Port := networkTestUtils.FindFreePort(t)
-	server2Port := networkTestUtils.FindFreePort(t)
+	server1Port := networkTestUtils.OpenFreePort(t)
+	server2Port := networkTestUtils.OpenFreePort(t)
 
-	httpServer1Port := networkTestUtils.FindFreePort(t)
-	httpServer2Port := networkTestUtils.FindFreePort(t)
+	httpServer1Port := networkTestUtils.OpenFreePort(t)
+	httpServer2Port := networkTestUtils.OpenFreePort(t)
 
 	nodes := []r.Node{
-		registryTestUtils.CreateNode(server1NodeID, server1Port, privateKey1),
-		registryTestUtils.CreateNode(server2NodeID, server2Port, privateKey2),
+		registryTestUtils.CreateNode(
+			server1NodeID,
+			server1Port.Addr().(*net.TCPAddr).Port,
+			privateKey1,
+		),
+		registryTestUtils.CreateNode(
+			server2NodeID,
+			server2Port.Addr().(*net.TCPAddr).Port,
+			privateKey2,
+		),
 	}
 
 	registry := registryTestUtils.CreateMockRegistry(t, nodes)
@@ -61,8 +70,8 @@ func TestCreateServer(t *testing.T) {
 	server1 := serverTestUtils.NewTestServer(
 		t,
 		serverTestUtils.TestServerCfg{
-			Port:             server1Port,
-			HttpPort:         httpServer1Port,
+			GRPCListener:     server1Port,
+			HTTPListener:     httpServer1Port,
 			Db:               dbs[0],
 			Registry:         registry,
 			PrivateKey:       privateKey1,
@@ -76,8 +85,8 @@ func TestCreateServer(t *testing.T) {
 	server2 := serverTestUtils.NewTestServer(
 		t,
 		serverTestUtils.TestServerCfg{
-			Port:             server2Port,
-			HttpPort:         httpServer2Port,
+			GRPCListener:     server2Port,
+			HTTPListener:     httpServer2Port,
 			Db:               dbs[1],
 			Registry:         registry,
 			PrivateKey:       privateKey2,
@@ -177,12 +186,18 @@ func TestReadOwnWritesGuarantee(t *testing.T) {
 	dbs := testutils.NewDBs(t, ctx, 1)
 	privateKey1, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	server1Port := networkTestUtils.FindFreePort(t)
-	httpServer1Port := networkTestUtils.FindFreePort(t)
+	server1Port := networkTestUtils.OpenFreePort(t)
+	httpServer1Port := networkTestUtils.OpenFreePort(t)
 
 	nodeId1 := server1NodeID
 
-	nodes := []r.Node{registryTestUtils.CreateNode(server1NodeID, server1Port, privateKey1)}
+	nodes := []r.Node{
+		registryTestUtils.CreateNode(
+			server1NodeID,
+			server1Port.Addr().(*net.TCPAddr).Port,
+			privateKey1,
+		),
+	}
 	registry := registryTestUtils.CreateMockRegistry(t, nodes)
 	wsUrl := anvil.StartAnvil(t, false)
 
@@ -191,8 +206,8 @@ func TestReadOwnWritesGuarantee(t *testing.T) {
 	server1 := serverTestUtils.NewTestServer(
 		t,
 		serverTestUtils.TestServerCfg{
-			Port:             server1Port,
-			HttpPort:         httpServer1Port,
+			GRPCListener:     server1Port,
+			HTTPListener:     httpServer1Port,
 			Db:               dbs[0],
 			Registry:         registry,
 			PrivateKey:       privateKey1,
@@ -246,17 +261,23 @@ func TestGRPCAndHTTPHealthEndpoints(t *testing.T) {
 	privateKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	grpcPort := networkTestUtils.FindFreePort(t)
-	httpPort := networkTestUtils.FindFreePort(t)
+	grpcPort := networkTestUtils.OpenFreePort(t)
+	httpPort := networkTestUtils.OpenFreePort(t)
 
-	nodes := []r.Node{registryTestUtils.CreateNode(server1NodeID, grpcPort, privateKey)}
+	nodes := []r.Node{
+		registryTestUtils.CreateNode(
+			server1NodeID,
+			grpcPort.Addr().(*net.TCPAddr).Port,
+			privateKey,
+		),
+	}
 	registry := registryTestUtils.CreateMockRegistry(t, nodes)
 	wsURL := anvil.StartAnvil(t, false)
 	contractsOptions := testutils.NewContractsOptions(t, wsURL)
 
 	server := serverTestUtils.NewTestServer(t, serverTestUtils.TestServerCfg{
-		Port:             grpcPort,
-		HttpPort:         httpPort,
+		GRPCListener:     grpcPort,
+		HTTPListener:     httpPort,
 		Db:               dbs[0],
 		Registry:         registry,
 		PrivateKey:       privateKey,

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -185,9 +185,15 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks) {
 
 	grpcListener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = grpcListener.Close()
+	})
 
 	httpListener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = httpListener.Close()
+	})
 
 	svr, err := api.NewAPIServer(
 		api.WithContext(ctx),

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -182,11 +183,17 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks) {
 		return nil
 	}
 
+	grpcListener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	httpListener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
 	svr, err := api.NewAPIServer(
 		api.WithContext(ctx),
 		api.WithLogger(log),
-		api.WithHTTPListenAddress("localhost:0"),
-		api.WithListenAddress("localhost:0"),
+		api.WithGRPCListener(grpcListener),
+		api.WithHTTPListener(httpListener),
 		api.WithJWTVerifier(jwtVerifier),
 		api.WithRegistrationFunc(serviceRegistrationFunc),
 		api.WithHTTPRegistrationFunc(httpRegistrationFunc),

--- a/pkg/testutils/network/port.go
+++ b/pkg/testutils/network/port.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func FindFreePort(t *testing.T) int {
+func OpenFreePort(t *testing.T) net.Listener {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer func() {
+	t.Cleanup(func() {
 		_ = ln.Close()
-	}()
-	return ln.Addr().(*net.TCPAddr).Port
+	})
+	return ln
 }

--- a/pkg/testutils/server/server.go
+++ b/pkg/testutils/server/server.go
@@ -4,7 +4,7 @@ import (
 	"crypto/ecdsa"
 	"database/sql"
 	"encoding/hex"
-	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -23,8 +23,8 @@ type EnabledServices struct {
 }
 
 type TestServerCfg struct {
-	Port             int
-	HttpPort         int
+	GRPCListener     net.Listener
+	HTTPListener     net.Listener
 	Db               *sql.DB
 	Registry         r.NodeRegistry
 	PrivateKey       *ecdsa.PrivateKey
@@ -43,8 +43,8 @@ func NewTestServer(
 		s.WithDB(cfg.Db),
 		s.WithNodeRegistry(cfg.Registry),
 		s.WithServerVersion(testutils.GetLatestVersion(t)),
-		s.WithListenAddress(fmt.Sprintf("localhost:%d", cfg.Port)),
-		s.WithHTTPListenAddress(fmt.Sprintf("localhost:%d", cfg.HttpPort)),
+		s.WithGRPCListener(cfg.GRPCListener),
+		s.WithHTTPListener(cfg.HTTPListener),
 		s.WithServerOptions(&config.ServerOptions{
 			Contracts: cfg.ContractsOptions,
 			MlsValidation: config.MlsValidationOptions{
@@ -52,10 +52,6 @@ func NewTestServer(
 			},
 			Signer: config.SignerOptions{
 				PrivateKey: hex.EncodeToString(crypto.FromECDSA(cfg.PrivateKey)),
-			},
-			API: config.ApiOptions{
-				Port:     cfg.Port,
-				HTTPPort: cfg.HttpPort,
 			},
 			Sync: config.SyncOptions{
 				Enable: cfg.Services.Sync,


### PR DESCRIPTION
Some of our tests fail because there is a timing gap between our test discovering a socket, and the test actually using the socket. This refactor discovers a socket and keeps the listener open until it is time to properly close it.