### PR TITLE
Skip attestation test until a fix is found

### DIFF
--- a/pkg/payerreport/workers/integration_test.go
+++ b/pkg/payerreport/workers/integration_test.go
@@ -396,6 +396,7 @@ func TestCanGenerateReport(t *testing.T) {
 }
 
 func TestCanGenerateAndAttestReport(t *testing.T) {
+	t.Skip("This test is flaky. See https://github.com/xmtp/xmtpd/issues/913")
 	scaffold := setupMultiNodeTest(t)
 	groupID := testutils.RandomGroupID()
 	messageTopic := topic.NewTopic(topic.TOPIC_KIND_GROUP_MESSAGES_V1, groupID[:]).Bytes()


### PR DESCRIPTION
Fails frequently locally. Almost all the time in CI. Re-running test is tedious. Disabling until resolved (https://github.com/xmtp/xmtpd/issues/913)