### PR TITLE
Create goreleaser process for building CLI and brew pushing

### DIFF
--- a/.github/workflows/release-goreleaser.yaml
+++ b/.github/workflows/release-goreleaser.yaml
@@ -66,7 +66,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: xmtpd-cli-dist-${{ github.run_number }}-${{ replace(github.ref_name, '/', '-') }}
+          name: xmtpd-cli-dist
           path: |
             dist/**
           if-no-files-found: ignore

--- a/.github/workflows/release-goreleaser.yaml
+++ b/.github/workflows/release-goreleaser.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   goreleaser:
-    name: Build & Release
+    name: Build & Release CLI Components
     runs-on: ubuntu-latest
 
     env:
@@ -36,13 +36,10 @@ jobs:
           cache-dependency-path: "**/*.sum"
 
       - name: GoReleaser Check
-        if: github.event_name == 'pull_request'
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Snapshot builds for PRs and non-tag pushes (no publish)
       - name: GoReleaser (snapshot)

--- a/.github/workflows/release-goreleaser.yaml
+++ b/.github/workflows/release-goreleaser.yaml
@@ -66,7 +66,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: xmtpd-cli-dist-${{ github.run_number }}-${{ github.ref_name }}
+          name: xmtpd-cli-dist-${{ github.run_number }}-${{ replace(github.ref_name, '/', '-') }}
           path: |
             dist/**
           if-no-files-found: ignore

--- a/.github/workflows/release-goreleaser.yaml
+++ b/.github/workflows/release-goreleaser.yaml
@@ -1,0 +1,76 @@
+name: Release (GoReleaser)
+
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  goreleaser:
+    name: Build & Release
+    runs-on: ubuntu-latest
+
+    env:
+      # Provide a PAT with 'contents:write' on xmtp/homebrew-tap:
+      HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+      GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: "**/*.sum"
+
+      - name: GoReleaser Check
+        if: github.event_name == 'pull_request'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Snapshot builds for PRs and non-tag pushes (no publish)
+      - name: GoReleaser (snapshot)
+        if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v')
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --snapshot --clean --skip=publish
+
+      # Real release on tags (publishes GitHub Release + pushes cask to tap)
+      - name: GoReleaser (release)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          # This token creates the GitHub Release in *this* repo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This PAT pushes to xmtp/homebrew-tap (required by Homebrew Casks)
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Upload dist artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xmtpd-cli-dist-${{ github.run_number }}-${{ github.ref_name }}
+          path: |
+            dist/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __debug_*
 # build folder
 build/
 bin/
+dist/
 
 # contracts development config
 contracts/config/anvil_localnet/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,13 +22,13 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w -X main.Version={{ if .IsSnapshot }}{{ .Tag }}-next+{{ .ShortCommit }}{{ else }}{{ .Tag }}-{{ .ShortCommit }}{{ end }}
+      - -s -w -X main.Version={{ if .IsSnapshot }}{{ replace .Version "/" "-" }}-next+{{ .ShortCommit }}{{ else }}{{ .Tag }}-{{ .ShortCommit }}{{ end }}
 
 archives:
   - id: zips
     ids: [xmtpd-cli]
     formats: ["zip"]
-    name_template: "{{ .Binary }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE*
       - src: build/completions/xmtpd-cli.bash
@@ -41,7 +41,7 @@ archives:
   - id: tars
     ids: [ xmtpd-cli ]
     formats: [ "tar.gz" ]
-    name_template: "{{ .Binary }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE*
       - src: build/completions/xmtpd-cli.bash
@@ -52,7 +52,7 @@ archives:
         dst: completions/xmtpd-cli.fish
 
 checksum:
-  name_template: "checksums_{{ .Tag }}.txt"
+  name_template: "checksums_{{ replace .Version "/" "-" }}.txt"
 
 homebrew_casks:
   - name: xmtpd-cli

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,81 @@
+version: 2
+
+project_name: xmtpd
+
+before:
+  hooks:
+    - go mod tidy
+    # Build a native helper we can run on the host to generate completions.
+    - bash -euo pipefail -c 'mkdir -p build/tools && go build -o build/tools/xmtpd-cli-gen ./cmd/xmtpd-cli'
+    # Generate completions into build/completions.
+    - bash -euo pipefail -c 'mkdir -p build/completions'
+    - bash -euo pipefail -c 'build/tools/xmtpd-cli-gen completion bash > build/completions/xmtpd-cli.bash && test -s build/completions/xmtpd-cli.bash'
+    - bash -euo pipefail -c 'build/tools/xmtpd-cli-gen completion zsh  > build/completions/_xmtpd-cli     && test -s build/completions/_xmtpd-cli'
+    - bash -euo pipefail -c 'build/tools/xmtpd-cli-gen completion fish > build/completions/xmtpd-cli.fish && test -s build/completions/xmtpd-cli.fish'
+
+builds:
+  - id: xmtpd-cli
+    main: ./cmd/xmtpd-cli/main.go
+    binary: xmtpd-cli
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.Version={{ if .IsSnapshot }}{{ .Tag }}-next+{{ .ShortCommit }}{{ else }}{{ .Tag }}-{{ .ShortCommit }}{{ end }}
+
+archives:
+  - id: zips
+    ids: [xmtpd-cli]
+    formats: ["zip"]
+    name_template: "{{ .Binary }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - src: build/completions/xmtpd-cli.bash
+        dst: completions/xmtpd-cli.bash
+      - src: build/completions/_xmtpd-cli
+        dst: completions/_xmtpd-cli
+      - src: build/completions/xmtpd-cli.fish
+        dst: completions/xmtpd-cli.fish
+
+  - id: tars
+    ids: [ xmtpd-cli ]
+    formats: [ "tar.gz" ]
+    name_template: "{{ .Binary }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - src: build/completions/xmtpd-cli.bash
+        dst: completions/xmtpd-cli.bash
+      - src: build/completions/_xmtpd-cli
+        dst: completions/_xmtpd-cli
+      - src: build/completions/xmtpd-cli.fish
+        dst: completions/xmtpd-cli.fish
+
+checksum:
+  name_template: "checksums_{{ .Tag }}.txt"
+
+homebrew_casks:
+  - name: xmtpd-cli
+    ids: [zips]
+    binary: xmtpd-cli
+    homepage: https://github.com/xmtp/xmtpd
+    description: "CLI to manage the XMTP Network."
+    repository:
+      owner: xmtp
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    completions:
+      bash: completions/xmtpd-cli.bash
+      zsh: completions/_xmtpd-cli
+      fish: completions/xmtpd-cli.fish
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/xmtpd-cli"]
+          end
+    skip_upload: auto
+    caveats: |
+      xmtpd-cli is not notarized. The installer removes the macOS quarantine attribute.
+      Prefer signed/notarized builds when available.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w -X main.Version={{ if .IsSnapshot }}{{ replace .Version "/" "-" }}-next+{{ .ShortCommit }}{{ else }}{{ .Tag }}-{{ .ShortCommit }}{{ end }}
+      - '-s -w -X main.Version={{ if .IsSnapshot }}{{ replace .Version "/" "-" }}-next+{{ .ShortCommit }}{{ else }}{{ .Tag }}-{{ .ShortCommit }}{{ end }}'
 
 archives:
   - id: zips
@@ -39,8 +39,8 @@ archives:
         dst: completions/xmtpd-cli.fish
 
   - id: tars
-    ids: [ xmtpd-cli ]
-    formats: [ "tar.gz" ]
+    ids: [xmtpd-cli]
+    formats: ["tar.gz"]
     name_template: "{{ .Binary }}_{{ replace .Version \"/\" \"-\" }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ archives:
   - id: zips
     ids: [xmtpd-cli]
     formats: ["zip"]
-    name_template: "{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .Binary }}_{{ replace .Version \"/\" \"-\" }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE*
       - src: build/completions/xmtpd-cli.bash
@@ -41,7 +41,7 @@ archives:
   - id: tars
     ids: [ xmtpd-cli ]
     formats: [ "tar.gz" ]
-    name_template: "{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .Binary }}_{{ replace .Version \"/\" \"-\" }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE*
       - src: build/completions/xmtpd-cli.bash
@@ -52,7 +52,7 @@ archives:
         dst: completions/xmtpd-cli.fish
 
 checksum:
-  name_template: "checksums_{{ replace .Version "/" "-" }}.txt"
+  name_template: "checksums_{{ replace .Version \"/\" \"-\" }}.txt"
 
 homebrew_casks:
   - name: xmtpd-cli


### PR DESCRIPTION
### Add GoReleaser-driven CI to build xmtpd-cli and publish tagged releases to GitHub Releases and the xmtp/homebrew-tap Homebrew cask
- Add a GitHub Actions workflow in [release-goreleaser.yaml](https://github.com/xmtp/xmtpd/pull/1133/files#diff-61560a689e7e64a8b34e16a7d5a14d63a1453251f166fb51ba0112c6a52205c4) that runs on tag pushes matching `v*`, pushes to `main`, pull requests, and manual dispatch, performs snapshot builds for non-tag events, publishes releases on tag pushes, and uploads `dist/**` artifacts.
- Introduce GoReleaser v2 config in [.goreleaser.yaml](https://github.com/xmtp/xmtpd/pull/1133/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826) to build `xmtpd-cli` for linux/darwin on `amd64`/`arm64` with CGO disabled, embed version metadata via `ldflags`, package archives as `.zip` and `.tar.gz` with shell completions and LICENSE, generate checksums, and update the Homebrew cask in `xmtp/homebrew-tap`.
- Ignore the build output directory by adding `dist/` to [.gitignore](https://github.com/xmtp/xmtpd/pull/1133/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947).

#### 📍Where to Start
Start with the workflow definition in [release-goreleaser.yaml](https://github.com/xmtp/xmtpd/pull/1133/files#diff-61560a689e7e64a8b34e16a7d5a14d63a1453251f166fb51ba0112c6a52205c4), then review the build and publishing configuration in [.goreleaser.yaml](https://github.com/xmtp/xmtpd/pull/1133/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826).

----

_[Macroscope](https://app.macroscope.com) summarized 4f3c214._