### PR TITLE
Migration client

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -305,6 +305,8 @@ func startAPIServer(
 ) error {
 	var err error
 
+	isMigrationEnabled := cfg.Options.MigrationServer.Enable || cfg.Options.MigrationClient.Enable
+
 	serviceRegistrationFunc := func(grpcServer *grpc.Server) error {
 		if cfg.Options.Replication.Enable {
 
@@ -319,6 +321,7 @@ func startAPIServer(
 				s.cursorUpdater,
 				getRatesFetcher(),
 				cfg.Options.Replication,
+				isMigrationEnabled,
 			)
 			if err != nil {
 				return err

--- a/pkg/sync/server.go
+++ b/pkg/sync/server.go
@@ -13,6 +13,11 @@ import (
 	"go.uber.org/zap"
 )
 
+type MigrationConfig struct {
+	Enable     bool
+	FromNodeID uint32
+}
+
 type SyncServerConfig struct {
 	Ctx                        context.Context
 	Log                        *zap.Logger
@@ -22,6 +27,7 @@ type SyncServerConfig struct {
 	FeeCalculator              fees.IFeeCalculator
 	PayerReportStore           payerreport.IPayerReportStore
 	PayerReportDomainSeparator common.Hash
+	Migration                  MigrationConfig
 }
 
 type SyncServerOption func(*SyncServerConfig)
@@ -56,6 +62,10 @@ func WithPayerReportStore(store payerreport.IPayerReportStore) SyncServerOption 
 
 func WithPayerReportDomainSeparator(domainSeparator common.Hash) SyncServerOption {
 	return func(cfg *SyncServerConfig) { cfg.PayerReportDomainSeparator = domainSeparator }
+}
+
+func WithMigration(migration MigrationConfig) SyncServerOption {
+	return func(cfg *SyncServerConfig) { cfg.Migration = migration }
 }
 
 type SyncServer struct {

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -143,6 +143,7 @@ func NewTestAPIServer(t *testing.T) (*api.ApiServer, *sql.DB, ApiServerMocks) {
 			config.ReplicationOptions{
 				SendKeepAliveInterval: 30 * time.Second,
 			},
+			false,
 		)
 		require.NoError(t, err)
 		message_api.RegisterReplicationApiServer(grpcServer, replicationService)


### PR DESCRIPTION
- Sync from migration originator ID's.
- D14N API is read-only while migrator is active.