### PR TITLE
No timeout on migration 16

### DIFF
--- a/pkg/migrations/00016_vector_clock.up.sql
+++ b/pkg/migrations/00016_vector_clock.up.sql
@@ -1,3 +1,6 @@
+-- Run without timeout, needed as the table can contain up to millions of rows
+SET statement_timeout = 0;
+
 -- Cover index for vector clock queries
 CREATE INDEX idx_gateway_envelopes_vector_clock ON gateway_envelopes(originator_node_id, originator_sequence_id DESC, gateway_time);
 


### PR DESCRIPTION
### Disable statement timeout by setting 0 for migration 16 covering index creation in [00016_vector_clock.up.sql](https://github.com/xmtp/xmtpd/pull/1163/files#diff-5655ad56d8b16a69f33177677f388c5a06449a686b8d9dfa36bfaa6e77d1cc4a)
This change inserts a session-level directive before the covering index creation in the migration. It adds `SET statement_timeout = 0;` and an explanatory comment in [00016_vector_clock.up.sql](https://github.com/xmtp/xmtpd/pull/1163/files#diff-5655ad56d8b16a69f33177677f388c5a06449a686b8d9dfa36bfaa6e77d1cc4a).

#### 📍Where to Start
Start with the session configuration at the top of [00016_vector_clock.up.sql](https://github.com/xmtp/xmtpd/pull/1163/files#diff-5655ad56d8b16a69f33177677f388c5a06449a686b8d9dfa36bfaa6e77d1cc4a) to review the `SET statement_timeout = 0;` addition.

----

_[Macroscope](https://app.macroscope.com) summarized 50e4991._