### PR TITLE
Pass contract options correctly

### DIFF
--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -14,8 +14,6 @@ type MigrationServerOptions struct {
 	BatchSize              int32         `long:"batch-size"               env:"XMTPD_MIGRATION_DB_BATCH_SIZE"               description:"Batch size for migration"                       default:"1000"`
 	PollInterval           time.Duration `long:"process-interval"         env:"XMTPD_MIGRATION_DB_PROCESS_INTERVAL"         description:"Interval for processing migration"              default:"10s"`
 	Namespace              string        `long:"namespace"                env:"XMTPD_MIGRATION_DB_NAMESPACE"                description:"Namespace for migration"                        default:""`
-
-	Contracts ContractsOptions `group:"Contracts Options" namespace:"contracts"`
 }
 
 type MigrationClientOptions struct {

--- a/pkg/migrator/builder.go
+++ b/pkg/migrator/builder.go
@@ -14,13 +14,14 @@ func setupBlockchainPublisher(
 	ctx context.Context,
 	log *zap.Logger,
 	db *sql.DB,
-	cfg *config.MigrationServerOptions,
+	payerPrivateKey string,
+	cfg *config.ContractsOptions,
 ) (*blockchain.BlockchainPublisher, error) {
 	nonceManager := sqlmgr.NewSQLBackedNonceManager(db, log)
 
 	signer, err := blockchain.NewPrivateKeySigner(
-		cfg.PayerPrivateKey,
-		cfg.Contracts.AppChain.ChainID,
+		payerPrivateKey,
+		cfg.AppChain.ChainID,
 	)
 	if err != nil {
 		return nil, err
@@ -28,7 +29,7 @@ func setupBlockchainPublisher(
 
 	appChainClient, err := blockchain.NewRPCClient(
 		ctx,
-		cfg.Contracts.AppChain.RPCURL,
+		cfg.AppChain.RPCURL,
 	)
 	if err != nil {
 		return nil, err
@@ -39,7 +40,7 @@ func setupBlockchainPublisher(
 		log,
 		appChainClient,
 		signer,
-		cfg.Contracts,
+		*cfg,
 		nonceManager,
 	)
 }

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -169,7 +169,13 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 
 	transformer := NewTransformer(payerPrivateKey, nodeSigningKey)
 
-	blockchainPublisher, err := setupBlockchainPublisher(cfg.ctx, logger, cfg.db, cfg.options.PayerPrivateKey, cfg.contracts)
+	blockchainPublisher, err := setupBlockchainPublisher(
+		cfg.ctx,
+		logger,
+		cfg.db,
+		cfg.options.PayerPrivateKey,
+		cfg.contracts,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -124,6 +124,10 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 		return nil, errors.New("migrator options are required")
 	}
 
+	if cfg.contracts == nil {
+		return nil, errors.New("contracts are required")
+	}
+
 	if cfg.options.ReaderConnectionString == "" {
 		return nil, errors.New("reader connection string is required")
 	}

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -41,10 +41,11 @@ const (
 )
 
 type DBMigratorConfig struct {
-	ctx     context.Context
-	log     *zap.Logger
-	db      *sql.DB
-	options *config.MigrationServerOptions
+	ctx       context.Context
+	log       *zap.Logger
+	db        *sql.DB
+	options   *config.MigrationServerOptions
+	contracts *config.ContractsOptions
 }
 
 type DBMigratorOption func(*DBMigratorConfig)
@@ -70,6 +71,12 @@ func WithDestinationDB(db *sql.DB) DBMigratorOption {
 func WithMigratorConfig(options *config.MigrationServerOptions) DBMigratorOption {
 	return func(cfg *DBMigratorConfig) {
 		cfg.options = options
+	}
+}
+
+func WithContractsOptions(contracts *config.ContractsOptions) DBMigratorOption {
+	return func(cfg *DBMigratorConfig) {
+		cfg.contracts = contracts
 	}
 }
 
@@ -162,7 +169,7 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 
 	transformer := NewTransformer(payerPrivateKey, nodeSigningKey)
 
-	blockchainPublisher, err := setupBlockchainPublisher(cfg.ctx, logger, cfg.db, cfg.options)
+	blockchainPublisher, err := setupBlockchainPublisher(cfg.ctx, logger, cfg.db, cfg.options.PayerPrivateKey, cfg.contracts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -65,8 +65,8 @@ func newMigratorTest(t *testing.T) *migratorTest {
 			WaitForDB:              5 * time.Second,
 			BatchSize:              1000,
 			PollInterval:           500 * time.Millisecond,
-			Contracts:              chainConfig,
 		}),
+		migrator.WithContractsOptions(&chainConfig),
 	)
 	require.NoError(t, err)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -246,6 +246,7 @@ func NewReplicationServer(
 			migrator.WithLogger(cfg.Log),
 			migrator.WithDestinationDB(cfg.DB),
 			migrator.WithMigratorConfig(&cfg.Options.MigrationServer),
+			migrator.WithContractsOptions(&cfg.Options.Contracts),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Require explicit `config.ContractsOptions` and payer private key in `migrator.NewMigrationService` and `migrator.setupBlockchainPublisher` to pass contract options correctly during migration setup
This refactor removes contracts from migration server config and makes the migrator require contract options and the payer private key explicitly.

- Add `contracts` to `DBMigratorConfig`, introduce `migrator.WithContractsOptions`, and make `migrator.NewMigrationService` return error "contracts are required" when missing in [migrator.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693)
- Change `migrator.setupBlockchainPublisher` to accept `payerPrivateKey string` and `*config.ContractsOptions`; update internal references and pass `*cfg` to `NewBlockchainPublisher` in [builder.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-46e4864b80a90cb84cdeb5bbfd4e38c43e8e721f6d561a0c561e872602970746)
- Remove `Contracts` from `config.MigrationServerOptions` in [migration.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-87c3e997fe7ecbf4c63d056ef11ed04d37b5ba302027c9efd6432f1a8c15880a)
- Pass `migrator.WithContractsOptions(&cfg.Options.Contracts)` from the server when migration is enabled in [server.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996)
- Update tests to provide contracts via `migrator.WithContractsOptions` in [migrator_test.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-e7344016aadd58a42e5066743aaa1f3c963766d2838ef917dbbd852d1a8f50b1)

#### 📍Where to Start
Start with `migrator.NewMigrationService` and the new `WithContractsOptions` path in [migrator.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693), then follow the call into `migrator.setupBlockchainPublisher` in [builder.go](https://github.com/xmtp/xmtpd/pull/1087/files#diff-46e4864b80a90cb84cdeb5bbfd4e38c43e8e721f6d561a0c561e872602970746).

----

_[Macroscope](https://app.macroscope.com) summarized c65bb3e._