### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/pkg/integration/docker_utils_test.go
+++ b/pkg/integration/docker_utils_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"strconv"
@@ -222,9 +223,7 @@ func (b *XmtpdContainerBuilder) WithContainerName(name string) *XmtpdContainerBu
 }
 
 func (b *XmtpdContainerBuilder) WithEnvVars(envVars map[string]string) *XmtpdContainerBuilder {
-	for k, v := range envVars {
-		b.envVars[k] = v
-	}
+	maps.Copy(b.envVars, envVars)
 	return b
 }
 


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.