### PR TITLE
Enhance vector clock performance

### DIFF
--- a/pkg/db/sqlc/envelopes.sql
+++ b/pkg/db/sqlc/envelopes.sql
@@ -44,12 +44,17 @@ DELETE FROM staged_originator_envelopes
 WHERE id = @id;
 
 -- name: SelectVectorClock :many
-SELECT DISTINCT ON (originator_node_id) originator_node_id,
-	originator_sequence_id,
-	originator_envelope
-FROM gateway_envelopes
-ORDER BY originator_node_id,
-	originator_sequence_id DESC;
+SELECT nodes.originator_node_id,
+       latest.originator_sequence_id,
+       latest.gateway_time
+FROM (SELECT DISTINCT originator_node_id FROM gateway_envelopes) nodes
+CROSS JOIN LATERAL (
+    SELECT originator_sequence_id, gateway_time
+    FROM gateway_envelopes
+    WHERE originator_node_id = nodes.originator_node_id
+    ORDER BY originator_sequence_id DESC
+    LIMIT 1
+) latest;
 
 -- name: GetLatestSequenceId :one
 SELECT COALESCE(max(originator_sequence_id), 0)::BIGINT AS originator_sequence_id

--- a/pkg/migrations/00016_vector_clock.down.sql
+++ b/pkg/migrations/00016_vector_clock.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_gateway_envelopes_vector_clock;

--- a/pkg/migrations/00016_vector_clock.down.sql
+++ b/pkg/migrations/00016_vector_clock.down.sql
@@ -1,1 +1,2 @@
 DROP INDEX IF EXISTS idx_gateway_envelopes_vector_clock;
+DROP INDEX IF EXISTS idx_gateway_envelopes_originator_node_id;

--- a/pkg/migrations/00016_vector_clock.up.sql
+++ b/pkg/migrations/00016_vector_clock.up.sql
@@ -1,2 +1,6 @@
 -- Cover index for vector clock queries
 CREATE INDEX idx_gateway_envelopes_vector_clock ON gateway_envelopes(originator_node_id, originator_sequence_id DESC, gateway_time);
+
+-- Index efficient for distinct originator_node_id
+CREATE INDEX idx_gateway_envelopes_originator_node_id 
+ON gateway_envelopes(originator_node_id);

--- a/pkg/migrations/00016_vector_clock.up.sql
+++ b/pkg/migrations/00016_vector_clock.up.sql
@@ -1,0 +1,2 @@
+-- Cover index for vector clock queries
+CREATE INDEX idx_gateway_envelopes_vector_clock ON gateway_envelopes(originator_node_id, originator_sequence_id DESC, gateway_time);

--- a/pkg/sync/originator_stream_test.go
+++ b/pkg/sync/originator_stream_test.go
@@ -68,7 +68,7 @@ func newTestOriginatorStream(
 	t *testing.T,
 	node *registry.Node,
 	stream message_api.ReplicationApi_SubscribeEnvelopesClient,
-	lastEnvelope *envUtils.OriginatorEnvelope,
+	cursor *cursor,
 	writeQueue chan *envUtils.OriginatorEnvelope,
 ) *originatorStream {
 	log := testutils.NewLog(t)
@@ -77,7 +77,7 @@ func newTestOriginatorStream(
 		t.Context(),
 		log,
 		node,
-		lastEnvelope,
+		cursor,
 		stream,
 		writeQueue,
 	)

--- a/pkg/sync/sync_worker.go
+++ b/pkg/sync/sync_worker.go
@@ -349,12 +349,12 @@ func (s *syncWorker) setupStream(
 		)
 	}
 
-	var lastEnvelope *envUtils.OriginatorEnvelope
+	var c *cursor
 	for _, row := range result {
 		if slices.Contains(originatorNodeIDs, uint32(row.OriginatorNodeID)) {
-			lastEnvelope, err = envUtils.NewOriginatorEnvelopeFromBytes(row.OriginatorEnvelope)
-			if err != nil {
-				return nil, err
+			c = &cursor{
+				sequenceID:  uint64(row.OriginatorSequenceID),
+				timestampNS: row.GatewayTime.UnixNano(),
 			}
 		}
 	}
@@ -363,7 +363,7 @@ func (s *syncWorker) setupStream(
 		s.ctx,
 		s.log,
 		&node,
-		lastEnvelope,
+		c,
 		stream,
 		writeQueue,
 	), nil


### PR DESCRIPTION
### Change SelectVectorClock to return gateway_time with latest originator_sequence_id per originator_node_id and initialize originator stream cursors to improve vector clock performance
This updates the vector clock query and stream initialization to use gateway timestamps instead of raw envelopes. - Replace `SelectVectorClock` SQL with a lateral join that returns `originator_node_id`, latest `originator_sequence_id`, and `gateway_time`, and regenerate query code to scan into `GatewayTime time.Time` in [envelopes.sql.go](https://github.com/xmtp/xmtpd/pull/1158/files#diff-3f51de4a0ba4deee29a5f71e1e2b1064e76742199ebc7af27f72735da3a76c2e) and update the SQL in [envelopes.sql](https://github.com/xmtp/xmtpd/pull/1158/files#diff-0db76750c39b995e412cfbdd8439a43304fa606c9a069d2573849894a125817e). - Create indexes `idx_gateway_envelopes_vector_clock` and `idx_gateway_envelopes_originator_node_id` in [00016_vector_clock.up.sql](https://github.com/xmtp/xmtpd/pull/1158/files#diff-5655ad56d8b16a69f33177677f388c5a06449a686b8d9dfa36bfaa6e77d1cc4a) and drop them in [00016_vector_clock.down.sql](https://github.com/xmtp/xmtpd/pull/1158/files#diff-7142991a7ecf2706760ea59454086e5d3b9318c088977ea54a80c7ece73b8878). - Introduce a lightweight `cursor` (sequenceID, timestampNS) and refactor `originatorStream` to track validation state using the cursor instead of the last envelope in [originator_stream.go](https://github.com/xmtp/xmtpd/pull/1158/files#diff-97117505ac569b0d8cd3712428e01f45344307de94e9ee8df64c8c8f46a51447) with matching test adjustments in [originator_stream_test.go](https://github.com/xmtp/xmtpd/pull/1158/files#diff-031b88e204ba2d2a9227afbb5b5bb9c0a09e0073a1dc4217fe1ee2db1990f08c). - Initialize stream position from `SelectVectorClock` by constructing a `cursor` using `OriginatorSequenceID` and `GatewayTime.UnixNano()` in `syncWorker.setupStream` in [sync_worker.go](https://github.com/xmtp/xmtpd/pull/1158/files#diff-566958c8832792b443513b0e677f3bdb0b96ffbd906d68b1cccc257aae31c852).

#### 📍Where to Start
Start with `syncWorker.setupStream` in [sync_worker.go](https://github.com/xmtp/xmtpd/pull/1158/files#diff-566958c8832792b443513b0e677f3bdb0b96ffbd906d68b1cccc257aae31c852), then review the `SelectVectorClock` changes in [envelopes.sql](https://github.com/xmtp/xmtpd/pull/1158/files#diff-0db76750c39b995e412cfbdd8439a43304fa606c9a069d2573849894a125817e) and the regenerated code in [envelopes.sql.go](https://github.com/xmtp/xmtpd/pull/1158/files#diff-3f51de4a0ba4deee29a5f71e1e2b1064e76742199ebc7af27f72735da3a76c2e).

----

_[Macroscope](https://app.macroscope.com) summarized 8c414bd._