### PR TITLE
Bubble up validation results

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -610,7 +610,11 @@ func (s *Service) validateKeyPackage(
 	}
 
 	if !validationResult[0].IsOk {
-		return status.Errorf(codes.InvalidArgument, "key package validation failed")
+		return status.Errorf(
+			codes.InvalidArgument,
+			"key package validation failed: %s",
+			validationResult[0].ErrorMessage,
+		)
 	}
 
 	return nil

--- a/pkg/mlsvalidate/interface.go
+++ b/pkg/mlsvalidate/interface.go
@@ -14,6 +14,7 @@ type KeyPackageValidationResult struct {
 	InstallationKey []byte
 	Credential      *identity_proto.MlsCredential
 	Expiration      uint64
+	ErrorMessage    string
 }
 
 type GroupMessageValidationResult struct {

--- a/pkg/mlsvalidate/service.go
+++ b/pkg/mlsvalidate/service.go
@@ -129,6 +129,7 @@ func (s *MLSValidationServiceImpl) ValidateKeyPackages(
 				InstallationKey: nil,
 				Credential:      nil,
 				Expiration:      0,
+				ErrorMessage:    response.ErrorMessage,
 			}
 		} else {
 			out[i] = KeyPackageValidationResult{
@@ -136,6 +137,7 @@ func (s *MLSValidationServiceImpl) ValidateKeyPackages(
 				InstallationKey: response.InstallationPublicKey,
 				Credential:      nil,
 				Expiration:      response.Expiration,
+				ErrorMessage:    response.ErrorMessage,
 			}
 		}
 	}


### PR DESCRIPTION
### Bubble up validation results by returning validator error messages from `message.Service.validateKeyPackage` and populating `mlsvalidate.KeyPackageValidationResult.ErrorMessage`
- Update `message.Service.validateKeyPackage` in [service.go](https://github.com/xmtp/xmtpd/pull/1113/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) to return an `InvalidArgument` error formatted with the first validation result's `ErrorMessage` when the result is not OK.
- Add `ErrorMessage` to `mlsvalidate.KeyPackageValidationResult` in [interface.go](https://github.com/xmtp/xmtpd/pull/1113/files#diff-eaa6ce23748d8d20bedf3a979d30cba1c480273210153dde27e2baf61713afb8).
- Populate `KeyPackageValidationResult.ErrorMessage` from the gRPC response in `mlsvalidate.MLSValidationServiceImpl.ValidateKeyPackages` in [service.go](https://github.com/xmtp/xmtpd/pull/1113/files#diff-cf2ccc76d6f62cb661c57271f77f99aeda76271380f1df4df1964599ea97f43a).

#### 📍Where to Start
Start with `message.Service.validateKeyPackage` in [service.go](https://github.com/xmtp/xmtpd/pull/1113/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) to see how the error message is bubbled up, then review the struct change in [interface.go](https://github.com/xmtp/xmtpd/pull/1113/files#diff-eaa6ce23748d8d20bedf3a979d30cba1c480273210153dde27e2baf61713afb8) and the population logic in `mlsvalidate.MLSValidationServiceImpl.ValidateKeyPackages` in [service.go](https://github.com/xmtp/xmtpd/pull/1113/files#diff-cf2ccc76d6f62cb661c57271f77f99aeda76271380f1df4df1964599ea97f43a).

----

_[Macroscope](https://app.macroscope.com) summarized 52f8d85._