### PR TITLE
Backfill page on sub error

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -20,7 +20,7 @@ type ContractsOptions struct {
 type AppChainOptions struct {
 	WssURL                           string        `long:"wss-url"                             env:"XMTPD_APP_CHAIN_WSS_URL"                           description:"Blockchain WSS URL"`
 	ChainID                          int           `long:"chain-id"                            env:"XMTPD_APP_CHAIN_CHAIN_ID"                          description:"Chain ID for the application chain"                           default:"31337"`
-	MaxChainDisconnectTime           time.Duration `long:"max-chain-disconnect-time"           env:"XMTPD_APP_CHAIN_MAX_CHAIN_DISCONNECT_TIME"         description:"Maximum time to allow the node to operate while disconnected" default:"300s"`
+	MaxChainDisconnectTime           time.Duration `long:"max-chain-disconnect-time"           env:"XMTPD_APP_CHAIN_MAX_CHAIN_DISCONNECT_TIME"         description:"Maximum time to allow the node to operate while disconnected" default:"60s"`
 	BackfillBlockPageSize            uint64        `long:"backfill-block-page-size"            env:"XMTPD_APP_CHAIN_BACKFILL_BLOCK_PAGE_SIZE"          description:"Maximal size of a backfill block page"                        default:"500"`
 	GroupMessageBroadcasterAddress   string        `long:"group-message-broadcaster-address"   env:"XMTPD_APP_CHAIN_GROUP_MESSAGE_BROADCAST_ADDRESS"   description:"Group message broadcaster contract address"`
 	IdentityUpdateBroadcasterAddress string        `long:"identity-update-broadcaster-address" env:"XMTPD_APP_CHAIN_IDENTITY_UPDATE_BROADCAST_ADDRESS" description:"Identity update broadcaster contract address"`

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -207,8 +207,17 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 				if err != nil {
 					switch err {
 					case ErrEndOfBackfill:
-						for _, log := range response.Logs {
-							cfg.eventChannel <- log
+						if response.NextBlockNumber != nil {
+							backfillFromBlockNumber = *response.NextBlockNumber
+							backfillFromBlockHash = response.NextBlockHash
+						}
+
+						if len(response.Logs) > 0 {
+							for _, log := range response.Logs {
+								cfg.eventChannel <- log
+							}
+						} else {
+							cfg.eventChannel <- c.NewUpdateProgressLog(backfillFromBlockNumber, backfillFromBlockHash)
 						}
 
 						logger.Info("Backfill complete, switching to subscription.")

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -189,10 +189,9 @@ backfillLoop:
 			logger.Error("Context cancelled, stopping watcher")
 			return
 
-		case err, open := <-sub.Err():
-			if !open {
-				logger.Error("subscription channel closed, closing watcher")
-				return
+		case err := <-sub.Err():
+			if err == nil {
+				continue
 			}
 
 			logger.Error("subscription error, rebuilding", zap.Error(err))
@@ -274,10 +273,9 @@ backfillLoop:
 			logger.Error("Context cancelled, stopping watcher")
 			return
 
-		case err, open := <-sub.Err():
-			if !open {
-				logger.Error("subscription channel closed, closing watcher")
-				return
+		case err := <-sub.Err():
+			if err == nil {
+				continue
 			}
 
 			logger.Error("subscription error, rebuilding", zap.Error(err))
@@ -287,6 +285,7 @@ backfillLoop:
 				return
 			}
 
+			logger.Info("backfilling page", zap.Uint64("fromBlock", backfillFromBlockNumber))
 			logs, err := r.backfillPage(r.ctx, cfg, backfillFromBlockNumber)
 			if err != nil {
 				logger.Error("failed to backfill page, closing", zap.Error(err))

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -288,6 +288,10 @@ backfillLoop:
 			logger.Info("backfilling page", zap.Uint64("fromBlock", backfillFromBlockNumber))
 			logs, err := r.backfillPage(r.ctx, cfg, backfillFromBlockNumber)
 			if err != nil {
+				if err == ErrEndOfBackfill {
+					continue
+				}
+
 				logger.Error("failed to backfill page, closing", zap.Error(err))
 				return
 			}


### PR DESCRIPTION
### Backfill page on subscription error by restructuring RPCLogStreamer error handling and reducing MaxChainDisconnectTime from 300s to 60s
- Restructures the `RPCLogStreamer.watchContract` method in [rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/947/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) to handle subscription errors within the main loop and restart backfill process when errors occur
- Reduces the default `MaxChainDisconnectTime` in `AppChainOptions` struct from 300s to 60s in [options.go](https://github.com/xmtp/xmtpd/pull/947/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c)
- Extracts subscription building logic into `buildSubscriptionWithBackoff` method and changes channel buffer size from hardcoded 100 to dynamic sizing based on expected logs per block

#### 📍Where to Start
Start with the `watchContract` method in [rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/947/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) to understand the restructured main loop and error handling logic.



#### Changes since #947 opened

- Modified backfill error handling in RPCLogStreamer.watchContract method [25da832]
----

_[Macroscope](https://app.macroscope.com) summarized 25da832._