### PR TITLE
Guarantee data integrity after sub fails completely

### DIFF
--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -198,8 +198,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 				logger.Error("subscription error, rebuilding", zap.Error(err))
 				sub, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
 				if err != nil {
-					logger.Error("failed to rebuild subscription, closing", zap.Error(err))
-					r.Stop()
+					logger.Fatal("failed rebuilding subscription after max disconnect time", zap.Error(err), zap.String("maxDisconnectTime", cfg.MaxDisconnectTime.String()))
 				}
 
 			default:
@@ -292,8 +291,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 				logger.Error("subscription error, rebuilding", zap.Error(err))
 				sub, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
 				if err != nil {
-					logger.Error("failed to rebuild subscription, closing", zap.Error(err))
-					r.Stop()
+					logger.Fatal("failed rebuilding subscription after max disconnect time", zap.Error(err), zap.String("maxDisconnectTime", cfg.MaxDisconnectTime.String()))
 				}
 
 				// Backfill everything that was missed.


### PR DESCRIPTION
### Change RPCLogStreamer.watchContract method to terminate application instead of gracefully stopping when subscription rebuilding fails to guarantee data integrity after sub fails completely
The error handling in the `RPCLogStreamer.watchContract` method in [rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/971/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) is modified to call `logger.Fatal()` instead of logging an error and calling `r.Stop()` when subscription rebuilding fails after the maximum disconnect time. This change occurs in two locations within the method and causes the application to terminate rather than attempt graceful shutdown when persistent connection failures occur.

#### 📍Where to Start
Start with the `RPCLogStreamer.watchContract` method in [rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/971/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d) where the error handling behavior has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized 534f60c._