### PR TITLE
Add GetNodes gateway endpoint

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -36,4 +36,4 @@ jobs:
       - name: metrics catalog
         uses: nickcharlton/diff-check@v1.0.0
         with:
-          command: ./dev/generate-metrics-catalog
+          command: ./dev/gen/metrics-catalog

--- a/dev/gen/env
+++ b/dev/gen/env
@@ -4,7 +4,9 @@ set -eu
 
 # Work always from the root directory
 script_dir=$(dirname "$(realpath "$0")")
-repo_root=$(realpath "${script_dir}/../")
+repo_root=$(realpath "${script_dir}/../..")
 cd "${repo_root}"
 
-go run pkg/metrics/docs/generator.go
+. dev/local.env
+
+env | grep '^XMTPD_' > .env

--- a/dev/gen/metrics-catalog
+++ b/dev/gen/metrics-catalog
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+# Work always from the root directory
+script_dir=$(dirname "$(realpath "$0")")
+repo_root=$(realpath "${script_dir}/../..")
+cd "${repo_root}"
+
+echo $PWD
+
+go run pkg/metrics/docs/generator.go

--- a/dev/generate-env
+++ b/dev/generate-env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-. dev/local.env
-
-env | grep '^XMTPD_' > .env

--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -31,7 +31,7 @@ This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/ope
 | `xmtp_migrator_writer_retry_attempts` | `Histogram` | Number of retry attempts before success or failure | `pkg/metrics/migrator.go` |
 | `xmtp_migrator_writer_rows_migrated` | `Counter` | Total number of rows successfully migrated | `pkg/metrics/migrator.go` |
 | `xmtp_payer_failed_attempts_to_publish_to_node_via_banlist` | `Histogram` | Number of failed attempts to publish to a node via banlist | `pkg/metrics/payer.go` |
-| `xmtp_payer_get_reader_node_available_nodes` | `Gauge` | Number of currently available nodes for reader selection | `pkg/metrics/payer.go` |
+| `xmtp_payer_get_nodes_available_nodes` | `Gauge` | Number of currently available nodes for reader selection | `pkg/metrics/payer.go` |
 | `xmtp_payer_lru_nonce` | `Gauge` | Least recently used blockchain nonce of the payer (not guaranteed to be the highest nonce). | `pkg/metrics/payer.go` |
 | `xmtp_payer_messages_originated` | `Counter` | Number of messages originated by the payer. | `pkg/metrics/payer.go` |
 | `xmtp_payer_node_publish_duration_seconds` | `Histogram` | Duration of the node publish call | `pkg/metrics/payer.go` |

--- a/pkg/api/payer/service_test.go
+++ b/pkg/api/payer/service_test.go
@@ -18,7 +18,7 @@ func TestGetReaderNode(t *testing.T) {
 		nodes         []registry.Node
 		registryError error
 		wantErr       bool
-		checkResponse func(t *testing.T, resp *payer_api.GetReaderNodeResponse)
+		checkResponse func(t *testing.T, resp *payer_api.GetNodesResponse)
 	}{
 		{
 			name: "success with multiple nodes",
@@ -29,13 +29,9 @@ func TestGetReaderNode(t *testing.T) {
 				nodeRegistry.GetHealthyNode(103),
 			},
 			wantErr: false,
-			checkResponse: func(t *testing.T, resp *payer_api.GetReaderNodeResponse) {
-				require.NotEmpty(t, resp.ReaderNodeUrl)
-				require.Len(t, resp.BackupNodeUrls, 3)
-
-				for _, backup := range resp.BackupNodeUrls {
-					require.NotEqual(t, resp.ReaderNodeUrl, backup)
-				}
+			checkResponse: func(t *testing.T, resp *payer_api.GetNodesResponse) {
+				require.NotEmpty(t, resp.Nodes)
+				require.Len(t, resp.Nodes, 4)
 			},
 		},
 		{
@@ -55,9 +51,9 @@ func TestGetReaderNode(t *testing.T) {
 				nodeRegistry.GetHealthyNode(100),
 			},
 			wantErr: false,
-			checkResponse: func(t *testing.T, resp *payer_api.GetReaderNodeResponse) {
-				require.NotEmpty(t, resp.ReaderNodeUrl)
-				require.Empty(t, resp.BackupNodeUrls)
+			checkResponse: func(t *testing.T, resp *payer_api.GetNodesResponse) {
+				require.NotEmpty(t, resp.Nodes)
+				require.Len(t, resp.Nodes, 1)
 			},
 		},
 	}
@@ -69,7 +65,7 @@ func TestGetReaderNode(t *testing.T) {
 
 			registryMocks.On("GetNodes").Return(tt.nodes, tt.registryError)
 
-			resp, err := svc.GetReaderNode(ctx, &payer_api.GetReaderNodeRequest{})
+			resp, err := svc.GetNodes(ctx, &payer_api.GetNodesRequest{})
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -99,7 +99,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		apiFailedGRPCRequestsCounter,
 		blockchainWaitForTransaction,
 		blockchainPublishPayload,
-		payerGetReaderNodeAvailableNodes,
+		payerGetNodesAvailableNodes,
 		migratorE2ELatency,
 		migratorDestLastSequenceIDBlockchain,
 		migratorDestLastSequenceIDDatabase,

--- a/pkg/metrics/payer.go
+++ b/pkg/metrics/payer.go
@@ -71,13 +71,13 @@ func EmitPayerMessageOriginated(originatorID uint32, count int) {
 		Add(float64(count))
 }
 
-var payerGetReaderNodeAvailableNodes = prometheus.NewGauge(
+var payerGetNodesAvailableNodes = prometheus.NewGauge(
 	prometheus.GaugeOpts{
-		Name: "xmtp_payer_get_reader_node_available_nodes",
+		Name: "xmtp_payer_get_nodes_available_nodes",
 		Help: "Number of currently available nodes for reader selection",
 	},
 )
 
-func EmitPayerGetReaderNodeAvailableNodes(count int) {
-	payerGetReaderNodeAvailableNodes.Set(float64(count))
+func EmitPayerGetNodesAvailableNodes(count int) {
+	payerGetNodesAvailableNodes.Set(float64(count))
 }

--- a/pkg/proto/openapi/xmtpv4/payer_api/payer_api.swagger.json
+++ b/pkg/proto/openapi/xmtpv4/payer_api/payer_api.swagger.json
@@ -16,14 +16,14 @@
     "application/json"
   ],
   "paths": {
-    "/mls/v2/payer/get-reader-node": {
+    "/mls/v2/payer/get-nodes": {
       "post": {
-        "operationId": "PayerApi_GetReaderNode",
+        "operationId": "PayerApi_GetNodes",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/payer_apiGetReaderNodeResponse"
+              "$ref": "#/definitions/payer_apiGetNodesResponse"
             }
           },
           "default": {
@@ -39,7 +39,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/payer_apiGetReaderNodeRequest"
+              "$ref": "#/definitions/payer_apiGetNodesRequest"
             }
           }
         ],
@@ -528,16 +528,13 @@
       "default": "WELCOME_WRAPPER_ALGORITHM_UNSPECIFIED",
       "title": "Describes the algorithm used to encrypt the Welcome Wrapper"
     },
-    "payer_apiGetReaderNodeRequest": {
+    "payer_apiGetNodesRequest": {
       "type": "object"
     },
-    "payer_apiGetReaderNodeResponse": {
+    "payer_apiGetNodesResponse": {
       "type": "object",
       "properties": {
-        "readerNodeUrl": {
-          "type": "string"
-        },
-        "backupNodeUrls": {
+        "nodes": {
           "type": "array",
           "items": {
             "type": "string"

--- a/pkg/proto/xmtpv4/payer_api/payer_api.pb.go
+++ b/pkg/proto/xmtpv4/payer_api/payer_api.pb.go
@@ -113,26 +113,26 @@ func (x *PublishClientEnvelopesResponse) GetOriginatorEnvelopes() []*envelopes.O
 	return nil
 }
 
-type GetReaderNodeRequest struct {
+type GetNodesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetReaderNodeRequest) Reset() {
-	*x = GetReaderNodeRequest{}
+func (x *GetNodesRequest) Reset() {
+	*x = GetNodesRequest{}
 	mi := &file_xmtpv4_payer_api_payer_api_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetReaderNodeRequest) String() string {
+func (x *GetNodesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetReaderNodeRequest) ProtoMessage() {}
+func (*GetNodesRequest) ProtoMessage() {}
 
-func (x *GetReaderNodeRequest) ProtoReflect() protoreflect.Message {
+func (x *GetNodesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_xmtpv4_payer_api_payer_api_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -144,33 +144,32 @@ func (x *GetReaderNodeRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetReaderNodeRequest.ProtoReflect.Descriptor instead.
-func (*GetReaderNodeRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetNodesRequest.ProtoReflect.Descriptor instead.
+func (*GetNodesRequest) Descriptor() ([]byte, []int) {
 	return file_xmtpv4_payer_api_payer_api_proto_rawDescGZIP(), []int{2}
 }
 
-type GetReaderNodeResponse struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	ReaderNodeUrl  string                 `protobuf:"bytes,1,opt,name=reader_node_url,json=readerNodeUrl,proto3" json:"reader_node_url,omitempty"`
-	BackupNodeUrls []string               `protobuf:"bytes,2,rep,name=backup_node_urls,json=backupNodeUrls,proto3" json:"backup_node_urls,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+type GetNodesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Nodes         []string               `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetReaderNodeResponse) Reset() {
-	*x = GetReaderNodeResponse{}
+func (x *GetNodesResponse) Reset() {
+	*x = GetNodesResponse{}
 	mi := &file_xmtpv4_payer_api_payer_api_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetReaderNodeResponse) String() string {
+func (x *GetNodesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetReaderNodeResponse) ProtoMessage() {}
+func (*GetNodesResponse) ProtoMessage() {}
 
-func (x *GetReaderNodeResponse) ProtoReflect() protoreflect.Message {
+func (x *GetNodesResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_xmtpv4_payer_api_payer_api_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -182,21 +181,14 @@ func (x *GetReaderNodeResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetReaderNodeResponse.ProtoReflect.Descriptor instead.
-func (*GetReaderNodeResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetNodesResponse.ProtoReflect.Descriptor instead.
+func (*GetNodesResponse) Descriptor() ([]byte, []int) {
 	return file_xmtpv4_payer_api_payer_api_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *GetReaderNodeResponse) GetReaderNodeUrl() string {
+func (x *GetNodesResponse) GetNodes() []string {
 	if x != nil {
-		return x.ReaderNodeUrl
-	}
-	return ""
-}
-
-func (x *GetReaderNodeResponse) GetBackupNodeUrls() []string {
-	if x != nil {
-		return x.BackupNodeUrls
+		return x.Nodes
 	}
 	return nil
 }
@@ -209,14 +201,13 @@ const file_xmtpv4_payer_api_payer_api_proto_rawDesc = "" +
 	"\x1dPublishClientEnvelopesRequest\x12C\n" +
 	"\tenvelopes\x18\x01 \x03(\v2%.xmtp.xmtpv4.envelopes.ClientEnvelopeR\tenvelopes\"~\n" +
 	"\x1ePublishClientEnvelopesResponse\x12\\\n" +
-	"\x14originator_envelopes\x18\x01 \x03(\v2).xmtp.xmtpv4.envelopes.OriginatorEnvelopeR\x13originatorEnvelopes\"\x16\n" +
-	"\x14GetReaderNodeRequest\"i\n" +
-	"\x15GetReaderNodeResponse\x12&\n" +
-	"\x0freader_node_url\x18\x01 \x01(\tR\rreaderNodeUrl\x12(\n" +
-	"\x10backup_node_urls\x18\x02 \x03(\tR\x0ebackupNodeUrls2\xdc\x02\n" +
+	"\x14originator_envelopes\x18\x01 \x03(\v2).xmtp.xmtpv4.envelopes.OriginatorEnvelopeR\x13originatorEnvelopes\"\x11\n" +
+	"\x0fGetNodesRequest\"(\n" +
+	"\x10GetNodesResponse\x12\x14\n" +
+	"\x05nodes\x18\x01 \x03(\tR\x05nodes2\xc6\x02\n" +
 	"\bPayerApi\x12\xb8\x01\n" +
-	"\x16PublishClientEnvelopes\x124.xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest\x1a5.xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/mls/v2/payer/publish-client-envelopes\x12\x94\x01\n" +
-	"\rGetReaderNode\x12+.xmtp.xmtpv4.payer_api.GetReaderNodeRequest\x1a,.xmtp.xmtpv4.payer_api.GetReaderNodeResponse\"(\x82\xd3\xe4\x93\x02\":\x01*\"\x1d/mls/v2/payer/get-reader-nodeB\xce\x01\n" +
+	"\x16PublishClientEnvelopes\x124.xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest\x1a5.xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/mls/v2/payer/publish-client-envelopes\x12\x7f\n" +
+	"\bGetNodes\x12&.xmtp.xmtpv4.payer_api.GetNodesRequest\x1a'.xmtp.xmtpv4.payer_api.GetNodesResponse\"\"\x82\xd3\xe4\x93\x02\x1c:\x01*\"\x17/mls/v2/payer/get-nodesB\xce\x01\n" +
 	"\x19com.xmtp.xmtpv4.payer_apiB\rPayerApiProtoP\x01Z0github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api\xa2\x02\x03XXP\xaa\x02\x14Xmtp.Xmtpv4.PayerApi\xca\x02\x14Xmtp\\Xmtpv4\\PayerApi\xe2\x02 Xmtp\\Xmtpv4\\PayerApi\\GPBMetadata\xea\x02\x16Xmtp::Xmtpv4::PayerApib\x06proto3"
 
 var (
@@ -235,8 +226,8 @@ var file_xmtpv4_payer_api_payer_api_proto_msgTypes = make([]protoimpl.MessageInf
 var file_xmtpv4_payer_api_payer_api_proto_goTypes = []any{
 	(*PublishClientEnvelopesRequest)(nil),  // 0: xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest
 	(*PublishClientEnvelopesResponse)(nil), // 1: xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse
-	(*GetReaderNodeRequest)(nil),           // 2: xmtp.xmtpv4.payer_api.GetReaderNodeRequest
-	(*GetReaderNodeResponse)(nil),          // 3: xmtp.xmtpv4.payer_api.GetReaderNodeResponse
+	(*GetNodesRequest)(nil),                // 2: xmtp.xmtpv4.payer_api.GetNodesRequest
+	(*GetNodesResponse)(nil),               // 3: xmtp.xmtpv4.payer_api.GetNodesResponse
 	(*envelopes.ClientEnvelope)(nil),       // 4: xmtp.xmtpv4.envelopes.ClientEnvelope
 	(*envelopes.OriginatorEnvelope)(nil),   // 5: xmtp.xmtpv4.envelopes.OriginatorEnvelope
 }
@@ -244,9 +235,9 @@ var file_xmtpv4_payer_api_payer_api_proto_depIdxs = []int32{
 	4, // 0: xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest.envelopes:type_name -> xmtp.xmtpv4.envelopes.ClientEnvelope
 	5, // 1: xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse.originator_envelopes:type_name -> xmtp.xmtpv4.envelopes.OriginatorEnvelope
 	0, // 2: xmtp.xmtpv4.payer_api.PayerApi.PublishClientEnvelopes:input_type -> xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest
-	2, // 3: xmtp.xmtpv4.payer_api.PayerApi.GetReaderNode:input_type -> xmtp.xmtpv4.payer_api.GetReaderNodeRequest
+	2, // 3: xmtp.xmtpv4.payer_api.PayerApi.GetNodes:input_type -> xmtp.xmtpv4.payer_api.GetNodesRequest
 	1, // 4: xmtp.xmtpv4.payer_api.PayerApi.PublishClientEnvelopes:output_type -> xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse
-	3, // 5: xmtp.xmtpv4.payer_api.PayerApi.GetReaderNode:output_type -> xmtp.xmtpv4.payer_api.GetReaderNodeResponse
+	3, // 5: xmtp.xmtpv4.payer_api.PayerApi.GetNodes:output_type -> xmtp.xmtpv4.payer_api.GetNodesResponse
 	4, // [4:6] is the sub-list for method output_type
 	2, // [2:4] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name

--- a/pkg/proto/xmtpv4/payer_api/payer_api.pb.gw.go
+++ b/pkg/proto/xmtpv4/payer_api/payer_api.pb.gw.go
@@ -57,28 +57,28 @@ func local_request_PayerApi_PublishClientEnvelopes_0(ctx context.Context, marsha
 
 }
 
-func request_PayerApi_GetReaderNode_0(ctx context.Context, marshaler runtime.Marshaler, client PayerApiClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq GetReaderNodeRequest
+func request_PayerApi_GetNodes_0(ctx context.Context, marshaler runtime.Marshaler, client PayerApiClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetNodesRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	msg, err := client.GetReaderNode(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.GetNodes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
 
-func local_request_PayerApi_GetReaderNode_0(ctx context.Context, marshaler runtime.Marshaler, server PayerApiServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq GetReaderNodeRequest
+func local_request_PayerApi_GetNodes_0(ctx context.Context, marshaler runtime.Marshaler, server PayerApiServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetNodesRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	msg, err := server.GetReaderNode(ctx, &protoReq)
+	msg, err := server.GetNodes(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -114,7 +114,7 @@ func RegisterPayerApiHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 
 	})
 
-	mux.Handle("POST", pattern_PayerApi_GetReaderNode_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("POST", pattern_PayerApi_GetNodes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -122,12 +122,12 @@ func RegisterPayerApiHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/xmtp.xmtpv4.payer_api.PayerApi/GetReaderNode", runtime.WithHTTPPathPattern("/mls/v2/payer/get-reader-node"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/xmtp.xmtpv4.payer_api.PayerApi/GetNodes", runtime.WithHTTPPathPattern("/mls/v2/payer/get-nodes"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_PayerApi_GetReaderNode_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_PayerApi_GetNodes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
@@ -135,7 +135,7 @@ func RegisterPayerApiHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 			return
 		}
 
-		forward_PayerApi_GetReaderNode_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_PayerApi_GetNodes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -202,25 +202,25 @@ func RegisterPayerApiHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 
 	})
 
-	mux.Handle("POST", pattern_PayerApi_GetReaderNode_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("POST", pattern_PayerApi_GetNodes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/xmtp.xmtpv4.payer_api.PayerApi/GetReaderNode", runtime.WithHTTPPathPattern("/mls/v2/payer/get-reader-node"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/xmtp.xmtpv4.payer_api.PayerApi/GetNodes", runtime.WithHTTPPathPattern("/mls/v2/payer/get-nodes"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_PayerApi_GetReaderNode_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_PayerApi_GetNodes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_PayerApi_GetReaderNode_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_PayerApi_GetNodes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -230,11 +230,11 @@ func RegisterPayerApiHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 var (
 	pattern_PayerApi_PublishClientEnvelopes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"mls", "v2", "payer", "publish-client-envelopes"}, ""))
 
-	pattern_PayerApi_GetReaderNode_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"mls", "v2", "payer", "get-reader-node"}, ""))
+	pattern_PayerApi_GetNodes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"mls", "v2", "payer", "get-nodes"}, ""))
 )
 
 var (
 	forward_PayerApi_PublishClientEnvelopes_0 = runtime.ForwardResponseMessage
 
-	forward_PayerApi_GetReaderNode_0 = runtime.ForwardResponseMessage
+	forward_PayerApi_GetNodes_0 = runtime.ForwardResponseMessage
 )

--- a/pkg/proto/xmtpv4/payer_api/payer_api_grpc.pb.go
+++ b/pkg/proto/xmtpv4/payer_api/payer_api_grpc.pb.go
@@ -22,7 +22,7 @@ const _ = grpc.SupportPackageIsVersion7
 
 const (
 	PayerApi_PublishClientEnvelopes_FullMethodName = "/xmtp.xmtpv4.payer_api.PayerApi/PublishClientEnvelopes"
-	PayerApi_GetReaderNode_FullMethodName          = "/xmtp.xmtpv4.payer_api.PayerApi/GetReaderNode"
+	PayerApi_GetNodes_FullMethodName               = "/xmtp.xmtpv4.payer_api.PayerApi/GetNodes"
 )
 
 // PayerApiClient is the client API for PayerApi service.
@@ -31,7 +31,7 @@ const (
 type PayerApiClient interface {
 	// Publish envelope
 	PublishClientEnvelopes(ctx context.Context, in *PublishClientEnvelopesRequest, opts ...grpc.CallOption) (*PublishClientEnvelopesResponse, error)
-	GetReaderNode(ctx context.Context, in *GetReaderNodeRequest, opts ...grpc.CallOption) (*GetReaderNodeResponse, error)
+	GetNodes(ctx context.Context, in *GetNodesRequest, opts ...grpc.CallOption) (*GetNodesResponse, error)
 }
 
 type payerApiClient struct {
@@ -51,9 +51,9 @@ func (c *payerApiClient) PublishClientEnvelopes(ctx context.Context, in *Publish
 	return out, nil
 }
 
-func (c *payerApiClient) GetReaderNode(ctx context.Context, in *GetReaderNodeRequest, opts ...grpc.CallOption) (*GetReaderNodeResponse, error) {
-	out := new(GetReaderNodeResponse)
-	err := c.cc.Invoke(ctx, PayerApi_GetReaderNode_FullMethodName, in, out, opts...)
+func (c *payerApiClient) GetNodes(ctx context.Context, in *GetNodesRequest, opts ...grpc.CallOption) (*GetNodesResponse, error) {
+	out := new(GetNodesResponse)
+	err := c.cc.Invoke(ctx, PayerApi_GetNodes_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (c *payerApiClient) GetReaderNode(ctx context.Context, in *GetReaderNodeReq
 type PayerApiServer interface {
 	// Publish envelope
 	PublishClientEnvelopes(context.Context, *PublishClientEnvelopesRequest) (*PublishClientEnvelopesResponse, error)
-	GetReaderNode(context.Context, *GetReaderNodeRequest) (*GetReaderNodeResponse, error)
+	GetNodes(context.Context, *GetNodesRequest) (*GetNodesResponse, error)
 	mustEmbedUnimplementedPayerApiServer()
 }
 
@@ -77,8 +77,8 @@ type UnimplementedPayerApiServer struct {
 func (UnimplementedPayerApiServer) PublishClientEnvelopes(context.Context, *PublishClientEnvelopesRequest) (*PublishClientEnvelopesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PublishClientEnvelopes not implemented")
 }
-func (UnimplementedPayerApiServer) GetReaderNode(context.Context, *GetReaderNodeRequest) (*GetReaderNodeResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetReaderNode not implemented")
+func (UnimplementedPayerApiServer) GetNodes(context.Context, *GetNodesRequest) (*GetNodesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNodes not implemented")
 }
 func (UnimplementedPayerApiServer) mustEmbedUnimplementedPayerApiServer() {}
 
@@ -111,20 +111,20 @@ func _PayerApi_PublishClientEnvelopes_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PayerApi_GetReaderNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetReaderNodeRequest)
+func _PayerApi_GetNodes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetNodesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(PayerApiServer).GetReaderNode(ctx, in)
+		return srv.(PayerApiServer).GetNodes(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: PayerApi_GetReaderNode_FullMethodName,
+		FullMethod: PayerApi_GetNodes_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PayerApiServer).GetReaderNode(ctx, req.(*GetReaderNodeRequest))
+		return srv.(PayerApiServer).GetNodes(ctx, req.(*GetNodesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -141,8 +141,8 @@ var PayerApi_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _PayerApi_PublishClientEnvelopes_Handler,
 		},
 		{
-			MethodName: "GetReaderNode",
-			Handler:    _PayerApi_GetReaderNode_Handler,
+			MethodName: "GetNodes",
+			Handler:    _PayerApi_GetNodes_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/registry/node_registry_contract.go
+++ b/pkg/registry/node_registry_contract.go
@@ -120,7 +120,7 @@ func (s *SmartContractRegistry) GetNodes() ([]Node, error) {
 	s.nodesMutex.RLock()
 	defer s.nodesMutex.RUnlock()
 
-	nodes := make([]Node, 0)
+	nodes := make([]Node, 0, len(s.nodes))
 	for _, node := range s.nodes {
 		nodes = append(nodes, node)
 	}


### PR DESCRIPTION
### Add GetNodes gateway endpoint by updating `payer.Service.GetNodes` to return all node URLs and changing the HTTP path to `/mls/v2/payer/get-nodes`
- Replace the reader-node API with a nodes-list API by updating `payer.Service.GetNodes` to return a flat list of node `HTTPAddress` values and emit `xmtp_payer_get_nodes_available_nodes` in [service.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280).
- Regenerate protobuf and gateway artifacts to rename request/response types to `GetNodes*` and change the HTTP route to `/mls/v2/payer/get-nodes` in [payer_api.pb.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-33dbabd792c0a769ddc7e0fb09eb3d8eddfd04a094ba2f2aa1bd5d06b6d71579), [payer_api_grpc.pb.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-a0c2abeee8804aba7fbf1caac6507ec8589a0193f39c6d912500af93bf8bf0e8), [payer_api.pb.gw.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-3db3c250c14fec10138d2bca32f2af61aba9f2d6fc3e25b74d2843b6961508b3), and [payer_api.swagger.json](https://github.com/xmtp/xmtpd/pull/1169/files#diff-9146cd0204f36da1a0e743caed8a149ed66f894efc54362b9be6ab129b53a31b).
- Rename the payer metric and its emitter to `xmtp_payer_get_nodes_available_nodes` across [metrics.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23) and [payer.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-e04f97104acd535b565bd77008777026f0f2dcd545aae4dfd19de19da284b46e).
- Update tests to validate the new response shape in [service_test.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-ea1ee90cc2809aae065a5464394d9e28bdf36a17038782395e11a9d18056ba2e).
- Add generator scripts and adjust workflow paths in [.github/workflows/lint-go.yml](https://github.com/xmtp/xmtpd/pull/1169/files#diff-e3eb5891b2343a83d8ea323d0f6ebf2724e3eb90de760155b1926e50f86039e9), [dev/gen/metrics-catalog](https://github.com/xmtp/xmtpd/pull/1169/files#diff-91a195f11223740f159780a82d3f43714808c2913d9d39d78ea568fd1d0eb3c0), and [dev/gen/env](https://github.com/xmtp/xmtpd/pull/1169/files#diff-379d974ec4d7a6c28c301b9cda0e60b3a5edd8c9e51bb29d6c98a4944e5047b9); remove [dev/generate-env](https://github.com/xmtp/xmtpd/pull/1169/files#diff-cd044065e76d028e594b847dab6b621a454b4dea70588f8fb91e1975ea9cad2a).
- Update the metrics catalog entry in [metrics_catalog.md](https://github.com/xmtp/xmtpd/pull/1169/files#diff-76ce58ca7626239d9d1fcf2571f79d0337a091f72961c3ef6113b2f5fe06a994) and preallocate the nodes slice in [node_registry_contract.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-e820e7abce854ff523aacd7f865173e0f630d48e6b49e86ae41ac037d619ad2e).

#### 📍Where to Start
Start with the gRPC handler `payer.Service.GetNodes` in [service.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280), then review the generated gateway and protobuf changes in [payer_api.pb.gw.go](https://github.com/xmtp/xmtpd/pull/1169/files#diff-3db3c250c14fec10138d2bca32f2af61aba9f2d6fc3e25b74d2843b6961508b3) and [payer_api.swagger.json](https://github.com/xmtp/xmtpd/pull/1169/files#diff-9146cd0204f36da1a0e743caed8a149ed66f894efc54362b9be6ab129b53a31b).

----

_[Macroscope](https://app.macroscope.com) summarized 523d377._