### PR TITLE
Indexer updates backfill progress on no logs

### DIFF
--- a/pkg/indexer/app_chain/contracts/group_message.go
+++ b/pkg/indexer/app_chain/contracts/group_message.go
@@ -2,7 +2,6 @@ package contracts
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -98,8 +97,8 @@ func groupMessageBroadcasterContract(
 	)
 }
 
-func GroupMessageBroadcasterName(chainID int) string {
-	return fmt.Sprintf("%s-%v", groupMessageName, chainID)
+func (gm *GroupMessageBroadcaster) ID(chainID int) string {
+	return c.ID(groupMessageName, chainID)
 }
 
 func groupMessageBroadcasterTopic() (common.Hash, error) {

--- a/pkg/indexer/app_chain/contracts/identity_update.go
+++ b/pkg/indexer/app_chain/contracts/identity_update.go
@@ -3,7 +3,6 @@ package contracts
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -103,8 +102,8 @@ func identityUpdateBroadcasterContract(
 	)
 }
 
-func IdentityUpdateBroadcasterName(chainID int) string {
-	return fmt.Sprintf("%s-%v", identityUpdateName, chainID)
+func (iu *IdentityUpdateBroadcaster) ID(chainID int) string {
+	return c.ID(identityUpdateName, chainID)
 }
 
 func identityUpdateBroadcasterTopic() (common.Hash, error) {

--- a/pkg/indexer/common/interface.go
+++ b/pkg/indexer/common/interface.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -16,12 +17,12 @@ type ILogStreamer interface {
 	Stop()
 }
 
-// Takes a log event and stores it, returning either an error that may be retriable, non-retriable, or nil.
+// ILogStorer stores logs, returning either an error that may be retriable, non-retriable, or nil.
 type ILogStorer interface {
 	StoreLog(ctx context.Context, event types.Log) re.RetryableError
 }
 
-// Tracks the latest block number and hash for a contract.
+// IBlockTracker tracks the latest block number and hash for a contract.
 type IBlockTracker interface {
 	GetLatestBlock() (uint64, []byte)
 	UpdateLatestBlock(ctx context.Context, block uint64, hash []byte) error
@@ -39,4 +40,9 @@ type IContract interface {
 	Address() common.Address
 	Topics() []common.Hash
 	Logger() *zap.Logger
+	ID(chainID int) string
+}
+
+func ID(name string, chainID int) string {
+	return fmt.Sprintf("%s-%v", name, chainID)
 }

--- a/pkg/indexer/settlement_chain/contracts/payer_registry.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_registry.go
@@ -2,7 +2,6 @@ package contracts
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -105,8 +104,8 @@ func payerRegistryContract(
 	)
 }
 
-func PayerRegistryName(chainID int) string {
-	return fmt.Sprintf("%s-%v", payerRegistryName, chainID)
+func (pr *PayerRegistry) ID(chainID int) string {
+	return c.ID(payerRegistryName, chainID)
 }
 
 func payerRegistryTopics() ([]common.Hash, error) {

--- a/pkg/indexer/settlement_chain/contracts/payer_report_manager.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_report_manager.go
@@ -2,7 +2,6 @@ package contracts
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -103,8 +102,8 @@ func payerReportManagerContract(
 	)
 }
 
-func PayerReportManagerName(chainID int) string {
-	return fmt.Sprintf("%s-%v", payerReportManagerName, chainID)
+func (p *PayerReportManager) ID(chainID int) string {
+	return c.ID(payerReportManagerName, chainID)
 }
 
 func payerReportManagerTopics() ([]common.Hash, error) {

--- a/pkg/indexer/settlement_chain/settlement_chain.go
+++ b/pkg/indexer/settlement_chain/settlement_chain.go
@@ -69,8 +69,6 @@ func NewSettlementChain(
 		return nil, err
 	}
 
-	payerRegistryLatestBlockNumber, payerRegistryLatestBlockHash := payerRegistry.GetLatestBlock()
-
 	payerReportManager, err := contracts.NewPayerReportManager(
 		ctxwc,
 		client,
@@ -86,30 +84,22 @@ func NewSettlementChain(
 		return nil, err
 	}
 
-	payerReportManagerLatestBlockNumber, payerReportManagerLatestBlockHash := payerReportManager.GetLatestBlock()
-
-	streamer, err := streamer.NewRpcLogStreamer(
+	streamer, err := streamer.NewRPCLogStreamer(
 		ctxwc,
 		client,
 		chainLogger,
 		streamer.WithLagFromHighestBlock(lagFromHighestBlock),
 		streamer.WithContractConfig(
 			&streamer.ContractConfig{
-				ID:                contracts.PayerRegistryName(cfg.ChainID),
-				FromBlockNumber:   payerRegistryLatestBlockNumber,
-				FromBlockHash:     payerRegistryLatestBlockHash,
-				Address:           payerRegistry.Address(),
-				Topics:            payerRegistry.Topics(),
+				ID:                payerRegistry.ID(cfg.ChainID),
+				Contract:          payerRegistry,
 				MaxDisconnectTime: cfg.MaxChainDisconnectTime,
 			},
 		),
 		streamer.WithContractConfig(
 			&streamer.ContractConfig{
-				ID:                contracts.PayerReportManagerName(cfg.ChainID),
-				FromBlockNumber:   payerReportManagerLatestBlockNumber,
-				FromBlockHash:     payerReportManagerLatestBlockHash,
-				Address:           payerReportManager.Address(),
-				Topics:            payerReportManager.Topics(),
+				ID:                payerReportManager.ID(cfg.ChainID),
+				Contract:          payerReportManager,
 				MaxDisconnectTime: cfg.MaxChainDisconnectTime,
 			},
 		),
@@ -184,9 +174,9 @@ func (s *SettlementChain) Stop() {
 }
 
 func (s *SettlementChain) PayerRegistryEventChannel() <-chan types.Log {
-	return s.streamer.GetEventChannel(contracts.PayerRegistryName(s.chainID))
+	return s.streamer.GetEventChannel(s.payerRegistry.ID(s.chainID))
 }
 
 func (s *SettlementChain) PayerReportManagerEventChannel() <-chan types.Log {
-	return s.streamer.GetEventChannel(contracts.PayerReportManagerName(s.chainID))
+	return s.streamer.GetEventChannel(s.payerReportManager.ID(s.chainID))
 }

--- a/pkg/mocks/common/mock_IContract.go
+++ b/pkg/mocks/common/mock_IContract.go
@@ -182,6 +182,52 @@ func (_c *MockIContract_HandleLog_Call) RunAndReturn(run func(context.Context, t
 	return _c
 }
 
+// ID provides a mock function with given fields: chainID
+func (_m *MockIContract) ID(chainID int) string {
+	ret := _m.Called(chainID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ID")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(int) string); ok {
+		r0 = rf(chainID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockIContract_ID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ID'
+type MockIContract_ID_Call struct {
+	*mock.Call
+}
+
+// ID is a helper method to define mock.On call
+//   - chainID int
+func (_e *MockIContract_Expecter) ID(chainID interface{}) *MockIContract_ID_Call {
+	return &MockIContract_ID_Call{Call: _e.mock.On("ID", chainID)}
+}
+
+func (_c *MockIContract_ID_Call) Run(run func(chainID int)) *MockIContract_ID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int))
+	})
+	return _c
+}
+
+func (_c *MockIContract_ID_Call) Return(_a0 string) *MockIContract_ID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockIContract_ID_Call) RunAndReturn(run func(int) string) *MockIContract_ID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Logger provides a mock function with no fields
 func (_m *MockIContract) Logger() *zap.Logger {
 	ret := _m.Called()


### PR DESCRIPTION
### Refactor indexer to update backfill progress on no logs by replacing static contract functions with object-oriented contract interface methods in RPCLogStreamer
The indexer components are refactored to use an object-oriented approach where contract objects implement the `IContract` interface instead of using static functions for contract identification and configuration. The changes include:

- Modified [rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) to accept contract objects through `ContractConfig.Contract` field instead of explicit block numbers, addresses, and topics, and added logic to update contract backfill progress when no logs are found
- Updated contract structs in [group_message.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-021a10a3349ce1a64a9afdf17c98b62e27b5cd2fc57e456e48f1c353fc79e47c), [identity_update.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-8d2f98c8ea96ab4fc3ec6e8b1e6fdaeb58bc05c0adda9ebfe8087b0c1df6d326), [payer_registry.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-1bf2fe0a2cfb5086289b10bb02cf6523e12eb52a91ff6f0667f508e467db0439), and [payer_report_manager.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-52141b78faed81893f4463ad0448a460fc7661d1641ed0ecd3d6dc6eb5f6d451) to implement `ID(chainID int) string` method instead of static naming functions
- Added `ID(chainID int) string` method to `IContract` interface in [interface.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-5cfd089dbe44085371c83acdae4a3de5a7ae9dbda09816f29adf96eafd6f4e34) with common implementation function
- Updated indexer initialization in [app_chain.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-a7396f85c51783c1d2690996fe8f2f2497869b03255b30a029cea4ec0eb1e7b3) and [settlement_chain.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-8b9b2747589f71d073557eb548618c3d85483288b54c070c4827567dee7c0257) to pass contract objects directly to `RPCLogStreamer` instead of manually extracting block information

#### 📍Where to Start
Start with the `watchContract` method in [rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/917/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) to understand how the streamer now retrieves block information from contract objects and updates backfill progress.

----

_[Macroscope](https://app.macroscope.com) summarized d4fcd95._