### PR TITLE
Allow using HTTP config paths in the CLI

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -171,8 +171,8 @@ func ContractOptionsFromEnv(filePath string) (ContractsOptions, error) {
 					resp.StatusCode,
 				)
 			}
-			// Guard against absurdly large config files (10MB cap).
-			limited := io.LimitReader(resp.Body, 10<<20)
+			// Guard against large config files (10KB cap).
+			limited := io.LimitReader(resp.Body, 10<<10)
 			data, err = io.ReadAll(limited)
 			if err != nil {
 				return ContractsOptions{}, fmt.Errorf("reading %s: %w", filePath, err)

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -204,7 +204,8 @@ func ContractOptionsFromEnv(filePath string) (ContractsOptions, error) {
 			defer func() {
 				_ = f.Close()
 			}()
-			data, err = io.ReadAll(f)
+			limited := io.LimitReader(f, 10<<10)
+			data, err = io.ReadAll(limited)
 			if err != nil {
 				return ContractsOptions{}, fmt.Errorf("read %s: %w", localPath, err)
 			}


### PR DESCRIPTION
### Allow the CLI to load configuration via HTTP(S) or file URLs and enforce a 10 KiB read limit in `config.ContractOptionsFromEnv` in [validation.go](https://github.com/xmtp/xmtpd/pull/1131/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b)
This change updates `config.ContractOptionsFromEnv` to accept configuration paths as local filesystem paths or URLs with `http`, `https`, or `file` schemes, applies a 10s HTTP client timeout, enforces 2xx responses, and limits reads to 10 KiB with contextual error wrapping. It also adds `net/http` to imports and wraps JSON unmarshal errors with context.

- Add HTTP fetching with 10s timeout and 2xx status requirement in `config.ContractOptionsFromEnv` in [validation.go](https://github.com/xmtp/xmtpd/pull/1131/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b)
- Support `file://` URLs with path normalization and 10 KiB read limit in `config.ContractOptionsFromEnv` in [validation.go](https://github.com/xmtp/xmtpd/pull/1131/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b)
- Apply 10 KiB read limit for local files and wrap errors with context in `config.ContractOptionsFromEnv` in [validation.go](https://github.com/xmtp/xmtpd/pull/1131/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b)
- Import `net/http` in [validation.go](https://github.com/xmtp/xmtpd/pull/1131/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b)

#### 📍Where to Start
Start with `config.ContractOptionsFromEnv` in [pkg/config/validation.go](https://github.com/xmtp/xmtpd/pull/1131/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b), which contains the URL/file path handling, HTTP client logic, read limits, and error wrapping.

----

_[Macroscope](https://app.macroscope.com) summarized 27b96e7._