### PR TITLE
Update the Gateway image in staging

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -148,6 +148,6 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: testnet-staging
-          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image"
-          variable-value: "${{ steps.digests.outputs.xmtpd_image }},${{ steps.digests.outputs.prune_image }}"
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image"
+          variable-value: "${{ steps.digests.outputs.xmtpd_image }},${{ steps.digests.outputs.prune_image }},${{ steps.digests.outputs.gateway_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"


### PR DESCRIPTION
### Pass the staging Gateway image to Terraform by adding the `xmtpd_gateway_docker_image` variable in the GitHub Actions workflow at [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1157/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9) to update the Gateway image in staging
The GitHub Actions workflow updates the Terraform variable payload to include a third variable, `xmtpd_gateway_docker_image`, whose value is set from `steps.digests.outputs.gateway_image`. This change occurs in [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1157/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9) within the step that assembles and passes variables to Terraform Cloud.

#### 📍Where to Start
Start with the workflow step that constructs Terraform variable lists in [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1157/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9), focusing on where `xmtpd_gateway_docker_image` is added and populated from `steps.digests.outputs.gateway_image`.

----

_[Macroscope](https://app.macroscope.com) summarized 80639d5._