### PR TITLE
Fix shellcheck error

### DIFF
--- a/dev/gen/abi
+++ b/dev/gen/abi
@@ -49,7 +49,9 @@ function download_release_artifacts() {
 }
 
 function gen_go_bindings() {
-    local package="$(echo "${contract}" | tr '[:upper:]' '[:lower:]')"
+    local package
+    package="$(echo "${contract}" | tr '[:upper:]' '[:lower:]')"
+
     local package_dir="${abi_dir}/${package}"
     local output_artifact="${package_dir}/${contract}.go"
 


### PR DESCRIPTION
### Fix shellcheck error by separating variable declaration from initialization in gen_go_bindings function in dev/gen/abi script
The `package` variable initialization in the `gen_go_bindings()` function is modified to declare the variable separately before assigning its value, rather than initializing it inline within the echo command in [dev/gen/abi](https://github.com/xmtp/xmtpd/pull/967/files#diff-07c185e365fc47359ea73e8726651811d883fd180b184e58d6309cf4a5f0d47c).

#### 📍Where to Start
Start with the `gen_go_bindings()` function in [dev/gen/abi](https://github.com/xmtp/xmtpd/pull/967/files#diff-07c185e365fc47359ea73e8726651811d883fd180b184e58d6309cf4a5f0d47c).

----

_[Macroscope](https://app.macroscope.com) summarized f6b5d82._