### PR TITLE
Print the data we need for out-of-order errors

### DIFF
--- a/pkg/sync/originatorStream.go
+++ b/pkg/sync/originatorStream.go
@@ -208,9 +208,12 @@ func (s *originatorStream) validateEnvelope(
 	if env.OriginatorSequenceID() != lastSequenceID+1 || env.OriginatorNs() < lastNs {
 		// TODO(rich) Submit misbehavior report and continue
 		s.log.Error(
-			"Received out of order envelope",
-			zap.Any("envelope", env),
-			zap.Any("lastEnvelope", s.lastEnvelope),
+			"Received out-of-order envelope",
+			zap.Uint64("expectedSequenceID", lastSequenceID+1),
+			zap.Uint64("actualSequenceID", env.OriginatorSequenceID()),
+			zap.Int64("lastTimestampNs", lastNs),
+			zap.Int64("actualTimestampNs", env.OriginatorNs()),
+			zap.Uint32("originatorId", env.OriginatorNodeID()),
 		)
 	}
 


### PR DESCRIPTION
Our existing logging such as 
```

{
--
 
caller | replication.syncWorker

{
caller	
replication.syncWorker

envelope
{

UnsignedOriginatorEnvelope
{

PayerEnvelope
{
TargetOriginator	
100
}
}
}
http_address	
https://grpc.testnet-dev.xmtp.network/

lastEnvelope
{

UnsignedOriginatorEnvelope
{

PayerEnvelope
{
TargetOriginator	
100
}
}
}
level	
ERROR
originator_id	
100
service	
xmtpd-server-sync
source	
stdout
timestamp	
1750968572803
}
```

was useless