### PR TITLE
Separate DB worker from sync

### DIFF
--- a/pkg/sync/envelopeSink.go
+++ b/pkg/sync/envelopeSink.go
@@ -1,0 +1,247 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/xmtp/xmtpd/pkg/currency"
+	"github.com/xmtp/xmtpd/pkg/db"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
+	envUtils "github.com/xmtp/xmtpd/pkg/envelopes"
+	"github.com/xmtp/xmtpd/pkg/fees"
+	"github.com/xmtp/xmtpd/pkg/payerreport"
+	"github.com/xmtp/xmtpd/pkg/topic"
+	"github.com/xmtp/xmtpd/pkg/utils"
+	"go.uber.org/zap"
+)
+
+type EnvelopeSink struct {
+	ctx                        context.Context
+	db                         *sql.DB
+	log                        *zap.Logger
+	queries                    *queries.Queries
+	feeCalculator              fees.IFeeCalculator
+	payerReportStore           payerreport.IPayerReportStore
+	payerReportDomainSeparator common.Hash
+	writeQueue                 chan *envUtils.OriginatorEnvelope
+}
+
+func newEnvelopeSink(
+	ctx context.Context,
+	db *sql.DB,
+	log *zap.Logger,
+	feeCalculator fees.IFeeCalculator,
+	payerReportStore payerreport.IPayerReportStore,
+	payerReportDomainSeparator common.Hash,
+	writeQueue chan *envUtils.OriginatorEnvelope,
+) *EnvelopeSink {
+	return &EnvelopeSink{
+		ctx:                        ctx,
+		db:                         db,
+		log:                        log,
+		queries:                    queries.New(db),
+		feeCalculator:              feeCalculator,
+		payerReportStore:           payerReportStore,
+		payerReportDomainSeparator: payerReportDomainSeparator,
+		writeQueue:                 writeQueue,
+	}
+}
+
+func (s *EnvelopeSink) Start() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case env, ok := <-s.writeQueue:
+			if !ok {
+				s.log.Debug("writeQueue is closed")
+				return
+			}
+
+			if env == nil {
+				continue
+			}
+
+		storeLoop:
+			for {
+				select {
+				case <-s.ctx.Done():
+					return
+				default:
+					err := s.storeEnvelope(env)
+					if err != nil {
+						s.log.Error("error storing envelope", zap.Error(err))
+						time.Sleep(1 * time.Second)
+						continue
+					}
+					break storeLoop
+				}
+			}
+		}
+	}
+}
+
+func (s *EnvelopeSink) storeEnvelope(env *envUtils.OriginatorEnvelope) error {
+	if env.TargetTopic().IsReserved() {
+		s.log.Info(
+			"Found envelope with reserved topic",
+			zap.String("topic", env.TargetTopic().String()),
+		)
+		return s.storeReservedEnvelope(env)
+	}
+
+	// Calculate the fees independently to verify the originator's calculation
+	ourFeeCalculation, err := s.calculateFees(env)
+	if err != nil {
+		s.log.Error("Failed to calculate fees", zap.Error(err))
+		return err
+	}
+	originatorsFeeCalculation := env.UnsignedOriginatorEnvelope.BaseFee() +
+		env.UnsignedOriginatorEnvelope.CongestionFee()
+
+	if ourFeeCalculation != originatorsFeeCalculation {
+		s.log.Warn(
+			"Fee calculation mismatch",
+			zap.Any("ourFee", ourFeeCalculation),
+			zap.Any("originatorsFee", originatorsFeeCalculation),
+		)
+	}
+
+	// If for some reason the envelope is not able to marshal (but has made it this far)
+	// the node will retry indefinitely.
+	// I don't think this will ever happen
+	originatorBytes, err := env.Bytes()
+	if err != nil {
+		s.log.Error("Failed to marshal originator envelope", zap.Error(err))
+		return err
+	}
+
+	// The payer address has already been validated, so any errors here should be transient
+	payerId, err := s.getPayerID(env)
+	if err != nil {
+		s.log.Error("Failed to get payer ID", zap.Error(err))
+		return err
+	}
+
+	originatorID := int32(env.OriginatorNodeID())
+	originatorTime := utils.NsToDate(env.OriginatorNs())
+	expiry := env.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime()
+	var expiryToSave sql.NullInt64
+	if expiry > 0 {
+		expiryToSave = db.NullInt64(int64(expiry))
+	}
+
+	inserted, err := db.InsertGatewayEnvelopeAndIncrementUnsettledUsage(
+		s.ctx,
+		s.db,
+		queries.InsertGatewayEnvelopeParams{
+			OriginatorNodeID:     int32(env.OriginatorNodeID()),
+			OriginatorSequenceID: int64(env.OriginatorSequenceID()),
+			Topic:                env.TargetTopic().Bytes(),
+			OriginatorEnvelope:   originatorBytes,
+			PayerID:              db.NullInt32(payerId),
+			Expiry:               expiryToSave,
+		},
+		queries.IncrementUnsettledUsageParams{
+			PayerID:           payerId,
+			OriginatorID:      originatorID,
+			MinutesSinceEpoch: utils.MinutesSinceEpoch(originatorTime),
+			SpendPicodollars:  int64(ourFeeCalculation),
+		},
+	)
+
+	if err != nil {
+		s.log.Error("Failed to insert gateway envelope", zap.Error(err))
+		return err
+	} else if inserted == 0 {
+		// Envelope was already inserted by another worker
+		s.log.Debug("Envelope already inserted", zap.Uint32("originatorID", env.OriginatorNodeID()), zap.Uint64("sequenceID", env.OriginatorSequenceID()))
+		return nil
+	}
+
+	return nil
+}
+
+func (s *EnvelopeSink) storeReservedEnvelope(env *envUtils.OriginatorEnvelope) error {
+	payerID, err := s.getPayerID(env)
+	if err != nil {
+		s.log.Error("Failed to get payer ID", zap.Error(err))
+		return err
+	}
+
+	switch env.TargetTopic().Kind() {
+	case topic.TOPIC_KIND_PAYER_REPORTS_V1:
+		err := s.payerReportStore.StoreSyncedReport(
+			s.ctx,
+			env,
+			payerID,
+			s.payerReportDomainSeparator,
+		)
+		if err != nil {
+			s.log.Error("Failed to store synced report", zap.Error(err))
+			// Return nil here to avoid infinite retries
+		}
+		return nil
+	case topic.TOPIC_KIND_PAYER_REPORT_ATTESTATIONS_V1:
+		err := s.payerReportStore.StoreSyncedAttestation(
+			s.ctx,
+			env,
+			payerID,
+		)
+		if err != nil {
+			s.log.Error("Failed to store synced attestation", zap.Error(err))
+			// Return nil here to avoid infinite retries
+		}
+		return nil
+	default:
+		s.log.Info(
+			"Received unknown reserved topic",
+			zap.String("topic", env.TargetTopic().String()),
+		)
+		return nil
+	}
+}
+
+func (s *EnvelopeSink) calculateFees(
+	env *envUtils.OriginatorEnvelope,
+) (currency.PicoDollar, error) {
+	payerEnvelopeLength := len(env.UnsignedOriginatorEnvelope.PayerEnvelopeBytes())
+	messageTime := utils.NsToDate(env.OriginatorNs())
+
+	baseFee, err := s.feeCalculator.CalculateBaseFee(
+		messageTime,
+		int64(payerEnvelopeLength),
+		env.UnsignedOriginatorEnvelope.PayerEnvelope.RetentionDays(),
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	congestionFee, err := s.feeCalculator.CalculateCongestionFee(
+		s.ctx,
+		s.queries,
+		messageTime,
+		env.OriginatorNodeID(),
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return baseFee + congestionFee, nil
+}
+
+func (s *EnvelopeSink) getPayerID(env *envUtils.OriginatorEnvelope) (int32, error) {
+	payerAddress, err := env.UnsignedOriginatorEnvelope.PayerEnvelope.RecoverSigner()
+	if err != nil {
+		return 0, err
+	}
+
+	payerId, err := s.queries.FindOrCreatePayer(s.ctx, payerAddress.Hex())
+	if err != nil {
+		return 0, err
+	}
+
+	return payerId, nil
+}

--- a/pkg/sync/originatorStream.go
+++ b/pkg/sync/originatorStream.go
@@ -2,75 +2,54 @@ package sync
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/xmtp/xmtpd/pkg/currency"
-	"github.com/xmtp/xmtpd/pkg/db"
-	"github.com/xmtp/xmtpd/pkg/db/queries"
 	envUtils "github.com/xmtp/xmtpd/pkg/envelopes"
-	"github.com/xmtp/xmtpd/pkg/fees"
 	"github.com/xmtp/xmtpd/pkg/metrics"
-	"github.com/xmtp/xmtpd/pkg/payerreport"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
 	"github.com/xmtp/xmtpd/pkg/registry"
-	"github.com/xmtp/xmtpd/pkg/topic"
-	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 )
 
 type originatorStream struct {
-	ctx                        context.Context
-	db                         *sql.DB
-	log                        *zap.Logger
-	node                       *registry.Node
-	queries                    *queries.Queries
-	lastEnvelope               *envUtils.OriginatorEnvelope
-	stream                     message_api.ReplicationApi_SubscribeEnvelopesClient
-	feeCalculator              fees.IFeeCalculator
-	payerReportStore           payerreport.IPayerReportStore
-	payerReportDomainSeparator common.Hash
+	ctx          context.Context
+	log          *zap.Logger
+	node         *registry.Node
+	lastEnvelope *envUtils.OriginatorEnvelope
+	stream       message_api.ReplicationApi_SubscribeEnvelopesClient
+	writeQueue   chan *envUtils.OriginatorEnvelope
 }
 
 func newOriginatorStream(
 	ctx context.Context,
-	db *sql.DB,
 	log *zap.Logger,
 	node *registry.Node,
 	lastEnvelope *envUtils.OriginatorEnvelope,
 	stream message_api.ReplicationApi_SubscribeEnvelopesClient,
-	feeCalculator fees.IFeeCalculator,
-	payerReportStore payerreport.IPayerReportStore,
-	payerReportDomainSeparator common.Hash,
+	writeQueue chan *envUtils.OriginatorEnvelope,
 ) *originatorStream {
 	return &originatorStream{
 		ctx: ctx,
-		db:  db,
 		log: log.With(
 			zap.Uint32("originator_id", node.NodeID),
 			zap.String("http_address", node.HttpAddress),
 		),
-		node:                       node,
-		queries:                    queries.New(db),
-		lastEnvelope:               lastEnvelope,
-		stream:                     stream,
-		feeCalculator:              feeCalculator,
-		payerReportStore:           payerReportStore,
-		payerReportDomainSeparator: payerReportDomainSeparator,
+		node:         node,
+		lastEnvelope: lastEnvelope,
+		stream:       stream,
+		writeQueue:   writeQueue,
 	}
 }
 
 func (s *originatorStream) listen() error {
 	recvChan := make(chan *message_api.SubscribeEnvelopesResponse)
-	errChan := make(chan error)
-	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	errChan := make(chan error, 1)
 
+	// Reader routine, responsible for reading from a blocking GRPC channel
 	go func() {
 		for {
 			envs, err := s.stream.Recv()
@@ -82,42 +61,7 @@ func (s *originatorStream) listen() error {
 		}
 	}()
 
-	go func() {
-		for {
-			select {
-			case <-s.ctx.Done():
-				return
-			case env, ok := <-writeQueue:
-				if !ok {
-					s.log.Error("writeQueue is closed")
-					return
-				}
-
-				if env == nil {
-					continue
-				}
-
-			storeLoop:
-				for {
-					select {
-					case <-s.ctx.Done():
-						return
-					default:
-						err := s.storeEnvelope(env)
-						if err != nil {
-							s.log.Error("error storing envelope", zap.Error(err))
-							time.Sleep(1 * time.Second)
-							continue
-						}
-						break storeLoop
-					}
-				}
-			}
-		}
-	}()
-
-	defer close(writeQueue)
-
+	// main routine, responsible for processing and validating messages
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -140,7 +84,7 @@ func (s *originatorStream) listen() error {
 					s.log.Error("discarding envelope after validation failed", zap.Error(err))
 					continue
 				}
-				writeQueue <- parsedEnv
+				s.writeQueue <- parsedEnv
 			}
 
 		case err := <-errChan:
@@ -226,167 +170,4 @@ func (s *originatorStream) validateEnvelope(
 	}
 
 	return env, nil
-}
-
-func (s *originatorStream) storeEnvelope(env *envUtils.OriginatorEnvelope) error {
-	if env.TargetTopic().IsReserved() {
-		s.log.Info(
-			"Found envelope with reserved topic",
-			zap.String("topic", env.TargetTopic().String()),
-		)
-		return s.storeReservedEnvelope(env)
-	}
-
-	// Calculate the fees independently to verify the originator's calculation
-	ourFeeCalculation, err := s.calculateFees(env)
-	if err != nil {
-		s.log.Error("Failed to calculate fees", zap.Error(err))
-		return err
-	}
-	originatorsFeeCalculation := env.UnsignedOriginatorEnvelope.BaseFee() +
-		env.UnsignedOriginatorEnvelope.CongestionFee()
-
-	if ourFeeCalculation != originatorsFeeCalculation {
-		s.log.Warn(
-			"Fee calculation mismatch",
-			zap.Any("ourFee", ourFeeCalculation),
-			zap.Any("originatorsFee", originatorsFeeCalculation),
-		)
-	}
-
-	// If for some reason the envelope is not able to marshal (but has made it this far)
-	// the node will retry indefinitely.
-	// I don't think this will ever happen
-	originatorBytes, err := env.Bytes()
-	if err != nil {
-		s.log.Error("Failed to marshal originator envelope", zap.Error(err))
-		return err
-	}
-
-	// The payer address has already been validated, so any errors here should be transient
-	payerId, err := s.getPayerID(env)
-	if err != nil {
-		s.log.Error("Failed to get payer ID", zap.Error(err))
-		return err
-	}
-
-	originatorID := int32(env.OriginatorNodeID())
-	originatorTime := utils.NsToDate(env.OriginatorNs())
-	expiry := env.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime()
-	var expiryToSave sql.NullInt64
-	if expiry > 0 {
-		expiryToSave = db.NullInt64(int64(expiry))
-	}
-
-	inserted, err := db.InsertGatewayEnvelopeAndIncrementUnsettledUsage(
-		s.ctx,
-		s.db,
-		queries.InsertGatewayEnvelopeParams{
-			OriginatorNodeID:     int32(env.OriginatorNodeID()),
-			OriginatorSequenceID: int64(env.OriginatorSequenceID()),
-			Topic:                env.TargetTopic().Bytes(),
-			OriginatorEnvelope:   originatorBytes,
-			PayerID:              db.NullInt32(payerId),
-			Expiry:               expiryToSave,
-		},
-		queries.IncrementUnsettledUsageParams{
-			PayerID:           payerId,
-			OriginatorID:      originatorID,
-			MinutesSinceEpoch: utils.MinutesSinceEpoch(originatorTime),
-			SpendPicodollars:  int64(ourFeeCalculation),
-		},
-	)
-
-	if err != nil {
-		s.log.Error("Failed to insert gateway envelope", zap.Error(err))
-		return err
-	} else if inserted == 0 {
-		// Envelope was already inserted by another worker
-		s.log.Debug("Envelope already inserted", zap.Uint32("originatorID", env.OriginatorNodeID()), zap.Uint64("sequenceID", env.OriginatorSequenceID()))
-		return nil
-	}
-
-	return nil
-}
-
-func (s *originatorStream) storeReservedEnvelope(env *envUtils.OriginatorEnvelope) error {
-	payerID, err := s.getPayerID(env)
-	if err != nil {
-		s.log.Error("Failed to get payer ID", zap.Error(err))
-		return err
-	}
-
-	switch env.TargetTopic().Kind() {
-	case topic.TOPIC_KIND_PAYER_REPORTS_V1:
-		err := s.payerReportStore.StoreSyncedReport(
-			s.ctx,
-			env,
-			payerID,
-			s.payerReportDomainSeparator,
-		)
-		if err != nil {
-			s.log.Error("Failed to store synced report", zap.Error(err))
-			// Return nil here to avoid infinite retries
-		}
-		return nil
-	case topic.TOPIC_KIND_PAYER_REPORT_ATTESTATIONS_V1:
-		err := s.payerReportStore.StoreSyncedAttestation(
-			s.ctx,
-			env,
-			payerID,
-		)
-		if err != nil {
-			s.log.Error("Failed to store synced attestation", zap.Error(err))
-			// Return nil here to avoid infinite retries
-		}
-		return nil
-	default:
-		s.log.Info(
-			"Received unknown reserved topic",
-			zap.String("topic", env.TargetTopic().String()),
-		)
-		return nil
-	}
-}
-
-func (s *originatorStream) calculateFees(
-	env *envUtils.OriginatorEnvelope,
-) (currency.PicoDollar, error) {
-	payerEnvelopeLength := len(env.UnsignedOriginatorEnvelope.PayerEnvelopeBytes())
-	messageTime := utils.NsToDate(env.OriginatorNs())
-
-	baseFee, err := s.feeCalculator.CalculateBaseFee(
-		messageTime,
-		int64(payerEnvelopeLength),
-		env.UnsignedOriginatorEnvelope.PayerEnvelope.RetentionDays(),
-	)
-	if err != nil {
-		return 0, err
-	}
-
-	congestionFee, err := s.feeCalculator.CalculateCongestionFee(
-		s.ctx,
-		s.queries,
-		messageTime,
-		env.OriginatorNodeID(),
-	)
-	if err != nil {
-		return 0, err
-	}
-
-	return baseFee + congestionFee, nil
-}
-
-func (s *originatorStream) getPayerID(env *envUtils.OriginatorEnvelope) (int32, error) {
-	payerAddress, err := env.UnsignedOriginatorEnvelope.PayerEnvelope.RecoverSigner()
-	if err != nil {
-		return 0, err
-	}
-
-	payerId, err := s.queries.FindOrCreatePayer(s.ctx, payerAddress.Hex())
-	if err != nil {
-		return 0, err
-	}
-
-	return payerId, nil
 }

--- a/pkg/sync/originatorStream_test.go
+++ b/pkg/sync/originatorStream_test.go
@@ -1,7 +1,9 @@
 package sync
 
 import (
+	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,37 +44,54 @@ func mockSubscriptionOnePage(
 	return stream
 }
 
+func newTestEnvelopeSink(
+	t *testing.T,
+	writeQueue chan *envUtils.OriginatorEnvelope,
+	ctx context.Context,
+) *EnvelopeSink {
+	log := testutils.NewLog(t)
+	calculator := feesTestUtils.NewTestFeeCalculator()
+	db, _ := testutils.NewDB(t, ctx)
+
+	return newEnvelopeSink(
+		ctx,
+		db,
+		log,
+		calculator,
+		payerreportMocks.NewMockIPayerReportStore(t),
+		payerReportDomainSeparator,
+		writeQueue,
+	)
+}
+
 func newTestOriginatorStream(
 	t *testing.T,
 	node *registry.Node,
 	stream message_api.ReplicationApi_SubscribeEnvelopesClient,
 	lastEnvelope *envUtils.OriginatorEnvelope,
+	writeQueue chan *envUtils.OriginatorEnvelope,
 ) *originatorStream {
 	log := testutils.NewLog(t)
-	calculator := feesTestUtils.NewTestFeeCalculator()
-	db, _ := testutils.NewDB(t, t.Context())
 
 	return newOriginatorStream(
 		t.Context(),
-		db,
 		log,
 		node,
 		lastEnvelope,
 		stream,
-		calculator,
-		payerreportMocks.NewMockIPayerReportStore(t),
-		payerReportDomainSeparator,
+		writeQueue,
 	)
 }
 
 func getAllMessagesForOriginator(
 	t *testing.T,
-	originatorStream *originatorStream,
+	storer *EnvelopeSink,
+	nodeID uint32,
 ) []queries.GatewayEnvelope {
-	envs, err := originatorStream.queries.SelectGatewayEnvelopes(
+	envs, err := storer.queries.SelectGatewayEnvelopes(
 		t.Context(),
 		queries.SelectGatewayEnvelopesParams{
-			OriginatorNodeIds: []int32{int32(originatorStream.node.NodeID)},
+			OriginatorNodeIds: []int32{int32(nodeID)},
 		},
 	)
 	require.NoError(t, err)
@@ -87,7 +106,13 @@ func TestSyncWorkerSuccess(t *testing.T) {
 
 	node := registryTestUtils.CreateNode(nodeID, 999, testutils.RandomPrivateKey(t))
 
-	origStream := newTestOriginatorStream(t, &node, stream, nil)
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	defer close(writeQueue)
+	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, t.Context())
+	go func() {
+		dbStorerInstance.Start()
+	}()
+	origStream := newTestOriginatorStream(t, &node, stream, nil, writeQueue)
 
 	err := origStream.listen()
 	var retryAfter *backoff.RetryAfterError
@@ -95,7 +120,7 @@ func TestSyncWorkerSuccess(t *testing.T) {
 	require.Equal(t, retryAfter.Duration.Seconds(), float64(1))
 
 	require.Eventually(t, func() bool {
-		envs := getAllMessagesForOriginator(t, origStream)
+		envs := getAllMessagesForOriginator(t, dbStorerInstance, nodeID)
 		return len(envs) == 1 && envs[0].OriginatorSequenceID == int64(sequenceID)
 	}, 1*time.Second, 50*time.Millisecond)
 }
@@ -113,7 +138,13 @@ func TestSyncWorkerIgnoresInvalidEnvelopes(t *testing.T) {
 	stream := mockSubscriptionOnePage(t, []*envelopes.OriginatorEnvelope{envelope})
 	node := registryTestUtils.CreateNode(nodeID, 999, testutils.RandomPrivateKey(t))
 
-	origStream := newTestOriginatorStream(t, &node, stream, nil)
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	defer close(writeQueue)
+	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, t.Context())
+	go func() {
+		dbStorerInstance.Start()
+	}()
+	origStream := newTestOriginatorStream(t, &node, stream, nil, writeQueue)
 
 	err := origStream.listen()
 	var retryAfter *backoff.RetryAfterError
@@ -121,6 +152,35 @@ func TestSyncWorkerIgnoresInvalidEnvelopes(t *testing.T) {
 
 	// Give the write worker a chance to save the envelope
 	time.Sleep(50 * time.Millisecond)
-	envs := getAllMessagesForOriginator(t, origStream)
+	envs := getAllMessagesForOriginator(t, dbStorerInstance, nodeID)
 	require.Len(t, envs, 0)
+}
+
+func TestEnvelopeSinkShutdownViaClose(t *testing.T) {
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, t.Context())
+	var wg sync.WaitGroup
+	go func() {
+		wg.Add(1)
+		dbStorerInstance.Start()
+	}()
+
+	close(writeQueue)
+	wg.Wait()
+}
+
+func TestEnvelopeSinkShutdownViaContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, ctx)
+	var wg sync.WaitGroup
+	go func() {
+		wg.Add(1)
+		dbStorerInstance.Start()
+	}()
+
+	cancel()
+
+	wg.Wait()
 }

--- a/pkg/sync/syncWorker.go
+++ b/pkg/sync/syncWorker.go
@@ -128,18 +128,37 @@ func (s *syncWorker) subscribeToNode(nodeid uint32) {
 
 	s.subscriptions[nodeid] = struct{}{}
 
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+
+	tracing.GoPanicWrap(
+		s.ctx,
+		&s.wg,
+		fmt.Sprintf("node-subscribe-%d-db", nodeid),
+		func(ctx context.Context) {
+			newEnvelopeSink(
+				ctx,
+				s.store,
+				s.log,
+				s.feeCalculator,
+				s.payerReportStore,
+				s.payerReportDomainSeparator,
+				writeQueue,
+			).Start()
+		})
+
 	tracing.GoPanicWrap(
 		s.ctx,
 		&s.wg,
 		fmt.Sprintf("node-subscribe-%d", nodeid),
 		func(ctx context.Context) {
+			defer close(writeQueue)
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				default:
 					config := s.setupNodeRegistration(ctx, nodeid)
-					s.subscribeToNodeRegistration(config)
+					s.subscribeToNodeRegistration(config, writeQueue)
 				}
 			}
 		})
@@ -147,6 +166,7 @@ func (s *syncWorker) subscribeToNode(nodeid uint32) {
 
 func (s *syncWorker) subscribeToNodeRegistration(
 	registration NodeRegistration,
+	writeQueue chan *envUtils.OriginatorEnvelope,
 ) {
 	connectionsStatusCounter := metrics.NewSyncConnectionsStatusCounter(registration.nodeid)
 	defer connectionsStatusCounter.Close()
@@ -207,7 +227,7 @@ func (s *syncWorker) subscribeToNodeRegistration(
 			return "", err
 		}
 
-		stream, err = s.setupStream(registration.ctx, *node, conn)
+		stream, err = s.setupStream(registration.ctx, *node, conn, writeQueue)
 		if err != nil {
 			return "", err
 		}
@@ -296,6 +316,7 @@ func (s *syncWorker) setupStream(
 	ctx context.Context,
 	node registry.Node,
 	conn *grpc.ClientConn,
+	writeQueue chan *envUtils.OriginatorEnvelope,
 ) (*originatorStream, error) {
 	result, err := queries.New(s.store).SelectVectorClock(ctx)
 	if err != nil {
@@ -345,13 +366,10 @@ func (s *syncWorker) setupStream(
 
 	return newOriginatorStream(
 		s.ctx,
-		s.store,
 		s.log,
 		&node,
 		lastEnvelope,
 		stream,
-		s.feeCalculator,
-		s.payerReportStore,
-		s.payerReportDomainSeparator,
+		writeQueue,
 	), nil
 }


### PR DESCRIPTION
The DB goroutine lifecycle was tied to the lifecycle of the GRPC connection. There were no guarantees that the DB conn won't outlive the main routine when being rebuilt. This could lead to concurrent DB writing coroutines, out-of-order writes and other nastiness.