### PR TITLE
More pause CLI commands

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -601,7 +601,7 @@ func setPause(logger *zap.Logger, options *CLI) {
 	appChainAdmin, err := setupAppChainAdmin(
 		ctx,
 		logger,
-		options.GetPause.AdminOptions.AdminPrivateKey,
+		options.SetPause.AdminOptions.AdminPrivateKey,
 		options,
 	)
 	if err != nil {
@@ -611,7 +611,7 @@ func setPause(logger *zap.Logger, options *CLI) {
 	settlementChainAdmin, err := setupSettlementChainAdmin(
 		ctx,
 		logger,
-		options.GetPause.AdminOptions.AdminPrivateKey,
+		options.SetPause.AdminOptions.AdminPrivateKey,
 		options,
 	)
 	if err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1076,6 +1076,11 @@ func setupAppChainAdmin(
 		return nil, fmt.Errorf("identity update broadcaster address is required")
 	}
 
+	// TODO(mkysel) https://github.com/xmtp/smart-contracts/issues/125
+	//if options.Contracts.AppChain.GatewayAddress == "" {
+	//	return nil, fmt.Errorf("gateway address is required")
+	//}
+
 	chainClient, err := blockchain.NewRPCClient(
 		ctx,
 		options.Contracts.AppChain.RPCURL,
@@ -1124,6 +1129,18 @@ func setupSettlementChainAdmin(
 	if options.Contracts.SettlementChain.ChainID == 0 {
 		return nil, fmt.Errorf("chain id is required")
 	}
+
+	if options.Contracts.SettlementChain.PayerRegistryAddress == "" {
+		return nil, fmt.Errorf("payer registry address is required")
+	}
+	if options.Contracts.SettlementChain.DistributionManagerAddress == "" {
+		return nil, fmt.Errorf("distribution manager address is required")
+	}
+
+	// TODO(mkysel) https://github.com/xmtp/smart-contracts/issues/125
+	//if options.Contracts.SettlementChain.GatewayAddress == "" {
+	//	return nil, fmt.Errorf("gateway address is required")
+	//}
 
 	chainClient, err := blockchain.NewRPCClient(
 		ctx,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -660,6 +660,14 @@ func setPause(logger *zap.Logger, options *CLI) {
 			"payer registry pause status set",
 			zap.Bool("paused", options.SetPause.Paused.Bool()),
 		)
+	case config.TargetDistributionManager:
+		if err := settlementChainAdmin.SetDistributionManagerPauseStatus(ctx, options.SetPause.Paused.Bool()); err != nil {
+			logger.Fatal("could not set distribution manager pause status", zap.Error(err))
+		}
+		logger.Info(
+			"distribution manager pause status set",
+			zap.Bool("paused", options.SetPause.Paused.Bool()),
+		)
 	}
 }
 
@@ -718,6 +726,12 @@ func getPause(logger *zap.Logger, options *CLI) {
 			logger.Fatal("could not get payer registry pause status", zap.Error(err))
 		}
 		logger.Info("payer registry pause status", zap.Bool("paused", paused))
+	case config.TargetDistributionManager:
+		paused, err := settlementChainAdmin.GetDistributionManagerPauseStatus(ctx)
+		if err != nil {
+			logger.Fatal("could not get distribution manager pause status", zap.Error(err))
+		}
+		logger.Info("distribution manager pause status", zap.Bool("paused", paused))
 	}
 }
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -652,6 +652,14 @@ func setPause(logger *zap.Logger, options *CLI) {
 			"settlement chain gateway pause status set",
 			zap.Bool("paused", options.SetPause.Paused.Bool()),
 		)
+	case config.TargetPayerRegistry:
+		if err := settlementChainAdmin.SetPayerRegistryPauseStatus(ctx, options.SetPause.Paused.Bool()); err != nil {
+			logger.Fatal("could not set payer registry pause status", zap.Error(err))
+		}
+		logger.Info(
+			"payer registry pause status set",
+			zap.Bool("paused", options.SetPause.Paused.Bool()),
+		)
 	}
 }
 
@@ -704,6 +712,12 @@ func getPause(logger *zap.Logger, options *CLI) {
 			logger.Fatal("could not get settlementchain gateway pause status", zap.Error(err))
 		}
 		logger.Info("settlement-chain gateway pause status", zap.Bool("paused", paused))
+	case config.TargetPayerRegistry:
+		paused, err := settlementChainAdmin.GetPayerRegistryPauseStatus(ctx)
+		if err != nil {
+			logger.Fatal("could not get payer registry pause status", zap.Error(err))
+		}
+		logger.Info("payer registry pause status", zap.Bool("paused", paused))
 	}
 }
 

--- a/pkg/blockchain/appchainAdmin.go
+++ b/pkg/blockchain/appchainAdmin.go
@@ -65,7 +65,7 @@ func NewAppChainAdmin(
 	}
 
 	acGateway, err := acg.NewAppChainGateway(
-		common.HexToAddress(contractsOptions.AppChain.GroupMessageBroadcasterAddress),
+		common.HexToAddress(contractsOptions.AppChain.GatewayAddress),
 		client,
 	)
 	if err != nil {

--- a/pkg/blockchain/appchainAdmin_test.go
+++ b/pkg/blockchain/appchainAdmin_test.go
@@ -167,58 +167,65 @@ func TestPauseFlags(t *testing.T) {
 
 	for _, tc := range cases {
 		tc := tc
-
-		t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
-			var err error
-			require.NoError(t, tc.set(ctx, true))
-			b, err := paramAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.True(t, b)
-
-			got, err := tc.get(ctx)
-			require.NoError(t, err)
-			require.True(t, got)
-
-			require.NoError(t, tc.set(ctx, false))
-			b, err = paramAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.False(t, b)
-
-			got, err = tc.get(ctx)
-			require.NoError(t, err)
-			require.False(t, got)
-		})
-
-		t.Run(tc.name+"/idempotent_repeat_true", func(t *testing.T) {
-			require.NoError(t, tc.set(ctx, true))
-			require.NoError(t, tc.set(ctx, true))
-
-			got, err := tc.get(ctx)
-			require.NoError(t, err)
-			require.True(t, got)
-		})
-
-		t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
-			newAppAdmin, newParamAdmin := buildAppChainAdmin(t)
-
-			var got bool
-			var err error
-			switch tc.name {
-			case "group":
-				got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
-			case "identity":
-				got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
-			case "app-chain-gateway":
-				got, err = newAppAdmin.GetAppChainGatewayPauseStatus(ctx)
-			default:
-				got, err = false, errors.New("invalid option")
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "app-chain-gateway" {
+				t.Skip(
+					"No contract address known: https://github.com/xmtp/smart-contracts/issues/125",
+				)
 			}
-			require.NoError(t, err)
-			require.False(t, got)
 
-			b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.False(t, b)
+			t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
+				var err error
+				require.NoError(t, tc.set(ctx, true))
+				b, err := paramAdmin.GetParameterBool(ctx, tc.key)
+				require.NoError(t, err)
+				require.True(t, b)
+
+				got, err := tc.get(ctx)
+				require.NoError(t, err)
+				require.True(t, got)
+
+				require.NoError(t, tc.set(ctx, false))
+				b, err = paramAdmin.GetParameterBool(ctx, tc.key)
+				require.NoError(t, err)
+				require.False(t, b)
+
+				got, err = tc.get(ctx)
+				require.NoError(t, err)
+				require.False(t, got)
+			})
+
+			t.Run(tc.name+"/idempotent_repeat_true", func(t *testing.T) {
+				require.NoError(t, tc.set(ctx, true))
+				require.NoError(t, tc.set(ctx, true))
+
+				got, err := tc.get(ctx)
+				require.NoError(t, err)
+				require.True(t, got)
+			})
+
+			t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
+				newAppAdmin, newParamAdmin := buildAppChainAdmin(t)
+
+				var got bool
+				var err error
+				switch tc.name {
+				case "group":
+					got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
+				case "identity":
+					got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
+				case "app-chain-gateway":
+					got, err = newAppAdmin.GetAppChainGatewayPauseStatus(ctx)
+				default:
+					got, err = false, errors.New("invalid option")
+				}
+				require.NoError(t, err)
+				require.False(t, got)
+
+				b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
+				require.NoError(t, err)
+				require.False(t, b)
+			})
 		})
 	}
 }

--- a/pkg/blockchain/appchainAdmin_test.go
+++ b/pkg/blockchain/appchainAdmin_test.go
@@ -2,6 +2,7 @@ package blockchain_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -112,8 +113,10 @@ func TestBootstrapperAddress(t *testing.T) {
 				switch tc.name {
 				case "identity":
 					return newAppAdmin.GetIdentityUpdateBootstrapper(ctx)
-				default:
+				case "group":
 					return newAppAdmin.GetGroupMessageBootstrapper(ctx)
+				default:
+					return common.Address{}, nil
 				}
 			}()
 			require.NoError(t, err)
@@ -203,8 +206,12 @@ func TestPauseFlags(t *testing.T) {
 			switch tc.name {
 			case "group":
 				got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
-			default:
+			case "identity":
 				got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
+			case "app-chain-gateway":
+				got, err = newAppAdmin.GetAppChainGatewayPauseStatus(ctx)
+			default:
+				got, err = false, errors.New("invalid option")
 			}
 			require.NoError(t, err)
 			require.False(t, got)

--- a/pkg/blockchain/appchainAdmin_test.go
+++ b/pkg/blockchain/appchainAdmin_test.go
@@ -154,6 +154,12 @@ func TestPauseFlags(t *testing.T) {
 			set:  appAdmin.SetIdentityUpdatePauseStatus,
 			get:  appAdmin.GetIdentityUpdatePauseStatus,
 		},
+		{
+			name: "app-chain-gateway",
+			key:  blockchain.APP_CHAIN_GATEWAY_PAUSED_KEY,
+			set:  appAdmin.SetAppChainGatewayPauseStatus,
+			get:  appAdmin.GetAppChainGatewayPauseStatus,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/blockchain/parameterAdmin.go
+++ b/pkg/blockchain/parameterAdmin.go
@@ -20,6 +20,8 @@ const (
 	GROUP_MESSAGE_PAYLOAD_BOOTSTRAPPER_KEY   = "xmtp.groupMessageBroadcaster.payloadBootstrapper"
 	IDENTITY_UPDATE_PAUSED_KEY               = "xmtp.identityUpdateBroadcaster.paused"
 	GROUP_MESSAGE_PAUSED_KEY                 = "xmtp.groupMessageBroadcaster.paused"
+	APP_CHAIN_GATEWAY_PAUSED_KEY             = "xmtp.appChainGateway.paused"
+	SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY      = "xmtp.settlementChainGateway.paused"
 )
 
 type ParameterAdmin struct {

--- a/pkg/blockchain/parameterAdmin.go
+++ b/pkg/blockchain/parameterAdmin.go
@@ -23,6 +23,7 @@ const (
 	APP_CHAIN_GATEWAY_PAUSED_KEY             = "xmtp.appChainGateway.paused"
 	SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY      = "xmtp.settlementChainGateway.paused"
 	PAYER_REGISTRY_PAUSED_KEY                = "xmtp.payerRegistry.paused"
+	DISTRIBUTION_MANAGER_PAUSED_KEY          = "xmtp.distributionManager.paused"
 )
 
 type ParameterAdmin struct {

--- a/pkg/blockchain/parameterAdmin.go
+++ b/pkg/blockchain/parameterAdmin.go
@@ -22,6 +22,7 @@ const (
 	GROUP_MESSAGE_PAUSED_KEY                 = "xmtp.groupMessageBroadcaster.paused"
 	APP_CHAIN_GATEWAY_PAUSED_KEY             = "xmtp.appChainGateway.paused"
 	SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY      = "xmtp.settlementChainGateway.paused"
+	PAYER_REGISTRY_PAUSED_KEY                = "xmtp.payerRegistry.paused"
 )
 
 type ParameterAdmin struct {

--- a/pkg/blockchain/settlementChainAdmin.go
+++ b/pkg/blockchain/settlementChainAdmin.go
@@ -1,0 +1,102 @@
+package blockchain
+
+import (
+	"context"
+
+	scg "github.com/xmtp/xmtpd/pkg/abi/settlementchaingateway"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/xmtp/xmtpd/pkg/config"
+	"go.uber.org/zap"
+)
+
+type ISettlementChainAdmin interface {
+	GetSettlementChainGatewayPauseStatus(ctx context.Context) (bool, error)
+	SetSettlementChainGatewayPauseStatus(ctx context.Context, paused bool) error
+}
+
+type settlementChainAdmin struct {
+	client                 *ethclient.Client
+	signer                 TransactionSigner
+	logger                 *zap.Logger
+	parameterAdmin         *ParameterAdmin
+	settlementChainGateway *scg.SettlementChainGateway
+}
+
+func (s settlementChainAdmin) GetSettlementChainGatewayPauseStatus(
+	ctx context.Context,
+) (bool, error) {
+	return s.parameterAdmin.GetParameterBool(ctx, SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY)
+}
+
+func (s settlementChainAdmin) SetSettlementChainGatewayPauseStatus(
+	ctx context.Context,
+	paused bool,
+) error {
+	if err := s.parameterAdmin.SetBoolParameter(ctx, SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY, paused); err != nil {
+		return err
+	}
+
+	err := ExecuteTransaction(
+		ctx,
+		s.signer,
+		s.logger,
+		s.client,
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return s.settlementChainGateway.UpdatePauseStatus(opts)
+		},
+		func(log *types.Log) (interface{}, error) {
+			return s.settlementChainGateway.ParsePauseStatusUpdated(*log)
+		},
+		func(event interface{}) {
+			ev, ok := event.(*scg.SettlementChainGatewayPauseStatusUpdated)
+			if !ok {
+				s.logger.Error(
+					"unexpected event type, not of type SettlementChainGatewayPauseStatusUpdated",
+				)
+				return
+			}
+			s.logger.Info(
+				"settlement-chain gateway pause status updated",
+				zap.Bool("paused", ev.Paused),
+			)
+		},
+	)
+	if err != nil {
+		if err.IsNoChange() {
+			s.logger.Info("No update needed")
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+var _ ISettlementChainAdmin = (*settlementChainAdmin)(nil)
+
+func NewSettlementChainAdmin(
+	logger *zap.Logger,
+	client *ethclient.Client,
+	signer TransactionSigner,
+	contractsOptions config.ContractsOptions,
+	parameterAdmin *ParameterAdmin,
+) (*settlementChainAdmin, error) {
+	acGateway, err := scg.NewSettlementChainGateway(
+		common.HexToAddress(contractsOptions.AppChain.GroupMessageBroadcasterAddress),
+		client,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &settlementChainAdmin{
+		client:                 client,
+		signer:                 signer,
+		logger:                 logger.Named("AppChainAdmin"),
+		parameterAdmin:         parameterAdmin,
+		settlementChainGateway: acGateway,
+	}, nil
+}

--- a/pkg/blockchain/settlementchainAdmin_test.go
+++ b/pkg/blockchain/settlementchainAdmin_test.go
@@ -70,6 +70,12 @@ func TestPauseFlagsSettlement(t *testing.T) {
 			set:  settlementChainAdmin.SetPayerRegistryPauseStatus,
 			get:  settlementChainAdmin.GetPayerRegistryPauseStatus,
 		},
+		{
+			name: "distribution-manager",
+			key:  blockchain.DISTRIBUTION_MANAGER_PAUSED_KEY,
+			set:  settlementChainAdmin.SetDistributionManagerPauseStatus,
+			get:  settlementChainAdmin.GetDistributionManagerPauseStatus,
+		},
 	}
 
 	for _, tc := range cases {
@@ -121,6 +127,8 @@ func TestPauseFlagsSettlement(t *testing.T) {
 					got, err = newSettlementAdmin.GetSettlementChainGatewayPauseStatus(ctx)
 				case "payer-registry":
 					got, err = newSettlementAdmin.GetPayerRegistryPauseStatus(ctx)
+				case "distribution-manager":
+					got, err = newSettlementAdmin.GetDistributionManagerPauseStatus(ctx)
 				default:
 					got, err = false, errors.New("invalid option")
 				}

--- a/pkg/blockchain/settlementchainAdmin_test.go
+++ b/pkg/blockchain/settlementchainAdmin_test.go
@@ -74,56 +74,63 @@ func TestPauseFlagsSettlement(t *testing.T) {
 
 	for _, tc := range cases {
 		tc := tc
-
-		t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
-			var err error
-			require.NoError(t, tc.set(ctx, true))
-			b, err := paramAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.True(t, b)
-
-			got, err := tc.get(ctx)
-			require.NoError(t, err)
-			require.True(t, got)
-
-			require.NoError(t, tc.set(ctx, false))
-			b, err = paramAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.False(t, b)
-
-			got, err = tc.get(ctx)
-			require.NoError(t, err)
-			require.False(t, got)
-		})
-
-		t.Run(tc.name+"/idempotent_repeat_true", func(t *testing.T) {
-			require.NoError(t, tc.set(ctx, true))
-			require.NoError(t, tc.set(ctx, true))
-
-			got, err := tc.get(ctx)
-			require.NoError(t, err)
-			require.True(t, got)
-		})
-
-		t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
-			newSettlementAdmin, newParamAdmin := buildSettlementChainAdmin(t)
-
-			var got bool
-			var err error
-			switch tc.name {
-			case "settlement-chain-gateway":
-				got, err = newSettlementAdmin.GetSettlementChainGatewayPauseStatus(ctx)
-			case "payer-registry":
-				got, err = newSettlementAdmin.GetPayerRegistryPauseStatus(ctx)
-			default:
-				got, err = false, errors.New("invalid option")
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "settlement-chain-gateway" {
+				t.Skip(
+					"No contract address known: https://github.com/xmtp/smart-contracts/issues/125",
+				)
 			}
-			require.NoError(t, err)
-			require.False(t, got)
 
-			b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.False(t, b)
+			t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
+				var err error
+				require.NoError(t, tc.set(ctx, true))
+				b, err := paramAdmin.GetParameterBool(ctx, tc.key)
+				require.NoError(t, err)
+				require.True(t, b)
+
+				got, err := tc.get(ctx)
+				require.NoError(t, err)
+				require.True(t, got)
+
+				require.NoError(t, tc.set(ctx, false))
+				b, err = paramAdmin.GetParameterBool(ctx, tc.key)
+				require.NoError(t, err)
+				require.False(t, b)
+
+				got, err = tc.get(ctx)
+				require.NoError(t, err)
+				require.False(t, got)
+			})
+
+			t.Run(tc.name+"/idempotent_repeat_true", func(t *testing.T) {
+				require.NoError(t, tc.set(ctx, true))
+				require.NoError(t, tc.set(ctx, true))
+
+				got, err := tc.get(ctx)
+				require.NoError(t, err)
+				require.True(t, got)
+			})
+
+			t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
+				newSettlementAdmin, newParamAdmin := buildSettlementChainAdmin(t)
+
+				var got bool
+				var err error
+				switch tc.name {
+				case "settlement-chain-gateway":
+					got, err = newSettlementAdmin.GetSettlementChainGatewayPauseStatus(ctx)
+				case "payer-registry":
+					got, err = newSettlementAdmin.GetPayerRegistryPauseStatus(ctx)
+				default:
+					got, err = false, errors.New("invalid option")
+				}
+				require.NoError(t, err)
+				require.False(t, got)
+
+				b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
+				require.NoError(t, err)
+				require.False(t, b)
+			})
 		})
 	}
 }

--- a/pkg/blockchain/settlementchainAdmin_test.go
+++ b/pkg/blockchain/settlementchainAdmin_test.go
@@ -34,7 +34,7 @@ func buildSettlementChainAdmin(
 	paramAdmin, err := blockchain.NewParameterAdmin(logger, client, signer, contractsOptions)
 	require.NoError(t, err)
 
-	appAdmin, err := blockchain.NewSettlementChainAdmin(
+	settlementChainAdmin, err := blockchain.NewSettlementChainAdmin(
 		logger,
 		client,
 		signer,
@@ -43,11 +43,11 @@ func buildSettlementChainAdmin(
 	)
 	require.NoError(t, err)
 
-	return appAdmin, paramAdmin
+	return settlementChainAdmin, paramAdmin
 }
 
 func TestPauseFlagsSettlement(t *testing.T) {
-	appAdmin, paramAdmin := buildSettlementChainAdmin(t)
+	settlementChainAdmin, paramAdmin := buildSettlementChainAdmin(t)
 	ctx := context.Background()
 
 	type pauseCase struct {
@@ -61,14 +61,14 @@ func TestPauseFlagsSettlement(t *testing.T) {
 		{
 			name: "settlement-chain-gateway",
 			key:  blockchain.SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY,
-			set:  appAdmin.SetSettlementChainGatewayPauseStatus,
-			get:  appAdmin.GetSettlementChainGatewayPauseStatus,
+			set:  settlementChainAdmin.SetSettlementChainGatewayPauseStatus,
+			get:  settlementChainAdmin.GetSettlementChainGatewayPauseStatus,
 		},
 		{
 			name: "payer-registry",
 			key:  blockchain.PAYER_REGISTRY_PAUSED_KEY,
-			set:  appAdmin.SetPayerRegistryPauseStatus,
-			get:  appAdmin.GetPayerRegistryPauseStatus,
+			set:  settlementChainAdmin.SetPayerRegistryPauseStatus,
+			get:  settlementChainAdmin.GetPayerRegistryPauseStatus,
 		},
 	}
 

--- a/pkg/blockchain/settlementchainAdmin_test.go
+++ b/pkg/blockchain/settlementchainAdmin_test.go
@@ -63,6 +63,12 @@ func TestPauseFlagsSettlement(t *testing.T) {
 			set:  appAdmin.SetSettlementChainGatewayPauseStatus,
 			get:  appAdmin.GetSettlementChainGatewayPauseStatus,
 		},
+		{
+			name: "payer-registry",
+			key:  blockchain.PAYER_REGISTRY_PAUSED_KEY,
+			set:  appAdmin.SetPayerRegistryPauseStatus,
+			get:  appAdmin.GetPayerRegistryPauseStatus,
+		},
 	}
 
 	for _, tc := range cases {
@@ -97,24 +103,24 @@ func TestPauseFlagsSettlement(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, got)
 		})
-
-		t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
-			newAppAdmin, newParamAdmin := buildAppChainAdmin(t)
-
-			var got bool
-			var err error
-			switch tc.name {
-			case "group":
-				got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
-			default:
-				got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
-			}
-			require.NoError(t, err)
-			require.False(t, got)
-
-			b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
-			require.NoError(t, err)
-			require.False(t, b)
-		})
+		//
+		//t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
+		//	newAppAdmin, newParamAdmin := buildSettlementChainAdmin(t)
+		//
+		//	var got bool
+		//	var err error
+		//	switch tc.name {
+		//	case "group":
+		//		got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
+		//	default:
+		//		got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
+		//	}
+		//	require.NoError(t, err)
+		//	require.False(t, got)
+		//
+		//	b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
+		//	require.NoError(t, err)
+		//	require.False(t, b)
+		//})
 	}
 }

--- a/pkg/blockchain/settlementchainAdmin_test.go
+++ b/pkg/blockchain/settlementchainAdmin_test.go
@@ -1,0 +1,120 @@
+package blockchain_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/xmtp/xmtpd/pkg/blockchain"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/testutils/anvil"
+)
+
+func buildSettlementChainAdmin(
+	t *testing.T,
+) (blockchain.ISettlementChainAdmin, *blockchain.ParameterAdmin) {
+	t.Helper()
+
+	ctx := context.Background()
+	logger := testutils.NewLog(t)
+	wsURL, rpcURL := anvil.StartAnvil(t, false)
+	contractsOptions := testutils.NewContractsOptions(t, rpcURL, wsURL)
+
+	signer, err := blockchain.NewPrivateKeySigner(
+		testutils.LOCAL_PRIVATE_KEY,
+		contractsOptions.SettlementChain.ChainID,
+	)
+	require.NoError(t, err)
+
+	client, err := blockchain.NewRPCClient(ctx, contractsOptions.SettlementChain.RPCURL)
+	require.NoError(t, err)
+
+	paramAdmin, err := blockchain.NewParameterAdmin(logger, client, signer, contractsOptions)
+	require.NoError(t, err)
+
+	appAdmin, err := blockchain.NewSettlementChainAdmin(
+		logger,
+		client,
+		signer,
+		contractsOptions,
+		paramAdmin,
+	)
+	require.NoError(t, err)
+
+	return appAdmin, paramAdmin
+}
+
+func TestPauseFlagsSettlement(t *testing.T) {
+	appAdmin, paramAdmin := buildSettlementChainAdmin(t)
+	ctx := context.Background()
+
+	type pauseCase struct {
+		name string
+		key  string
+		set  func(ctx context.Context, paused bool) error
+		get  func(ctx context.Context) (bool, error)
+	}
+
+	cases := []pauseCase{
+		{
+			name: "settlement-chain-gateway",
+			key:  blockchain.SETTLEMENT_CHAIN_GATEWAY_PAUSED_KEY,
+			set:  appAdmin.SetSettlementChainGatewayPauseStatus,
+			get:  appAdmin.GetSettlementChainGatewayPauseStatus,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
+			var err error
+			require.NoError(t, tc.set(ctx, true))
+			b, err := paramAdmin.GetParameterBool(ctx, tc.key)
+			require.NoError(t, err)
+			require.True(t, b)
+
+			got, err := tc.get(ctx)
+			require.NoError(t, err)
+			require.True(t, got)
+
+			require.NoError(t, tc.set(ctx, false))
+			b, err = paramAdmin.GetParameterBool(ctx, tc.key)
+			require.NoError(t, err)
+			require.False(t, b)
+
+			got, err = tc.get(ctx)
+			require.NoError(t, err)
+			require.False(t, got)
+		})
+
+		t.Run(tc.name+"/idempotent_repeat_true", func(t *testing.T) {
+			require.NoError(t, tc.set(ctx, true))
+			require.NoError(t, tc.set(ctx, true))
+
+			got, err := tc.get(ctx)
+			require.NoError(t, err)
+			require.True(t, got)
+		})
+
+		t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
+			newAppAdmin, newParamAdmin := buildAppChainAdmin(t)
+
+			var got bool
+			var err error
+			switch tc.name {
+			case "group":
+				got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
+			default:
+				got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
+			}
+			require.NoError(t, err)
+			require.False(t, got)
+
+			b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
+			require.NoError(t, err)
+			require.False(t, b)
+		})
+	}
+}

--- a/pkg/blockchain/settlementchainAdmin_test.go
+++ b/pkg/blockchain/settlementchainAdmin_test.go
@@ -2,6 +2,7 @@ package blockchain_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -103,24 +104,26 @@ func TestPauseFlagsSettlement(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, got)
 		})
-		//
-		//t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
-		//	newAppAdmin, newParamAdmin := buildSettlementChainAdmin(t)
-		//
-		//	var got bool
-		//	var err error
-		//	switch tc.name {
-		//	case "group":
-		//		got, err = newAppAdmin.GetGroupMessagePauseStatus(ctx)
-		//	default:
-		//		got, err = newAppAdmin.GetIdentityUpdatePauseStatus(ctx)
-		//	}
-		//	require.NoError(t, err)
-		//	require.False(t, got)
-		//
-		//	b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
-		//	require.NoError(t, err)
-		//	require.False(t, b)
-		//})
+
+		t.Run(tc.name+"/getter_unset_returns_false", func(t *testing.T) {
+			newSettlementAdmin, newParamAdmin := buildSettlementChainAdmin(t)
+
+			var got bool
+			var err error
+			switch tc.name {
+			case "settlement-chain-gateway":
+				got, err = newSettlementAdmin.GetSettlementChainGatewayPauseStatus(ctx)
+			case "payer-registry":
+				got, err = newSettlementAdmin.GetPayerRegistryPauseStatus(ctx)
+			default:
+				got, err = false, errors.New("invalid option")
+			}
+			require.NoError(t, err)
+			require.False(t, got)
+
+			b, err := newParamAdmin.GetParameterBool(ctx, tc.key)
+			require.NoError(t, err)
+			require.False(t, b)
+		})
 	}
 }

--- a/pkg/config/chainConfig.go
+++ b/pkg/config/chainConfig.go
@@ -3,6 +3,7 @@ package config
 type ChainConfig struct {
 	AppChainDeploymentBlock          int    `json:"appChainDeploymentBlock"`
 	AppChainID                       int    `json:"appChainId"`
+	AppChainGateway                  string `json:"appChainGateway"`
 	DistributionManager              string `json:"distributionManager"`
 	GroupMessageBroadcaster          string `json:"groupMessageBroadcaster"`
 	IdentityUpdateBroadcaster        string `json:"identityUpdateBroadcaster"`
@@ -11,6 +12,7 @@ type ChainConfig struct {
 	PayerReportManager               string `json:"payerReportManager"`
 	RateRegistry                     string `json:"rateRegistry"`
 	SettlementChainDeploymentBlock   int    `json:"settlementChainDeploymentBlock"`
+	SettlementChainGateway           string `json:"settlementChainGateway"`
 	SettlementChainID                int    `json:"settlementChainId"`
 	SettlementChainParameterRegistry string `json:"settlementChainParameterRegistry"`
 }

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -135,7 +135,10 @@ func (t *Target) UnmarshalFlag(v string) error {
 		*t = Target(v)
 		return nil
 	default:
-		return fmt.Errorf("invalid target %q (allowed: identity|group)", v)
+		return fmt.Errorf(
+			"invalid target %q (allowed: identity|group|app-chain-gateway|distribution-manager|payer-registry|settlement-chain-gateway)",
+			v,
+		)
 	}
 }
 

--- a/pkg/config/cliOptions.go
+++ b/pkg/config/cliOptions.go
@@ -116,13 +116,22 @@ type WatcherOptions struct {
 type Target string
 
 const (
-	TargetIdentity Target = "identity"
-	TargetGroup    Target = "group"
+	TargetIdentity               Target = "identity"
+	TargetGroup                  Target = "group"
+	TargetAppChainGateway        Target = "app-chain-gateway"
+	TargetDistributionManager    Target = "distribution-manager"
+	TargetPayerRegistry          Target = "payer-registry"
+	TargetSettlementChainGateway Target = "settlement-chain-gateway"
 )
 
 func (t *Target) UnmarshalFlag(v string) error {
 	switch v {
-	case string(TargetIdentity), string(TargetGroup):
+	case string(TargetIdentity),
+		string(TargetGroup),
+		string(TargetAppChainGateway),
+		string(TargetDistributionManager),
+		string(TargetPayerRegistry),
+		string(TargetSettlementChainGateway):
 		*t = Target(v)
 		return nil
 	default:

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -25,6 +25,7 @@ type AppChainOptions struct {
 	BackfillBlockPageSize            uint64        `long:"backfill-block-page-size"            env:"XMTPD_APP_CHAIN_BACKFILL_BLOCK_PAGE_SIZE"          description:"Maximal size of a backfill block page"                        default:"500"`
 	GroupMessageBroadcasterAddress   string        `long:"group-message-broadcaster-address"   env:"XMTPD_APP_CHAIN_GROUP_MESSAGE_BROADCAST_ADDRESS"   description:"Group message broadcaster contract address"`
 	IdentityUpdateBroadcasterAddress string        `long:"identity-update-broadcaster-address" env:"XMTPD_APP_CHAIN_IDENTITY_UPDATE_BROADCAST_ADDRESS" description:"Identity update broadcaster contract address"`
+	GatewayAddress                   string        `long:"gateway-address"                     env:"XMTPD_APP_CHAIN_GATEWAY_ADDRESS"                   description:"App Chain Gateway contract address"`
 	DeploymentBlock                  uint64        `long:"deployment-block"                    env:"XMTPD_APP_CHAIN_DEPLOYMENT_BLOCK"                  description:"Deployment block for the application chain"                   default:"0"`
 }
 
@@ -41,6 +42,7 @@ type SettlementChainOptions struct {
 	ParameterRegistryAddress    string        `long:"parameter-registry-address"     env:"XMTPD_SETTLEMENT_CHAIN_PARAMETER_REGISTRY_ADDRESS"     description:"Parameter Registry contract address"`
 	PayerRegistryAddress        string        `long:"payer-registry-address"         env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_ADDRESS"         description:"Payer Registry contract address"`
 	PayerReportManagerAddress   string        `long:"payer-report-manager-address"   env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REPORT_MANAGER_ADDRESS"   description:"Payer Report Manager contract address"`
+	GatewayAddress              string        `long:"gateway-address"                env:"XMTPD_SETTLEMENT_CHAIN_GATEWAY_ADDRESS"                description:"Settlement Chain Gateway contract address"`
 	DeploymentBlock             uint64        `long:"deployment-block"               env:"XMTPD_SETTLEMENT_CHAIN_DEPLOYMENT_BLOCK"               description:"Deployment block for the settlement chain"                    default:"0"`
 }
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -43,6 +43,7 @@ type SettlementChainOptions struct {
 	PayerRegistryAddress        string        `long:"payer-registry-address"         env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REGISTRY_ADDRESS"         description:"Payer Registry contract address"`
 	PayerReportManagerAddress   string        `long:"payer-report-manager-address"   env:"XMTPD_SETTLEMENT_CHAIN_PAYER_REPORT_MANAGER_ADDRESS"   description:"Payer Report Manager contract address"`
 	GatewayAddress              string        `long:"gateway-address"                env:"XMTPD_SETTLEMENT_CHAIN_GATEWAY_ADDRESS"                description:"Settlement Chain Gateway contract address"`
+	DistributionManagerAddress  string        `long:"distribution-manager-address"   env:"XMTPD_SETTLEMENT_CHAIN_DISTRIBUTION_MANAGER_ADDRESS"   description:"Distribution Manager contract address"`
 	DeploymentBlock             uint64        `long:"deployment-block"               env:"XMTPD_SETTLEMENT_CHAIN_DEPLOYMENT_BLOCK"               description:"Deployment block for the settlement chain"                    default:"0"`
 }
 

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -276,6 +276,9 @@ func fillConfigFromJson(options *ContractsOptions, config *ChainConfig) {
 	if options.SettlementChain.GatewayAddress == "" {
 		options.SettlementChain.GatewayAddress = config.SettlementChainGateway
 	}
+	if options.SettlementChain.DistributionManagerAddress == "" {
+		options.SettlementChain.DistributionManagerAddress = config.DistributionManager
+	}
 }
 
 func validateBlockchainConfig(

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -273,6 +273,9 @@ func fillConfigFromJson(options *ContractsOptions, config *ChainConfig) {
 	if options.SettlementChain.DeploymentBlock == 0 {
 		options.SettlementChain.DeploymentBlock = uint64(config.SettlementChainDeploymentBlock)
 	}
+	if options.SettlementChain.GatewayAddress == "" {
+		options.SettlementChain.GatewayAddress = config.SettlementChainGateway
+	}
 }
 
 func validateBlockchainConfig(

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -247,6 +247,9 @@ func fillConfigFromJson(options *ContractsOptions, config *ChainConfig) {
 	if options.AppChain.ChainID == 0 || options.AppChain.ChainID == 31337 {
 		options.AppChain.ChainID = config.AppChainID
 	}
+	if options.AppChain.GatewayAddress == "" {
+		options.AppChain.GatewayAddress = config.AppChainGateway
+	}
 	if options.AppChain.DeploymentBlock == 0 {
 		options.AppChain.DeploymentBlock = uint64(config.AppChainDeploymentBlock)
 	}

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -44,6 +44,7 @@ func NewContractsOptions(t *testing.T, rpcUrl, wsUrl string) config.ContractsOpt
 			GroupMessageBroadcasterAddress:   chainConfig.GroupMessageBroadcaster,
 			IdentityUpdateBroadcasterAddress: chainConfig.IdentityUpdateBroadcaster,
 			BackfillBlockPageSize:            500,
+			GatewayAddress:                   chainConfig.AppChainGateway,
 		},
 		SettlementChain: config.SettlementChainOptions{
 			RPCURL:                      rpcUrl,
@@ -58,6 +59,7 @@ func NewContractsOptions(t *testing.T, rpcUrl, wsUrl string) config.ContractsOpt
 			PayerReportManagerAddress:   chainConfig.PayerReportManager,
 			MaxChainDisconnectTime:      10 * time.Second,
 			BackfillBlockPageSize:       500,
+			GatewayAddress:              chainConfig.SettlementChainGateway,
 		},
 	}
 }

--- a/pkg/testutils/config.go
+++ b/pkg/testutils/config.go
@@ -60,6 +60,7 @@ func NewContractsOptions(t *testing.T, rpcUrl, wsUrl string) config.ContractsOpt
 			MaxChainDisconnectTime:      10 * time.Second,
 			BackfillBlockPageSize:       500,
 			GatewayAddress:              chainConfig.SettlementChainGateway,
+			DistributionManagerAddress:  chainConfig.DistributionManager,
 		},
 	}
 }


### PR DESCRIPTION
### Add more pause CLI commands by extending `cmd/cli/main.go` `setPause` and `getPause` to control app-chain gateway, settlement-chain gateway, payer registry, and distribution manager via new `blockchain.SettlementChainAdmin` and updated `blockchain.AppChainAdmin`.
- Expand CLI pause targets in [main.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2) by wiring `setPause`/`getPause` to `blockchain.AppChainAdmin` and a new `blockchain.SettlementChainAdmin`, with `setupSettlementChainAdmin` handling settlement-chain admin construction.
- Add `settlementChainAdmin` in [settlementChainAdmin.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-bddef5bfa08c3db7ad8e7feb3170713a75951cb3f006074727c832ecadcc63ec) to bind to SettlementChainGateway, PayerRegistry, and DistributionManager and implement get/set pause with on-chain `UpdatePauseStatus` transactions and event parsing.
- Extend `appChainAdmin` in [appchainAdmin.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-0e088f77670d3c11eb702c27fa0c729fcce93ee51358b9652f85e34ad1843eb4) to bind `AppChainGateway` and add `GetAppChainGatewayPauseStatus`/`SetAppChainGatewayPauseStatus`.
- Add pause parameter keys in [parameterAdmin.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-fa6d656653ab9ec004d3bd0bf71298ef5fac4467a6057e3b6fa2f42aad487f72).
- Update configuration for gateway and distribution manager addresses in [chainConfig.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-db8d1876182861b388033399f17c69fde29aaa76dc12ed571b0b545890713dd2), [options.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c), [validation.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b), and extend target parsing in [cliOptions.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-8405561572b34bc30144dc45f17a7b17be5cbc74d653efdeb4caef1092301f5c); update test config in [config.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-38c61c1c2b86ea79e9a35d68b7b509efd25e103202b01361f98433f41d51ceb7).
- Add and adjust tests in [settlementchainAdmin_test.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-8d055e0fb96b1af4241c583c71b687957c5c1974d5a27ebf4f9c9ec22c29c4c2) and [appchainAdmin_test.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-c2e2fa8024eebfc005def2e11b5d009d109e9820416c0c205cd1d47a18833def).

#### 📍Where to Start
Start with `setPause`, `getPause`, and `setupSettlementChainAdmin` in [main.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2), then review `NewSettlementChainAdmin` and pause setters/getters in [settlementChainAdmin.go](https://github.com/xmtp/xmtpd/pull/1090/files#diff-bddef5bfa08c3db7ad8e7feb3170713a75951cb3f006074727c832ecadcc63ec).



#### Changes since #1090 opened

- Added contract address validations to CLI setup functions [78fb926]
- Added TODO blocks for future gateway address validations [78fb926]
- Updated error message in `config.Target.UnmarshalFlag` method to include all valid target values [1644423]
- Added fallback configuration logic in `config.fillConfigFromJson` function [174dee8]
----

_[Macroscope](https://app.macroscope.com) summarized 174dee8._