### PR TITLE
Check closed channels

### DIFF
--- a/pkg/api/message/publishWorker.go
+++ b/pkg/api/message/publishWorker.go
@@ -94,7 +94,12 @@ func (p *publishWorker) start() {
 		select {
 		case <-p.ctx.Done():
 			return
-		case new_batch := <-p.listener:
+		case new_batch, ok := <-p.listener:
+			if !ok {
+				p.log.Error("listener is closed")
+				return
+			}
+
 			for _, stagedEnv := range new_batch {
 				p.log.Info("publishing envelope", zap.Int64("sequenceID", stagedEnv.ID))
 				for !p.publishStagedEnvelope(stagedEnv) {

--- a/pkg/api/message/subscribeWorker.go
+++ b/pkg/api/message/subscribeWorker.go
@@ -210,7 +210,12 @@ func (s *subscribeWorker) start() {
 		select {
 		case <-s.ctx.Done():
 			return
-		case new_batch := <-s.dbSubscription:
+		case new_batch, ok := <-s.dbSubscription:
+			if !ok {
+				s.log.Error("dbSubscription is closed")
+				return
+			}
+
 			s.log.Debug("Received new batch", zap.Int("numEnvelopes", len(new_batch)))
 			envs := make([]*envelopes.OriginatorEnvelope, 0, len(new_batch))
 			for _, row := range new_batch {

--- a/pkg/api/payer/nodeCursorTracker.go
+++ b/pkg/api/payer/nodeCursorTracker.go
@@ -95,7 +95,14 @@ func (ct *NodeCursorTracker) BlockUntilDesiredCursorReached(
 				"Wait for cursor was unsuccessful after %s",
 				time.Since(start),
 			)
-		case err := <-errCh:
+		case err, ok := <-errCh:
+			if !ok {
+				return status.Errorf(
+					codes.Internal,
+					"error getting node cursor: error channel closed",
+				)
+			}
+
 			if errors.Is(ctx.Err(), context.Canceled) {
 				return nil
 			}
@@ -103,7 +110,14 @@ func (ct *NodeCursorTracker) BlockUntilDesiredCursorReached(
 				return status.Errorf(codes.Aborted, "node terminated. Cancelled wait for cursor")
 			}
 			return err
-		case resp := <-respCh:
+		case resp, ok := <-respCh:
+			if !ok {
+				return status.Errorf(
+					codes.Internal,
+					"error getting node cursor: response channel closed",
+				)
+			}
+
 			if resp == nil || resp.LatestSync == nil {
 				return status.Errorf(codes.Internal, "error getting node cursor: response is nil")
 			}

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -257,7 +257,12 @@ func (s *syncWorker) setupNodeRegistration(
 				// this indicates that the node is shutting down
 				// the notifierCtx should have been shut down already,but it can't hurt to cancel it just in case
 				notifierCancel()
-			case <-registryChan:
+			case _, ok := <-registryChan:
+				if !ok {
+					s.log.Error("registryChan is closed")
+					return
+				}
+
 				// this indicates that the registry has changed, and we need to rebuild the connection
 				s.log.Info(
 					"Node has been updated in the registry, terminating and rebuilding...",


### PR DESCRIPTION
### Add channel closure detection to prevent panics when reading from closed channels in message workers, payer tracker, and sync components
The changes add channel closure detection across multiple components to handle closed channel scenarios gracefully:

- Modified `publishWorker.start()` method in [publishWorker.go](https://github.com/xmtp/xmtpd/pull/921/files#diff-cd2a58705d7eacdaf32fc6b4148beb71638e391186b9682bd0c678a91362ce7b) to check if `p.listener` channel is closed and log error before returning
- Modified `subscribeWorker.start()` method in [subscribeWorker.go](https://github.com/xmtp/xmtpd/pull/921/files#diff-a73ab8897a790989a2033ac2677ef15a461f5f7428d91e5ae576461f20919c83) to check if `s.dbSubscription` channel is closed and log error before returning  
- Modified `BlockUntilDesiredCursorReached()` method in [nodeCursorTracker.go](https://github.com/xmtp/xmtpd/pull/921/files#diff-53bc52b24f8bd6ebdbf96bf10c2fe152f927d6c8c0487f89e3e94d73a31b7e74) to check if `errCh` and `respCh` channels are closed and return Internal status errors
- Modified `originatorStream.listen()` method in [originatorStream.go](https://github.com/xmtp/xmtpd/pull/921/files#diff-ef2c8eedfaea0d04082c5ce6c5835dc2a0886632e5eb547ca5c79e01b12cd6a2) to check if `writeQueue`, `recvChan`, and `errChan` channels are closed and handle with error logging and permanent errors
- Modified `setupNodeRegistration()` goroutine in [syncWorker.go](https://github.com/xmtp/xmtpd/pull/921/files#diff-e977881a181cfedab87b22f76500ad9a52546c1a942c48b2a780dee62422e691) to check if `registryChan` channel is closed and log error before returning

#### 📍Where to Start
Start with the `start()` method in [publishWorker.go](https://github.com/xmtp/xmtpd/pull/921/files#diff-cd2a58705d7eacdaf32fc6b4148beb71638e391186b9682bd0c678a91362ce7b) to see the pattern of channel closure detection that is applied across all modified components.

----

_[Macroscope](https://app.macroscope.com) summarized c319861._