### PR TITLE
Fix missing return

### DIFF
--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -483,7 +483,7 @@ func (r *RPCLogStreamer) buildSubscriptionWithBackoff(
 			"failed to rebuild subscription, closing",
 			zap.Error(err),
 		)
-		return
+		return nil, err
 	}
 
 	r.logger.Info("Subscription rebuilt")


### PR DESCRIPTION
### Fix missing return statement in RPCLogStreamer.buildSubscriptionWithBackoff method to explicitly return nil subscription with error
The `buildSubscriptionWithBackoff` method in the `RPCLogStreamer` struct now explicitly returns `nil, err` when subscription rebuilding fails, replacing the previous implicit return that only returned the error. This change affects error handling in [pkg/indexer/rpc_streamer/rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/989/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d).

#### 📍Where to Start
Start with the `buildSubscriptionWithBackoff` method in the `RPCLogStreamer` struct in [pkg/indexer/rpc_streamer/rpc_log_streamer.go](https://github.com/xmtp/xmtpd/pull/989/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d).

----

_[Macroscope](https://app.macroscope.com) summarized 82f9c78._