### PR TITLE
GetVersion metadata endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ethereum/go-ethereum v1.16.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang-migrate/migrate/v4 v4.18.2
+	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.0
 	github.com/jackc/pgx/v5 v5.7.2
@@ -89,7 +90,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/pkg/mocks/metadata_api/mock_MetadataApiClient.go
+++ b/pkg/mocks/metadata_api/mock_MetadataApiClient.go
@@ -99,6 +99,80 @@ func (_c *MockMetadataApiClient_GetSyncCursor_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// GetVersion provides a mock function with given fields: ctx, in, opts
+func (_m *MockMetadataApiClient) GetVersion(ctx context.Context, in *metadata_api.GetVersionRequest, opts ...grpc.CallOption) (*metadata_api.GetVersionResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetVersion")
+	}
+
+	var r0 *metadata_api.GetVersionResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *metadata_api.GetVersionRequest, ...grpc.CallOption) (*metadata_api.GetVersionResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *metadata_api.GetVersionRequest, ...grpc.CallOption) *metadata_api.GetVersionResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata_api.GetVersionResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *metadata_api.GetVersionRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockMetadataApiClient_GetVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVersion'
+type MockMetadataApiClient_GetVersion_Call struct {
+	*mock.Call
+}
+
+// GetVersion is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *metadata_api.GetVersionRequest
+//   - opts ...grpc.CallOption
+func (_e *MockMetadataApiClient_Expecter) GetVersion(ctx interface{}, in interface{}, opts ...interface{}) *MockMetadataApiClient_GetVersion_Call {
+	return &MockMetadataApiClient_GetVersion_Call{Call: _e.mock.On("GetVersion",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *MockMetadataApiClient_GetVersion_Call) Run(run func(ctx context.Context, in *metadata_api.GetVersionRequest, opts ...grpc.CallOption)) *MockMetadataApiClient_GetVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*metadata_api.GetVersionRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockMetadataApiClient_GetVersion_Call) Return(_a0 *metadata_api.GetVersionResponse, _a1 error) *MockMetadataApiClient_GetVersion_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockMetadataApiClient_GetVersion_Call) RunAndReturn(run func(context.Context, *metadata_api.GetVersionRequest, ...grpc.CallOption) (*metadata_api.GetVersionResponse, error)) *MockMetadataApiClient_GetVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SubscribeSyncCursor provides a mock function with given fields: ctx, in, opts
 func (_m *MockMetadataApiClient) SubscribeSyncCursor(ctx context.Context, in *metadata_api.GetSyncCursorRequest, opts ...grpc.CallOption) (metadata_api.MetadataApi_SubscribeSyncCursorClient, error) {
 	_va := make([]interface{}, len(opts))

--- a/pkg/proto/openapi/xmtpv4/metadata_api/metadata_api.swagger.json
+++ b/pkg/proto/openapi/xmtpv4/metadata_api/metadata_api.swagger.json
@@ -88,6 +88,38 @@
           "MetadataApi"
         ]
       }
+    },
+    "/mls/v2/metadata/version": {
+      "post": {
+        "operationId": "MetadataApi_GetVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/metadata_apiGetVersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/metadata_apiGetVersionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "MetadataApi"
+        ]
+      }
     }
   },
   "definitions": {
@@ -99,6 +131,17 @@
       "properties": {
         "latestSync": {
           "$ref": "#/definitions/xmtpv4envelopesCursor"
+        }
+      }
+    },
+    "metadata_apiGetVersionRequest": {
+      "type": "object"
+    },
+    "metadata_apiGetVersionResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
         }
       }
     },

--- a/pkg/proto/xmtpv4/metadata_api/metadata_api.pb.go
+++ b/pkg/proto/xmtpv4/metadata_api/metadata_api.pb.go
@@ -105,6 +105,86 @@ func (x *GetSyncCursorResponse) GetLatestSync() *envelopes.Cursor {
 	return nil
 }
 
+type GetVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVersionRequest) Reset() {
+	*x = GetVersionRequest{}
+	mi := &file_xmtpv4_metadata_api_metadata_api_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVersionRequest) ProtoMessage() {}
+
+func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_xmtpv4_metadata_api_metadata_api_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVersionRequest.ProtoReflect.Descriptor instead.
+func (*GetVersionRequest) Descriptor() ([]byte, []int) {
+	return file_xmtpv4_metadata_api_metadata_api_proto_rawDescGZIP(), []int{2}
+}
+
+type GetVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVersionResponse) Reset() {
+	*x = GetVersionResponse{}
+	mi := &file_xmtpv4_metadata_api_metadata_api_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVersionResponse) ProtoMessage() {}
+
+func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_xmtpv4_metadata_api_metadata_api_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVersionResponse.ProtoReflect.Descriptor instead.
+func (*GetVersionResponse) Descriptor() ([]byte, []int) {
+	return file_xmtpv4_metadata_api_metadata_api_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *GetVersionResponse) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 var File_xmtpv4_metadata_api_metadata_api_proto protoreflect.FileDescriptor
 
 const file_xmtpv4_metadata_api_metadata_api_proto_rawDesc = "" +
@@ -113,10 +193,15 @@ const file_xmtpv4_metadata_api_metadata_api_proto_rawDesc = "" +
 	"\x14GetSyncCursorRequest\"W\n" +
 	"\x15GetSyncCursorResponse\x12>\n" +
 	"\vlatest_sync\x18\x01 \x01(\v2\x1d.xmtp.xmtpv4.envelopes.CursorR\n" +
-	"latestSync2\xdb\x02\n" +
+	"latestSync\"\x13\n" +
+	"\x11GetVersionRequest\".\n" +
+	"\x12GetVersionResponse\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\tR\aversion2\xea\x03\n" +
 	"\vMetadataApi\x12\x9d\x01\n" +
 	"\rGetSyncCursor\x12..xmtp.xmtpv4.metadata_api.GetSyncCursorRequest\x1a/.xmtp.xmtpv4.metadata_api.GetSyncCursorResponse\"+\x82\xd3\xe4\x93\x02%:\x01*\" /mls/v2/metadata/get-sync-cursor\x12\xab\x01\n" +
-	"\x13SubscribeSyncCursor\x12..xmtp.xmtpv4.metadata_api.GetSyncCursorRequest\x1a/.xmtp.xmtpv4.metadata_api.GetSyncCursorResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/mls/v2/metadata/subscribe-sync-cursor0\x01B\xe3\x01\n" +
+	"\x13SubscribeSyncCursor\x12..xmtp.xmtpv4.metadata_api.GetSyncCursorRequest\x1a/.xmtp.xmtpv4.metadata_api.GetSyncCursorResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/mls/v2/metadata/subscribe-sync-cursor0\x01\x12\x8c\x01\n" +
+	"\n" +
+	"GetVersion\x12+.xmtp.xmtpv4.metadata_api.GetVersionRequest\x1a,.xmtp.xmtpv4.metadata_api.GetVersionResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/mls/v2/metadata/versionB\xe3\x01\n" +
 	"\x1ccom.xmtp.xmtpv4.metadata_apiB\x10MetadataApiProtoP\x01Z3github.com/xmtp/xmtpd/pkg/proto/xmtpv4/metadata_api\xa2\x02\x03XXM\xaa\x02\x17Xmtp.Xmtpv4.MetadataApi\xca\x02\x17Xmtp\\Xmtpv4\\MetadataApi\xe2\x02#Xmtp\\Xmtpv4\\MetadataApi\\GPBMetadata\xea\x02\x19Xmtp::Xmtpv4::MetadataApib\x06proto3"
 
 var (
@@ -131,20 +216,24 @@ func file_xmtpv4_metadata_api_metadata_api_proto_rawDescGZIP() []byte {
 	return file_xmtpv4_metadata_api_metadata_api_proto_rawDescData
 }
 
-var file_xmtpv4_metadata_api_metadata_api_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_xmtpv4_metadata_api_metadata_api_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_xmtpv4_metadata_api_metadata_api_proto_goTypes = []any{
 	(*GetSyncCursorRequest)(nil),  // 0: xmtp.xmtpv4.metadata_api.GetSyncCursorRequest
 	(*GetSyncCursorResponse)(nil), // 1: xmtp.xmtpv4.metadata_api.GetSyncCursorResponse
-	(*envelopes.Cursor)(nil),      // 2: xmtp.xmtpv4.envelopes.Cursor
+	(*GetVersionRequest)(nil),     // 2: xmtp.xmtpv4.metadata_api.GetVersionRequest
+	(*GetVersionResponse)(nil),    // 3: xmtp.xmtpv4.metadata_api.GetVersionResponse
+	(*envelopes.Cursor)(nil),      // 4: xmtp.xmtpv4.envelopes.Cursor
 }
 var file_xmtpv4_metadata_api_metadata_api_proto_depIdxs = []int32{
-	2, // 0: xmtp.xmtpv4.metadata_api.GetSyncCursorResponse.latest_sync:type_name -> xmtp.xmtpv4.envelopes.Cursor
+	4, // 0: xmtp.xmtpv4.metadata_api.GetSyncCursorResponse.latest_sync:type_name -> xmtp.xmtpv4.envelopes.Cursor
 	0, // 1: xmtp.xmtpv4.metadata_api.MetadataApi.GetSyncCursor:input_type -> xmtp.xmtpv4.metadata_api.GetSyncCursorRequest
 	0, // 2: xmtp.xmtpv4.metadata_api.MetadataApi.SubscribeSyncCursor:input_type -> xmtp.xmtpv4.metadata_api.GetSyncCursorRequest
-	1, // 3: xmtp.xmtpv4.metadata_api.MetadataApi.GetSyncCursor:output_type -> xmtp.xmtpv4.metadata_api.GetSyncCursorResponse
-	1, // 4: xmtp.xmtpv4.metadata_api.MetadataApi.SubscribeSyncCursor:output_type -> xmtp.xmtpv4.metadata_api.GetSyncCursorResponse
-	3, // [3:5] is the sub-list for method output_type
-	1, // [1:3] is the sub-list for method input_type
+	2, // 3: xmtp.xmtpv4.metadata_api.MetadataApi.GetVersion:input_type -> xmtp.xmtpv4.metadata_api.GetVersionRequest
+	1, // 4: xmtp.xmtpv4.metadata_api.MetadataApi.GetSyncCursor:output_type -> xmtp.xmtpv4.metadata_api.GetSyncCursorResponse
+	1, // 5: xmtp.xmtpv4.metadata_api.MetadataApi.SubscribeSyncCursor:output_type -> xmtp.xmtpv4.metadata_api.GetSyncCursorResponse
+	3, // 6: xmtp.xmtpv4.metadata_api.MetadataApi.GetVersion:output_type -> xmtp.xmtpv4.metadata_api.GetVersionResponse
+	4, // [4:7] is the sub-list for method output_type
+	1, // [1:4] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
 	1, // [1:1] is the sub-list for extension extendee
 	0, // [0:1] is the sub-list for field type_name
@@ -161,7 +250,7 @@ func file_xmtpv4_metadata_api_metadata_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_xmtpv4_metadata_api_metadata_api_proto_rawDesc), len(file_xmtpv4_metadata_api_metadata_api_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/xmtpv4/metadata_api/metadata_api.pb.gw.go
+++ b/pkg/proto/xmtpv4/metadata_api/metadata_api.pb.gw.go
@@ -78,6 +78,32 @@ func request_MetadataApi_SubscribeSyncCursor_0(ctx context.Context, marshaler ru
 
 }
 
+func request_MetadataApi_GetVersion_0(ctx context.Context, marshaler runtime.Marshaler, client MetadataApiClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetVersionRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.GetVersion(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_MetadataApi_GetVersion_0(ctx context.Context, marshaler runtime.Marshaler, server MetadataApiServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetVersionRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.GetVersion(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterMetadataApiHandlerServer registers the http handlers for service MetadataApi to "mux".
 // UnaryRPC     :call MetadataApiServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -114,6 +140,31 @@ func RegisterMetadataApiHandlerServer(ctx context.Context, mux *runtime.ServeMux
 		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 		return
+	})
+
+	mux.Handle("POST", pattern_MetadataApi_GetVersion_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/xmtp.xmtpv4.metadata_api.MetadataApi/GetVersion", runtime.WithHTTPPathPattern("/mls/v2/metadata/version"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MetadataApi_GetVersion_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_MetadataApi_GetVersion_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	return nil
@@ -201,6 +252,28 @@ func RegisterMetadataApiHandlerClient(ctx context.Context, mux *runtime.ServeMux
 
 	})
 
+	mux.Handle("POST", pattern_MetadataApi_GetVersion_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/xmtp.xmtpv4.metadata_api.MetadataApi/GetVersion", runtime.WithHTTPPathPattern("/mls/v2/metadata/version"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MetadataApi_GetVersion_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_MetadataApi_GetVersion_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -208,10 +281,14 @@ var (
 	pattern_MetadataApi_GetSyncCursor_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"mls", "v2", "metadata", "get-sync-cursor"}, ""))
 
 	pattern_MetadataApi_SubscribeSyncCursor_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"mls", "v2", "metadata", "subscribe-sync-cursor"}, ""))
+
+	pattern_MetadataApi_GetVersion_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"mls", "v2", "metadata", "version"}, ""))
 )
 
 var (
 	forward_MetadataApi_GetSyncCursor_0 = runtime.ForwardResponseMessage
 
 	forward_MetadataApi_SubscribeSyncCursor_0 = runtime.ForwardResponseStream
+
+	forward_MetadataApi_GetVersion_0 = runtime.ForwardResponseMessage
 )

--- a/pkg/proto/xmtpv4/metadata_api/metadata_api_grpc.pb.go
+++ b/pkg/proto/xmtpv4/metadata_api/metadata_api_grpc.pb.go
@@ -23,6 +23,7 @@ const _ = grpc.SupportPackageIsVersion7
 const (
 	MetadataApi_GetSyncCursor_FullMethodName       = "/xmtp.xmtpv4.metadata_api.MetadataApi/GetSyncCursor"
 	MetadataApi_SubscribeSyncCursor_FullMethodName = "/xmtp.xmtpv4.metadata_api.MetadataApi/SubscribeSyncCursor"
+	MetadataApi_GetVersion_FullMethodName          = "/xmtp.xmtpv4.metadata_api.MetadataApi/GetVersion"
 )
 
 // MetadataApiClient is the client API for MetadataApi service.
@@ -31,6 +32,7 @@ const (
 type MetadataApiClient interface {
 	GetSyncCursor(ctx context.Context, in *GetSyncCursorRequest, opts ...grpc.CallOption) (*GetSyncCursorResponse, error)
 	SubscribeSyncCursor(ctx context.Context, in *GetSyncCursorRequest, opts ...grpc.CallOption) (MetadataApi_SubscribeSyncCursorClient, error)
+	GetVersion(ctx context.Context, in *GetVersionRequest, opts ...grpc.CallOption) (*GetVersionResponse, error)
 }
 
 type metadataApiClient struct {
@@ -82,12 +84,22 @@ func (x *metadataApiSubscribeSyncCursorClient) Recv() (*GetSyncCursorResponse, e
 	return m, nil
 }
 
+func (c *metadataApiClient) GetVersion(ctx context.Context, in *GetVersionRequest, opts ...grpc.CallOption) (*GetVersionResponse, error) {
+	out := new(GetVersionResponse)
+	err := c.cc.Invoke(ctx, MetadataApi_GetVersion_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MetadataApiServer is the server API for MetadataApi service.
 // All implementations must embed UnimplementedMetadataApiServer
 // for forward compatibility
 type MetadataApiServer interface {
 	GetSyncCursor(context.Context, *GetSyncCursorRequest) (*GetSyncCursorResponse, error)
 	SubscribeSyncCursor(*GetSyncCursorRequest, MetadataApi_SubscribeSyncCursorServer) error
+	GetVersion(context.Context, *GetVersionRequest) (*GetVersionResponse, error)
 	mustEmbedUnimplementedMetadataApiServer()
 }
 
@@ -100,6 +112,9 @@ func (UnimplementedMetadataApiServer) GetSyncCursor(context.Context, *GetSyncCur
 }
 func (UnimplementedMetadataApiServer) SubscribeSyncCursor(*GetSyncCursorRequest, MetadataApi_SubscribeSyncCursorServer) error {
 	return status.Errorf(codes.Unimplemented, "method SubscribeSyncCursor not implemented")
+}
+func (UnimplementedMetadataApiServer) GetVersion(context.Context, *GetVersionRequest) (*GetVersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
 }
 func (UnimplementedMetadataApiServer) mustEmbedUnimplementedMetadataApiServer() {}
 
@@ -153,6 +168,24 @@ func (x *metadataApiSubscribeSyncCursorServer) Send(m *GetSyncCursorResponse) er
 	return x.ServerStream.SendMsg(m)
 }
 
+func _MetadataApi_GetVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetadataApiServer).GetVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MetadataApi_GetVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetadataApiServer).GetVersion(ctx, req.(*GetVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MetadataApi_ServiceDesc is the grpc.ServiceDesc for MetadataApi service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -163,6 +196,10 @@ var MetadataApi_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSyncCursor",
 			Handler:    _MetadataApi_GetSyncCursor_Handler,
+		},
+		{
+			MethodName: "GetVersion",
+			Handler:    _MetadataApi_GetVersion_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -312,6 +312,7 @@ func startAPIServer(
 				s.ctx,
 				cfg.Log,
 				s.cursorUpdater,
+				cfg.ServerVersion,
 			)
 			if err != nil {
 				return err

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -162,6 +162,7 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks) {
 			ctx,
 			log,
 			metadata.NewCursorUpdater(ctx, log, db),
+			testutils.GetLatestVersion(t),
 		)
 		require.NoError(t, err)
 		metadata_api.RegisterMetadataApiServer(grpcServer, metadataService)


### PR DESCRIPTION
### Add GetVersion metadata endpoint to return server version information
The metadata API service now includes a `GetVersion` RPC method that returns the server's version as a string. The changes include:

- Add version field to `Service` struct in [pkg/api/metadata/service.go](https://github.com/xmtp/xmtpd/pull/957/files#diff-eac101b9b3412e0c38f70b290ed9a62394b8414802b777b472b3ca4ae017f935) and update constructor to accept version parameter
- Generate protobuf definitions and gRPC service code for `GetVersionRequest` and `GetVersionResponse` message types
- Update server initialization in [pkg/server/server.go](https://github.com/xmtp/xmtpd/pull/957/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996) to pass `cfg.ServerVersion` to metadata service constructor
- Add mock implementations for testing the new `GetVersion` method
- Generate OpenAPI/Swagger documentation for the new `/mls/v2/metadata/version` POST endpoint

#### 📍Where to Start
Start with the `GetVersion` method implementation in the `Service` struct in [pkg/api/metadata/service.go](https://github.com/xmtp/xmtpd/pull/957/files#diff-eac101b9b3412e0c38f70b290ed9a62394b8414802b777b472b3ca4ae017f935).

----

_[Macroscope](https://app.macroscope.com) summarized 46c2a48._