### PR TITLE
Bulk move from previous to current

### DIFF
--- a/.github/workflows/bulk-move-to-next-iteration.yml
+++ b/.github/workflows/bulk-move-to-next-iteration.yml
@@ -1,0 +1,21 @@
+on:
+  schedule:
+    # Runs "at 05:00, only on Sunday" (see https://crontab.guru)
+    - cron: '0 5 * * 0'
+  workflow_dispatch:
+
+jobs:
+  move-to-next-iteration:
+    name: Move to next iteration
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: blombard/move-to-next-iteration@v0.6.1
+        with:
+          owner: XMTP
+          number: 1
+          token: ${{ secrets.PROJECT_PAT }}
+          iteration-field: Iteration
+          iteration: previous
+          new-iteration: current
+          excluded-statuses: "Done,Won't Fix"


### PR DESCRIPTION
### Add GitHub Actions workflow to bulk move XMTP project #1 items from the previous iteration to the current iteration on Sundays at 05:00 and via manual dispatch
Create [bulk-move-to-next-iteration.yml](https://github.com/xmtp/xmtpd/pull/1099/files#diff-49d8db6b36d54bc4bd68ead642d8dbe88084d60a95cfd595883055b200bbb7b9) defining job `move-to-next-iteration` on `ubuntu-latest` that invokes `blombard/move-to-next-iteration@v0.6.1` with inputs `owner`, `number`, `token` from `secrets.PROJECT_PAT`, `iteration-field`, `iteration`, `new-iteration`, and `excluded-statuses`.

#### 📍Where to Start
Start with the workflow definition in [bulk-move-to-next-iteration.yml](https://github.com/xmtp/xmtpd/pull/1099/files#diff-49d8db6b36d54bc4bd68ead642d8dbe88084d60a95cfd595883055b200bbb7b9), focusing on the `move-to-next-iteration` job configuration and the action inputs.

----

_[Macroscope](https://app.macroscope.com) summarized ce8b3c2._