### PR TITLE
Migrator writer is the source of truth

### DIFF
--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -18,6 +18,18 @@ This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/ope
 | `xmtp_indexer_log_streamer_logs` | `Counter` | Number of logs found by the log streamer | `pkg/metrics/indexer.go` |
 | `xmtp_indexer_log_streamer_max_block` | `Gauge` | Max block on the chain to be processed by the log streamer | `pkg/metrics/indexer.go` |
 | `xmtp_indexer_retryable_storage_error_count` | `Counter` | Number of retryable storage errors | `pkg/metrics/indexer.go` |
+| `xmtp_migrator_destination_blockchain_last_sequence_id` | `Gauge` | Last sequence ID published to blockchain | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_destination_database_last_sequence_id` | `Gauge` | Last sequence ID persisted in destination database | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_e2e_latency_seconds` | `Histogram` | Time spent migrating a message | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_reader_errors_total` | `Counter` | Total number of reader errors | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_reader_fetch_duration_seconds` | `Histogram` | Time spent fetching records from source database | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_reader_num_rows_found` | `Counter` | Number of rows fetched from source database | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_source_last_sequence_id` | `Gauge` | Last sequence ID pulled from source DB | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_transformer_errors_total` | `Counter` | Total number of transformation errors | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_writer_errors_total` | `Counter` | Total number of writer errors by destination and error type | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_writer_latency_seconds` | `Histogram` | Time spent writing to destination | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_writer_retry_attempts` | `Histogram` | Number of retry attempts before success or failure | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_writer_rows_migrated` | `Counter` | Total number of rows successfully migrated | `pkg/metrics/migrator.go` |
 | `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist | `pkg/metrics/payer.go` |
 | `xmtp_payer_get_reader_node_available_nodes` | `Gauge` | Number of currently available nodes for reader selection | `pkg/metrics/payer.go` |
 | `xmtp_payer_lru_nonce` | `Gauge` | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go` |

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -99,6 +99,16 @@ func registerCollectors(reg prometheus.Registerer) {
 		blockchainWaitForTransaction,
 		blockchainPublishPayload,
 		payerGetReaderNodeAvailableNodes,
+		migratorE2ELatency,
+		migratorDestLastSequenceIDBlockchain,
+		migratorDestLastSequenceIDDatabase,
+		migratorReaderNumRowsFound,
+		migratorSourceLastSequenceID,
+		migratorTransformerErrors,
+		migratorWriterErrors,
+		migratorWriterLatency,
+		migratorWriterRetryAttempts,
+		migratorWriterRowsMigrated,
 	}
 
 	for _, col := range cols {

--- a/pkg/metrics/migrator.go
+++ b/pkg/metrics/migrator.go
@@ -1,0 +1,194 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var migratorE2ELatency = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "xmtp_migrator_e2e_latency_seconds",
+		Help:    "Time spent migrating a message",
+		Buckets: []float64{0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0},
+	},
+	[]string{"table", "destination"},
+)
+
+func EmitMigratorE2ELatency(table, destination string, duration float64) {
+	migratorE2ELatency.With(prometheus.Labels{
+		"table":       table,
+		"destination": destination,
+	}).Observe(duration)
+}
+
+var migratorDestLastSequenceIDBlockchain = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtp_migrator_destination_blockchain_last_sequence_id",
+		Help: "Last sequence ID published to blockchain",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorDestLastSequenceIDBlockchain(table string, sequenceID int64) {
+	migratorDestLastSequenceIDBlockchain.With(prometheus.Labels{"table": table}).
+		Set(float64(sequenceID))
+}
+
+var migratorDestLastSequenceIDDatabase = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtp_migrator_destination_database_last_sequence_id",
+		Help: "Last sequence ID persisted in destination database",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorDestLastSequenceIDDatabase(table string, sequenceID int64) {
+	migratorDestLastSequenceIDDatabase.With(prometheus.Labels{"table": table}).
+		Set(float64(sequenceID))
+}
+
+var migratorReaderErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtp_migrator_reader_errors_total",
+		Help: "Total number of reader errors",
+	},
+	[]string{"table", "error_type"},
+)
+
+func EmitMigratorReaderError(table, errorType string) {
+	migratorReaderErrors.With(prometheus.Labels{
+		"table":      table,
+		"error_type": errorType,
+	}).Inc()
+}
+
+var migratorReaderFetchDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "xmtp_migrator_reader_fetch_duration_seconds",
+		Help:    "Time spent fetching records from source database",
+		Buckets: []float64{0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0},
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorReaderFetchDuration(table string, duration float64) {
+	migratorReaderFetchDuration.With(prometheus.Labels{"table": table}).Observe(duration)
+}
+
+func MeasureReaderLatency[Return any](table string, fn func() (Return, error)) (Return, error) {
+	start := time.Now()
+	ret, err := fn()
+	if err == nil {
+		EmitMigratorReaderFetchDuration(table, time.Since(start).Seconds())
+	}
+	return ret, err
+}
+
+var migratorReaderNumRowsFound = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtp_migrator_reader_num_rows_found",
+		Help: "Number of rows fetched from source database",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorReaderNumRowsFound(table string, numRows int64) {
+	migratorReaderNumRowsFound.With(prometheus.Labels{"table": table}).Add(float64(numRows))
+}
+
+var migratorSourceLastSequenceID = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtp_migrator_source_last_sequence_id",
+		Help: "Last sequence ID pulled from source DB",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorSourceLastSequenceID(table string, sequenceID int64) {
+	migratorSourceLastSequenceID.With(prometheus.Labels{"table": table}).Set(float64(sequenceID))
+}
+
+var migratorTransformerErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtp_migrator_transformer_errors_total",
+		Help: "Total number of transformation errors",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorTransformerError(table string) {
+	migratorTransformerErrors.With(prometheus.Labels{"table": table}).Inc()
+}
+
+var migratorWriterErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtp_migrator_writer_errors_total",
+		Help: "Total number of writer errors by destination and error type",
+	},
+	[]string{"table", "destination", "error_type"},
+)
+
+func EmitMigratorWriterError(table, destination, errorType string) {
+	migratorWriterErrors.With(prometheus.Labels{
+		"table":       table,
+		"destination": destination,
+		"error_type":  errorType,
+	}).Inc()
+}
+
+var migratorWriterLatency = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "xmtp_migrator_writer_latency_seconds",
+		Help:    "Time spent writing to destination",
+		Buckets: []float64{0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 60.0},
+	},
+	[]string{"table", "destination"},
+)
+
+func EmitMigratorWriterLatency(table, destination string, duration float64) {
+	migratorWriterLatency.With(prometheus.Labels{
+		"table":       table,
+		"destination": destination,
+	}).Observe(duration)
+}
+
+func MeasureWriterLatency(
+	table, destination string,
+	fn func() error,
+) error {
+	start := time.Now()
+	err := fn()
+	if err == nil {
+		EmitMigratorWriterLatency(table, destination, time.Since(start).Seconds())
+	}
+	return err
+}
+
+var migratorWriterRetryAttempts = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "xmtp_migrator_writer_retry_attempts",
+		Help:    "Number of retry attempts before success or failure",
+		Buckets: []float64{0, 1, 2, 3, 4, 5, 10, 20},
+	},
+	[]string{"table", "destination"},
+)
+
+var migratorWriterRowsMigrated = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "xmtp_migrator_writer_rows_migrated",
+		Help: "Total number of rows successfully migrated",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorWriterRowsMigrated(table string, numRows int64) {
+	migratorWriterRowsMigrated.With(prometheus.Labels{"table": table}).Add(float64(numRows))
+}
+
+func EmitMigratorWriterRetryAttempts(table, destination string, attempts int) {
+	migratorWriterRetryAttempts.With(prometheus.Labels{
+		"table":       table,
+		"destination": destination,
+	}).Observe(float64(attempts))
+}

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -254,6 +254,8 @@ func (m *Migrator) migrationWorker(tableName string) {
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
+		default:
+			// semaphore already full => double-release attempt; don't block
 		}
 	}
 
@@ -406,8 +408,6 @@ func (m *Migrator) migrationWorker(tableName string) {
 				case record, open := <-recvChan:
 					if !open {
 						logger.Info("channel closed, stopping")
-
-						cleanupInflight(ctx, record.GetID())
 						return
 					}
 

--- a/pkg/migrator/reader.go
+++ b/pkg/migrator/reader.go
@@ -30,40 +30,33 @@ func (r *DBReader[T]) Fetch(
 	ctx context.Context,
 	lastID int64,
 	limit int32,
-) ([]ISourceRecord, int64, error) {
+) ([]ISourceRecord, error) {
 	rows, err := r.db.QueryContext(ctx, r.query, lastID, limit)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	defer func() {
 		_ = rows.Close()
 	}()
 
-	var (
-		records = make([]ISourceRecord, 0, limit)
-		maxID   int64
-	)
+	records := make([]ISourceRecord, 0, limit)
 
 	for rows.Next() {
 		record := r.factory()
 
 		if err := record.Scan(rows); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 
 		records = append(records, record)
-
-		if record.GetID() > maxID {
-			maxID = record.GetID()
-		}
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return records, maxID, nil
+	return records, nil
 }
 
 type GroupMessageReader struct {

--- a/pkg/migrator/reader_test.go
+++ b/pkg/migrator/reader_test.go
@@ -50,9 +50,8 @@ func TestGroupMessageReader(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			records, maxID, err := reader.Fetch(ctx, tc.lastID, tc.limit)
+			records, err := reader.Fetch(ctx, tc.lastID, tc.limit)
 			require.NoError(t, err)
-			require.Equal(t, tc.wantMaxID, maxID)
 
 			for _, record := range records {
 				require.IsType(t, &migrator.GroupMessage{}, record)
@@ -103,9 +102,8 @@ func TestInboxLogReader(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			records, maxID, err := reader.Fetch(ctx, tc.lastID, tc.limit)
+			records, err := reader.Fetch(ctx, tc.lastID, tc.limit)
 			require.NoError(t, err)
-			require.Equal(t, tc.wantMaxID, maxID)
 
 			for _, record := range records {
 				require.IsType(t, &migrator.InboxLog{}, record)
@@ -156,9 +154,8 @@ func TestKeyPackageReader(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			records, maxID, err := reader.Fetch(ctx, tc.lastID, tc.limit)
+			records, err := reader.Fetch(ctx, tc.lastID, tc.limit)
 			require.NoError(t, err)
-			require.Equal(t, tc.wantMaxID, maxID)
 
 			for _, record := range records {
 				require.IsType(t, &migrator.KeyPackage{}, record)
@@ -209,9 +206,8 @@ func TestWelcomeMessageReader(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			records, maxID, err := reader.Fetch(ctx, tc.lastID, tc.limit)
+			records, err := reader.Fetch(ctx, tc.lastID, tc.limit)
 			require.NoError(t, err)
-			require.Equal(t, tc.wantMaxID, maxID)
 
 			for _, record := range records {
 				require.IsType(t, &migrator.WelcomeMessage{}, record)

--- a/pkg/migrator/transformer_test.go
+++ b/pkg/migrator/transformer_test.go
@@ -69,7 +69,7 @@ func TestTransformGroupMessage(t *testing.T) {
 
 	defer test.cleanup()
 
-	records, _, err := reader.Fetch(test.ctx, 0, 1)
+	records, err := reader.Fetch(test.ctx, 0, 1)
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	require.IsType(t, &migrator.GroupMessage{}, records[0])
@@ -136,7 +136,7 @@ func TestTransformInboxLog(t *testing.T) {
 
 	defer test.cleanup()
 
-	records, _, err := reader.Fetch(test.ctx, 0, 1)
+	records, err := reader.Fetch(test.ctx, 0, 1)
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	require.IsType(t, &migrator.InboxLog{}, records[0])
@@ -214,7 +214,7 @@ func TestTransformKeyPackage(t *testing.T) {
 
 	defer test.cleanup()
 
-	records, _, err := reader.Fetch(test.ctx, 0, 1)
+	records, err := reader.Fetch(test.ctx, 0, 1)
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	require.IsType(t, &migrator.KeyPackage{}, records[0])
@@ -283,7 +283,7 @@ func TestTransformWelcomeMessage(t *testing.T) {
 
 	defer test.cleanup()
 
-	records, _, err := reader.Fetch(test.ctx, 0, 1)
+	records, err := reader.Fetch(test.ctx, 0, 1)
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	require.IsType(t, &migrator.WelcomeMessage{}, records[0])

--- a/pkg/migrator/types.go
+++ b/pkg/migrator/types.go
@@ -45,7 +45,7 @@ type IDestinationWriter interface {
 
 // ISourceReader defines the interface for reading records from the source database.
 type ISourceReader interface {
-	Fetch(ctx context.Context, lastID int64, limit int32) ([]ISourceRecord, int64, error)
+	Fetch(ctx context.Context, lastID int64, limit int32) ([]ISourceRecord, error)
 }
 
 // ISourceRecord defines a record from the source database,


### PR DESCRIPTION
### Implement comprehensive migrator metrics collection and flow control with semaphore-based inflight tracking to make the migrator writer the source of truth
The migrator system now collects extensive metrics across the reader, transformer, and writer stages while implementing flow control through a semaphore-based inflight tracking system. The changes include:

- Addition of 15 new migrator-specific metrics in [pkg/metrics/migrator.go](https://github.com/xmtp/xmtpd/pull/1042/files#diff-94129ac032a24ee9c3f1a8c70772094f4d1e3d5979baeb72a86b511833303bcb) covering latency histograms, error counters, and sequence ID gauges
- Modification of `migrator.Migrator.migrationWorker` method in [pkg/metrics/migrator.go](https://github.com/xmtp/xmtpd/pull/1042/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693) to implement semaphore-based flow control with batchSize*4 maximum inflight records and comprehensive metrics emission
- Refactoring of `migrator.ISourceReader.Fetch` interface in [pkg/migrator/types.go](https://github.com/xmtp/xmtpd/pull/1042/files#diff-9f0a533504d524cea30380cd792a79e21a2c6a46594c9be99de7399fd288d1ba) to remove max ID return value, making the writer the authoritative source for migration progress
- Updates to retry logic in [pkg/migrator/writer.go](https://github.com/xmtp/xmtpd/pull/1042/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258) to include retry attempt metrics with table and destination labels

#### 📍Where to Start
Start with the `migrator.Migrator.migrationWorker` method in [pkg/migrator/migrator.go](https://github.com/xmtp/xmtpd/pull/1042/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693) to understand the core flow control and metrics implementation changes.

----

_[Macroscope](https://app.macroscope.com) summarized 395fc63._