### PR TITLE
Check for closed channel

### DIFF
--- a/pkg/sync/originatorStream.go
+++ b/pkg/sync/originatorStream.go
@@ -87,7 +87,12 @@ func (s *originatorStream) listen() error {
 			select {
 			case <-s.ctx.Done():
 				return
-			case env := <-writeQueue:
+			case env, ok := <-writeQueue:
+				if !ok {
+					s.log.Error("writeQueue is closed")
+					return
+				}
+
 				if env == nil {
 					continue
 				}


### PR DESCRIPTION
### Check for closed channel in originatorStream.listen method to handle writeQueue channel closure
The code adds error handling for closed channel detection in the `originatorStream.listen` method within [pkg/sync/originatorStream.go](https://github.com/xmtp/xmtpd/pull/920/files#diff-ef2c8eedfaea0d04082c5ce6c5835dc2a0886632e5eb547ca5c79e01b12cd6a2). The modification introduces a second return value check when receiving from the `writeQueue` channel to detect if the channel is closed, and logs an error message before terminating the goroutine when closure is detected.

#### 📍Where to Start
Start with the `originatorStream.listen` method in [pkg/sync/originatorStream.go](https://github.com/xmtp/xmtpd/pull/920/files#diff-ef2c8eedfaea0d04082c5ce6c5835dc2a0886632e5eb547ca5c79e01b12cd6a2).

----

_[Macroscope](https://app.macroscope.com) summarized e7028b9._