### PR TITLE
Take the good improvements from node-go pruner

### DIFF
--- a/pkg/config/pruneOptions.go
+++ b/pkg/config/pruneOptions.go
@@ -1,9 +1,10 @@
 package config
 
 type PruneConfig struct {
-	MaxCycles int   `long:"max-prune-cycles" env:"XMTPD_PRUNE_MAX_CYCLES" description:"Maximum pruning cycles" default:"10"`
-	BatchSize int32 `long:"batch-size"       env:"XMTPD_PRUNE_BATCH_SIZE" description:"Batch size"             default:"10000"`
-	DryRun    bool  `long:"dry-run"          env:"XMTPD_PRUNE_DRY_RUN"    description:"Dry run mode"`
+	MaxCycles      int   `long:"max-prune-cycles" env:"XMTPD_PRUNE_MAX_CYCLES"      description:"Maximum pruning cycles"                   default:"10"`
+	BatchSize      int32 `long:"batch-size"       env:"XMTPD_PRUNE_BATCH_SIZE"      description:"Batch size"                               default:"10000"`
+	CountDeletable bool  `long:"count-deletable"  env:"XMTPD_PRUNE_COUNT_DELETABLE" description:"Attempt to count all deletable envelopes"`
+	DryRun         bool  `long:"dry-run"          env:"XMTPD_PRUNE_DRY_RUN"         description:"Dry run mode"`
 }
 type PruneOptions struct {
 	DB          DbOptions        `group:"Database Options"  namespace:"db"`

--- a/pkg/prune/prune.go
+++ b/pkg/prune/prune.go
@@ -3,7 +3,6 @@ package prune
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/xmtp/xmtpd/pkg/config"
@@ -40,14 +39,20 @@ func NewPruneExecutor(
 
 func (e *Executor) Run() error {
 	querier := queries.New(e.writerDB)
-	totalDeletionCount := 0
 	start := time.Now()
 
-	cnt, err := querier.CountExpiredEnvelopes(e.ctx)
-	if err != nil {
-		return err
+	if e.config.CountDeletable {
+		cnt, err := querier.CountExpiredEnvelopes(e.ctx)
+		if err != nil {
+			return err
+		}
+		e.log.Info("Count of envelopes eligible for pruning", zap.Int64("count", cnt))
+
+		if cnt == 0 {
+			e.log.Info("No envelopes found for pruning")
+			return nil
+		}
 	}
-	e.log.Info("Count of envelopes eligible for pruning", zap.Int64("count", cnt))
 
 	if e.config.DryRun {
 		e.log.Info("Dry run mode enabled. Nothing to do")
@@ -55,30 +60,30 @@ func (e *Executor) Run() error {
 	}
 
 	cyclesCompleted := 0
+	totalDeletionCount := 0
 
 	for {
-		if cyclesCompleted >= e.config.MaxCycles {
-			e.log.Warn("Reached maximum pruning cycles", zap.Int("maxCycles", e.config.MaxCycles))
-			break
-		}
-
 		rows, err := querier.DeleteExpiredEnvelopesBatch(e.ctx, e.config.BatchSize)
 		if err != nil {
 			return err
 		}
 
-		if len(rows) == 0 {
+		deletedThisCycle := len(rows)
+
+		totalDeletionCount = totalDeletionCount + deletedThisCycle
+
+		e.log.Info("Pruned expired envelopes batch", zap.Int("count", deletedThisCycle))
+
+		cyclesCompleted++
+
+		if deletedThisCycle < int(e.config.BatchSize) {
 			break
 		}
 
-		totalDeletionCount = totalDeletionCount + len(rows)
-
-		e.log.Info("Pruned expired envelopes batch", zap.Int("count", len(rows)))
-
-		for _, row := range rows {
-			e.log.Debug(fmt.Sprintf("Pruning expired envelopes batch row: %v", row))
+		if cyclesCompleted >= e.config.MaxCycles {
+			e.log.Warn("Reached maximum pruning cycles", zap.Int("maxCycles", e.config.MaxCycles))
+			break
 		}
-		cyclesCompleted++
 	}
 
 	if totalDeletionCount == 0 {

--- a/pkg/testutils/log.go
+++ b/pkg/testutils/log.go
@@ -2,7 +2,10 @@ package testutils
 
 import (
 	"flag"
+	"strings"
 	"testing"
+
+	"go.uber.org/zap/zapcore"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -22,4 +25,54 @@ func NewLog(t testing.TB) *zap.Logger {
 	log, err := cfg.Build()
 	require.NoError(t, err)
 	return log
+}
+
+// CapturingWriteSyncer is a WriteSyncer that stores logs in memory.
+type CapturingWriteSyncer struct {
+	logs []string
+}
+
+func (c *CapturingWriteSyncer) Write(p []byte) (n int, err error) {
+	c.logs = append(c.logs, string(p))
+	return len(p), nil
+}
+
+func (c *CapturingWriteSyncer) Sync() error {
+	return nil
+}
+
+// CapturingLogger wraps a zap.Logger and stores emitted logs.
+type CapturingLogger struct {
+	*zap.Logger
+	cws *CapturingWriteSyncer
+}
+
+// NewCapturingLogger creates a zap.Logger that records all logs in memory.
+func NewCapturingLogger(level zapcore.Level) *CapturingLogger {
+	cws := &CapturingWriteSyncer{}
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig()),
+		cws,
+		level,
+	)
+
+	return &CapturingLogger{
+		Logger: zap.New(core),
+		cws:    cws,
+	}
+}
+
+// Logs returns all captured logs as a single string.
+func (cl *CapturingLogger) Logs() string {
+	return strings.Join(cl.cws.logs, "\n")
+}
+
+// Contains checks if any captured log contains the given substring.
+func (cl *CapturingLogger) Contains(substr string) bool {
+	for _, l := range cl.cws.logs {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### Add CountDeletable configuration option to prune.Executor.Run method and modify pruning loop termination logic to stop when batch deletes fewer rows than BatchSize
- Adds `CountDeletable` boolean field to `config.PruneConfig` struct with CLI flag and environment variable support in [pkg/config/pruneOptions.go](https://github.com/xmtp/xmtpd/pull/1041/files#diff-fd23a98cbc9c92d896f65d69d65f90028001af86148579c59753f6715cd85e0c)
- Modifies `prune.Executor.Run` method to conditionally count deletable envelopes based on `CountDeletable` configuration and changes loop termination to stop when batch deletes fewer rows than `BatchSize` in [pkg/prune/prune.go](https://github.com/xmtp/xmtpd/pull/1041/files#diff-1a9bef57c3cc14ab5b07561eb0aece529ef508cc606a179483dace998beb9eff)
- Introduces `CapturingWriteSyncer` and `CapturingLogger` test utilities for in-memory log capture in [pkg/testutils/log.go](https://github.com/xmtp/xmtpd/pull/1041/files#diff-a027d16b7af021984f42348b77421902dd85811042922fe9655236c307bc155c)
- Adds test case `TestExecutor_PruneCountWorks` to verify counting functionality in [pkg/prune/prune_test.go](https://github.com/xmtp/xmtpd/pull/1041/files#diff-4017c4c995dfb20aa0d7f3e4f7714a2b1c542d31dddf2555425e840c9105a4fb)

#### 📍Where to Start
Start with the `prune.Executor.Run` method in [pkg/prune/prune.go](https://github.com/xmtp/xmtpd/pull/1041/files#diff-1a9bef57c3cc14ab5b07561eb0aece529ef508cc606a179483dace998beb9eff) to understand the core pruning logic changes and how the new `CountDeletable` configuration affects execution flow.

----

_[Macroscope](https://app.macroscope.com) summarized 792cd72._