### PR TITLE
Prevent dependsOn for non-commits:

### DIFF
--- a/pkg/api/message/publish_test.go
+++ b/pkg/api/message/publish_test.go
@@ -265,12 +265,29 @@ func TestPublishEnvelopeOriginatorUnknown(t *testing.T) {
 		envelopeTestUtils.DefaultClientEnvelopeNodeId,
 		&envelopes.Cursor{
 			NodeIdToSequenceId: map[uint32]uint64{
-				1600: 1,
+				97: 1,
 			},
 		},
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "DependsOn has not been seen by this node")
+}
+
+func TestPublishEnvelolopeDependsOnOriginator(t *testing.T) {
+	api, _, _ := apiTestUtils.NewTestReplicationAPIClient(t)
+
+	err := publishPayerEnvelopeWithNodeIDAndCursor(
+		t,
+		api,
+		envelopeTestUtils.DefaultClientEnvelopeNodeId,
+		&envelopes.Cursor{
+			NodeIdToSequenceId: map[uint32]uint64{
+				100: 1,
+			},
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "A message can not depend on a non-commit")
 }
 
 func TestPublishEnvelopeFees(t *testing.T) {

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -616,7 +616,15 @@ func (s *Service) validateClientInfo(clientEnv *envelopes.ClientEnvelope) error 
 		lastSeenCursor := s.cu.GetCursor()
 		for nodeId, seqId := range aad.GetDependsOn().NodeIdToSequenceId {
 			lastSeqId, exists := lastSeenCursor.NodeIdToSequenceId[nodeId]
-			if !exists {
+			if nodeId >= 100 {
+				// The failure scenarios of non-commits are different from the blockchain path
+				// and as such should be prevented
+				return status.Errorf(
+					codes.InvalidArgument,
+					"node ID %d specified in DependsOn is not a valid node ID. A message can not depend on a non-commit.",
+					nodeId,
+				)
+			} else if !exists {
 				return status.Errorf(codes.InvalidArgument,
 					"node ID %d specified in DependsOn has not been seen by this node",
 					nodeId,


### PR DESCRIPTION
### Prevent messages from depending on non-commit nodes by adding validation in Service.validateClientInfo method to reject node IDs ≥ 100
The `Service.validateClientInfo` method in [service.go](https://github.com/xmtp/xmtpd/pull/1008/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) now validates that messages cannot depend on node IDs ≥ 100, which represent non-commits, returning an error message "A message can not depend on a non-commit" when such dependencies are detected. A new test `TestPublishEnvelolopeDependsOnOriginator` has been added to [publish_test.go](https://github.com/xmtp/xmtpd/pull/1008/files#diff-b6d92459b9ec3f2503f1ccb187101664984e631b23275bd4a716b694de10408c) to verify this validation behavior, and an existing test has been updated to use node ID 97 instead of 1600.

#### 📍Where to Start
Start with the `validateClientInfo` method in the `Service` struct in [service.go](https://github.com/xmtp/xmtpd/pull/1008/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) to understand the new validation logic for non-commit dependencies.

----

_[Macroscope](https://app.macroscope.com) summarized 851c9f3._