### PR TITLE
Update settlement flows

### DIFF
--- a/pkg/db/sqlc/payerReports.sql
+++ b/pkg/db/sqlc/payerReports.sql
@@ -168,6 +168,11 @@ FROM rpt
 WHERE sqlc.narg(min_attestations)::INT IS NULL
 	OR attestations_count >= sqlc.narg(min_attestations)::INT;
 
+-- name: FetchPayerReport :one
+SELECT *
+FROM payer_reports
+WHERE id = @id;
+
 -- name: SetReportAttestationStatus :exec
 UPDATE payer_reports
 SET attestation_status = @new_status
@@ -192,3 +197,9 @@ WHERE (
 		sqlc.narg(attester_node_id)::INT IS NULL
 		OR sqlc.narg(attester_node_id)::INT = node_id
 	);
+
+-- name: ClearUnsettledUsage :exec
+DELETE FROM unsettled_usage
+WHERE originator_id = @originator_id
+	AND minutes_since_epoch > @prev_report_end_minute_since_epoch
+	AND minutes_since_epoch <= @end_minute_since_epoch;

--- a/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer_test.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer_test.go
@@ -113,16 +113,6 @@ func TestStorePayerReportManagerPayerReportSubmittedIdempotency(t *testing.T) {
 	require.Len(t, res, 1)
 }
 
-func TestStorePayerReportManagerPayerReportSubsetSettled(t *testing.T) {
-	tester := buildPayerReportManagerStorerTester(t)
-
-	log := tester.newLog(t, "PayerReportSubsetSettled")
-
-	err := tester.storer.StoreLog(t.Context(), log)
-
-	require.NoError(t, err)
-}
-
 func buildPayerReportManagerStorerTester(t *testing.T) *payerReportManagerStorerTester {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -157,15 +147,6 @@ func buildPayerReportManagerStorerTester(t *testing.T) *payerReportManagerStorer
 		abi:     abi,
 		storer:  storer,
 		queries: queries.New(db),
-	}
-}
-
-func (st *payerReportManagerStorerTester) newLog(t *testing.T, event string) types.Log {
-	topic, err := utils.GetEventTopic(st.abi, event)
-	require.NoError(t, err)
-
-	return types.Log{
-		Topics: []common.Hash{topic},
 	}
 }
 

--- a/pkg/mocks/payerreport/mock_IPayerReportStore.go
+++ b/pkg/mocks/payerreport/mock_IPayerReportStore.go
@@ -302,17 +302,17 @@ func (_c *MockIPayerReportStore_Queries_Call) RunAndReturn(run func() *queries.Q
 	return _c
 }
 
-// SetReportAttestationStatus provides a mock function with given fields: ctx, id, fromStatus, toStatus
-func (_m *MockIPayerReportStore) SetReportAttestationStatus(ctx context.Context, id payerreport.ReportID, fromStatus []payerreport.AttestationStatus, toStatus payerreport.AttestationStatus) error {
-	ret := _m.Called(ctx, id, fromStatus, toStatus)
+// SetReportAttestationApproved provides a mock function with given fields: ctx, id
+func (_m *MockIPayerReportStore) SetReportAttestationApproved(ctx context.Context, id payerreport.ReportID) error {
+	ret := _m.Called(ctx, id)
 
 	if len(ret) == 0 {
-		panic("no return value specified for SetReportAttestationStatus")
+		panic("no return value specified for SetReportAttestationApproved")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID, []payerreport.AttestationStatus, payerreport.AttestationStatus) error); ok {
-		r0 = rf(ctx, id, fromStatus, toStatus)
+	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID) error); ok {
+		r0 = rf(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -320,48 +320,46 @@ func (_m *MockIPayerReportStore) SetReportAttestationStatus(ctx context.Context,
 	return r0
 }
 
-// MockIPayerReportStore_SetReportAttestationStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReportAttestationStatus'
-type MockIPayerReportStore_SetReportAttestationStatus_Call struct {
+// MockIPayerReportStore_SetReportAttestationApproved_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReportAttestationApproved'
+type MockIPayerReportStore_SetReportAttestationApproved_Call struct {
 	*mock.Call
 }
 
-// SetReportAttestationStatus is a helper method to define mock.On call
+// SetReportAttestationApproved is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id payerreport.ReportID
-//   - fromStatus []payerreport.AttestationStatus
-//   - toStatus payerreport.AttestationStatus
-func (_e *MockIPayerReportStore_Expecter) SetReportAttestationStatus(ctx interface{}, id interface{}, fromStatus interface{}, toStatus interface{}) *MockIPayerReportStore_SetReportAttestationStatus_Call {
-	return &MockIPayerReportStore_SetReportAttestationStatus_Call{Call: _e.mock.On("SetReportAttestationStatus", ctx, id, fromStatus, toStatus)}
+func (_e *MockIPayerReportStore_Expecter) SetReportAttestationApproved(ctx interface{}, id interface{}) *MockIPayerReportStore_SetReportAttestationApproved_Call {
+	return &MockIPayerReportStore_SetReportAttestationApproved_Call{Call: _e.mock.On("SetReportAttestationApproved", ctx, id)}
 }
 
-func (_c *MockIPayerReportStore_SetReportAttestationStatus_Call) Run(run func(ctx context.Context, id payerreport.ReportID, fromStatus []payerreport.AttestationStatus, toStatus payerreport.AttestationStatus)) *MockIPayerReportStore_SetReportAttestationStatus_Call {
+func (_c *MockIPayerReportStore_SetReportAttestationApproved_Call) Run(run func(ctx context.Context, id payerreport.ReportID)) *MockIPayerReportStore_SetReportAttestationApproved_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(payerreport.ReportID), args[2].([]payerreport.AttestationStatus), args[3].(payerreport.AttestationStatus))
+		run(args[0].(context.Context), args[1].(payerreport.ReportID))
 	})
 	return _c
 }
 
-func (_c *MockIPayerReportStore_SetReportAttestationStatus_Call) Return(_a0 error) *MockIPayerReportStore_SetReportAttestationStatus_Call {
+func (_c *MockIPayerReportStore_SetReportAttestationApproved_Call) Return(_a0 error) *MockIPayerReportStore_SetReportAttestationApproved_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockIPayerReportStore_SetReportAttestationStatus_Call) RunAndReturn(run func(context.Context, payerreport.ReportID, []payerreport.AttestationStatus, payerreport.AttestationStatus) error) *MockIPayerReportStore_SetReportAttestationStatus_Call {
+func (_c *MockIPayerReportStore_SetReportAttestationApproved_Call) RunAndReturn(run func(context.Context, payerreport.ReportID) error) *MockIPayerReportStore_SetReportAttestationApproved_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// SetReportSubmissionStatus provides a mock function with given fields: ctx, id, fromStatus, toStatus
-func (_m *MockIPayerReportStore) SetReportSubmissionStatus(ctx context.Context, id payerreport.ReportID, fromStatus []payerreport.SubmissionStatus, toStatus payerreport.SubmissionStatus) error {
-	ret := _m.Called(ctx, id, fromStatus, toStatus)
+// SetReportAttestationRejected provides a mock function with given fields: ctx, id
+func (_m *MockIPayerReportStore) SetReportAttestationRejected(ctx context.Context, id payerreport.ReportID) error {
+	ret := _m.Called(ctx, id)
 
 	if len(ret) == 0 {
-		panic("no return value specified for SetReportSubmissionStatus")
+		panic("no return value specified for SetReportAttestationRejected")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID, []payerreport.SubmissionStatus, payerreport.SubmissionStatus) error); ok {
-		r0 = rf(ctx, id, fromStatus, toStatus)
+	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID) error); ok {
+		r0 = rf(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -369,33 +367,125 @@ func (_m *MockIPayerReportStore) SetReportSubmissionStatus(ctx context.Context, 
 	return r0
 }
 
-// MockIPayerReportStore_SetReportSubmissionStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReportSubmissionStatus'
-type MockIPayerReportStore_SetReportSubmissionStatus_Call struct {
+// MockIPayerReportStore_SetReportAttestationRejected_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReportAttestationRejected'
+type MockIPayerReportStore_SetReportAttestationRejected_Call struct {
 	*mock.Call
 }
 
-// SetReportSubmissionStatus is a helper method to define mock.On call
+// SetReportAttestationRejected is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id payerreport.ReportID
-//   - fromStatus []payerreport.SubmissionStatus
-//   - toStatus payerreport.SubmissionStatus
-func (_e *MockIPayerReportStore_Expecter) SetReportSubmissionStatus(ctx interface{}, id interface{}, fromStatus interface{}, toStatus interface{}) *MockIPayerReportStore_SetReportSubmissionStatus_Call {
-	return &MockIPayerReportStore_SetReportSubmissionStatus_Call{Call: _e.mock.On("SetReportSubmissionStatus", ctx, id, fromStatus, toStatus)}
+func (_e *MockIPayerReportStore_Expecter) SetReportAttestationRejected(ctx interface{}, id interface{}) *MockIPayerReportStore_SetReportAttestationRejected_Call {
+	return &MockIPayerReportStore_SetReportAttestationRejected_Call{Call: _e.mock.On("SetReportAttestationRejected", ctx, id)}
 }
 
-func (_c *MockIPayerReportStore_SetReportSubmissionStatus_Call) Run(run func(ctx context.Context, id payerreport.ReportID, fromStatus []payerreport.SubmissionStatus, toStatus payerreport.SubmissionStatus)) *MockIPayerReportStore_SetReportSubmissionStatus_Call {
+func (_c *MockIPayerReportStore_SetReportAttestationRejected_Call) Run(run func(ctx context.Context, id payerreport.ReportID)) *MockIPayerReportStore_SetReportAttestationRejected_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(payerreport.ReportID), args[2].([]payerreport.SubmissionStatus), args[3].(payerreport.SubmissionStatus))
+		run(args[0].(context.Context), args[1].(payerreport.ReportID))
 	})
 	return _c
 }
 
-func (_c *MockIPayerReportStore_SetReportSubmissionStatus_Call) Return(_a0 error) *MockIPayerReportStore_SetReportSubmissionStatus_Call {
+func (_c *MockIPayerReportStore_SetReportAttestationRejected_Call) Return(_a0 error) *MockIPayerReportStore_SetReportAttestationRejected_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockIPayerReportStore_SetReportSubmissionStatus_Call) RunAndReturn(run func(context.Context, payerreport.ReportID, []payerreport.SubmissionStatus, payerreport.SubmissionStatus) error) *MockIPayerReportStore_SetReportSubmissionStatus_Call {
+func (_c *MockIPayerReportStore_SetReportAttestationRejected_Call) RunAndReturn(run func(context.Context, payerreport.ReportID) error) *MockIPayerReportStore_SetReportAttestationRejected_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetReportSettled provides a mock function with given fields: ctx, id
+func (_m *MockIPayerReportStore) SetReportSettled(ctx context.Context, id payerreport.ReportID) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetReportSettled")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockIPayerReportStore_SetReportSettled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReportSettled'
+type MockIPayerReportStore_SetReportSettled_Call struct {
+	*mock.Call
+}
+
+// SetReportSettled is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id payerreport.ReportID
+func (_e *MockIPayerReportStore_Expecter) SetReportSettled(ctx interface{}, id interface{}) *MockIPayerReportStore_SetReportSettled_Call {
+	return &MockIPayerReportStore_SetReportSettled_Call{Call: _e.mock.On("SetReportSettled", ctx, id)}
+}
+
+func (_c *MockIPayerReportStore_SetReportSettled_Call) Run(run func(ctx context.Context, id payerreport.ReportID)) *MockIPayerReportStore_SetReportSettled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(payerreport.ReportID))
+	})
+	return _c
+}
+
+func (_c *MockIPayerReportStore_SetReportSettled_Call) Return(_a0 error) *MockIPayerReportStore_SetReportSettled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockIPayerReportStore_SetReportSettled_Call) RunAndReturn(run func(context.Context, payerreport.ReportID) error) *MockIPayerReportStore_SetReportSettled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetReportSubmitted provides a mock function with given fields: ctx, id
+func (_m *MockIPayerReportStore) SetReportSubmitted(ctx context.Context, id payerreport.ReportID) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetReportSubmitted")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockIPayerReportStore_SetReportSubmitted_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReportSubmitted'
+type MockIPayerReportStore_SetReportSubmitted_Call struct {
+	*mock.Call
+}
+
+// SetReportSubmitted is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id payerreport.ReportID
+func (_e *MockIPayerReportStore_Expecter) SetReportSubmitted(ctx interface{}, id interface{}) *MockIPayerReportStore_SetReportSubmitted_Call {
+	return &MockIPayerReportStore_SetReportSubmitted_Call{Call: _e.mock.On("SetReportSubmitted", ctx, id)}
+}
+
+func (_c *MockIPayerReportStore_SetReportSubmitted_Call) Run(run func(ctx context.Context, id payerreport.ReportID)) *MockIPayerReportStore_SetReportSubmitted_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(payerreport.ReportID))
+	})
+	return _c
+}
+
+func (_c *MockIPayerReportStore_SetReportSubmitted_Call) Return(_a0 error) *MockIPayerReportStore_SetReportSubmitted_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockIPayerReportStore_SetReportSubmitted_Call) RunAndReturn(run func(context.Context, payerreport.ReportID) error) *MockIPayerReportStore_SetReportSubmitted_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/payerreport/interface.go
+++ b/pkg/payerreport/interface.go
@@ -59,17 +59,9 @@ type IPayerReportStore interface {
 		envelope *envelopes.OriginatorEnvelope,
 		payerID int32,
 	) error
-	SetReportAttestationStatus(
-		ctx context.Context,
-		id ReportID,
-		fromStatus []AttestationStatus,
-		toStatus AttestationStatus,
-	) error
-	SetReportSubmissionStatus(
-		ctx context.Context,
-		id ReportID,
-		fromStatus []SubmissionStatus,
-		toStatus SubmissionStatus,
-	) error
+	SetReportSubmitted(ctx context.Context, id ReportID) error
+	SetReportSettled(ctx context.Context, id ReportID) error
+	SetReportAttestationApproved(ctx context.Context, id ReportID) error
+	SetReportAttestationRejected(ctx context.Context, id ReportID) error
 	Queries() *queries.Queries
 }

--- a/pkg/payerreport/workers/attestation.go
+++ b/pkg/payerreport/workers/attestation.go
@@ -227,10 +227,5 @@ func (w *AttestationWorker) signClientEnvelope(
 }
 
 func (w *AttestationWorker) rejectAttestation(report *payerreport.PayerReportWithStatus) error {
-	return w.store.SetReportAttestationStatus(
-		w.ctx,
-		report.ID,
-		[]payerreport.AttestationStatus{payerreport.AttestationPending},
-		payerreport.AttestationRejected,
-	)
+	return w.store.SetReportAttestationRejected(w.ctx, report.ID)
 }

--- a/pkg/payerreport/workers/attestation_test.go
+++ b/pkg/payerreport/workers/attestation_test.go
@@ -57,23 +57,6 @@ func storeReport(
 	return reportWithStatus
 }
 
-func setReportAttestationStatus(
-	t *testing.T,
-	store payerreport.IPayerReportStore,
-	id payerreport.ReportID,
-	attestationStatus payerreport.AttestationStatus,
-) {
-	require.NoError(
-		t,
-		store.SetReportAttestationStatus(
-			t.Context(),
-			id,
-			[]payerreport.AttestationStatus{payerreport.AttestationPending},
-			attestationStatus,
-		),
-	)
-}
-
 func TestFindReport(t *testing.T) {
 	worker, store, _, _ := testAttestationWorker(t, time.Second)
 
@@ -92,7 +75,13 @@ func TestFindReport(t *testing.T) {
 	require.Len(t, reports, 1)
 	require.Equal(t, storedReport.ID, reports[0].ID)
 
-	setReportAttestationStatus(t, store, storedReport.ID, payerreport.AttestationApproved)
+	require.NoError(
+		t,
+		store.SetReportAttestationApproved(
+			t.Context(),
+			storedReport.ID,
+		),
+	)
 
 	reports, err = worker.findReportsNeedingAttestation()
 	require.NoError(t, err)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -232,6 +232,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 // indirect
+	github.com/pganalyze/pg_query_go/v5 v5.1.0 // indirect
 	github.com/pganalyze/pg_query_go/v6 v6.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.16 // indirect
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1495,6 +1495,7 @@ github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNH
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
+github.com/pganalyze/pg_query_go/v5 v5.1.0/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
 github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
 github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=


### PR DESCRIPTION
### TL;DR

Refactored payer report status management and added functionality to clear unsettled usage when reports are settled.

### What changed?

- Added a new `ClearUnsettledUsage` SQL query to delete unsettled usage records for an originator up to a specific time
- Added a `FetchPayerReport` query to retrieve a single payer report by ID
- Replaced string manipulation in SQL queries with proper PostgreSQL array parameters using `pq.Array`
- Simplified the report status management API by replacing generic status transition methods with specific, purpose-named methods:
    - `SetReportSubmitted`
    - `SetReportSettled`
    - `SetReportAttestationApproved`
    - `SetReportAttestationRejected`
- Implemented the `PayerReportSubsetSettled` event handler to properly mark reports as settled and clear associated unsettled usage
- Added comprehensive tests for the new settlement functionality

### How to test?

1. Create a payer report with unsettled usage
2. Call `SetReportSettled` on the report
3. Verify that:
    - The report status changes to `SubmissionSettled`
    - Unsettled usage records for that originator up to the report's end minute are cleared
    - Unsettled usage records after the end minute remain intact
    - Unsettled usage for other originators is not affected

### Why make this change?

This change improves the settlement process by automatically clearing unsettled usage records once a report is settled on-chain. This prevents double-counting of usage in future reports and maintains data integrity. The refactored API also makes the code more maintainable by providing clear, purpose-specific methods for state transitions rather than generic methods that could be misused.