### PR TITLE
Finish withdrawal flow for CLI

### DIFF
--- a/cmd/xmtpd-cli/commands/funds.go
+++ b/cmd/xmtpd-cli/commands/funds.go
@@ -178,7 +178,6 @@ func withdrawHandler(opts WithdrawOpts) error {
 }
 
 func receiveWithdrawalCmd() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:          "receive-withdrawal",
 		Short:        "Receive a withdrawal from XMTP",
@@ -223,7 +222,6 @@ func receiveWithdrawalHandler() error {
 // ---- balances ----
 
 func balancesCmd() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:          "balances",
 		Short:        "Check balances for an address",

--- a/cmd/xmtpd-cli/commands/funds.go
+++ b/cmd/xmtpd-cli/commands/funds.go
@@ -96,7 +96,7 @@ func depositHandler(opts DepositOpts) error {
 	}
 
 	if amount.Sign() == -1 {
-		return fmt.Errorf("invalid --amount %d; must be non-negative", amount)
+		return fmt.Errorf("invalid --amount %s; must be non-negative", opts.Amount)
 	}
 	if opts.GasLimit < 0 {
 		return fmt.Errorf("invalid --gas-limit %d; must be non-negative", opts.GasLimit)

--- a/cmd/xmtpd-cli/commands/funds.go
+++ b/cmd/xmtpd-cli/commands/funds.go
@@ -165,7 +165,7 @@ func withdrawHandler(opts WithdrawOpts) error {
 	}
 
 	if amount.Sign() == -1 {
-		return fmt.Errorf("invalid --amount %d; must be non-negative", amount)
+		return fmt.Errorf("invalid --amount %s; must be non-negative", opts.Amount)
 	}
 
 	err = admin.Withdraw(ctx, amount)

--- a/pkg/blockchain/funds_admin.go
+++ b/pkg/blockchain/funds_admin.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/xmtp/xmtpd/pkg/currency"
+
 	acg "github.com/xmtp/xmtpd/pkg/abi/appchaingateway"
 	scg "github.com/xmtp/xmtpd/pkg/abi/settlementchaingateway"
 
@@ -128,7 +130,7 @@ func (f *fundsAdmin) Balances(ctx context.Context) error {
 		f.logger.Info(
 			"ETH balance of",
 			zap.String("address", address.Hex()),
-			zap.String("balance", FromWei(ethBalance, 18)),
+			zap.String("balance", currency.FromWei(ethBalance, 18)),
 		)
 	}
 
@@ -138,7 +140,7 @@ func (f *fundsAdmin) Balances(ctx context.Context) error {
 	} else {
 		f.logger.Info(
 			"xUSD balance of", zap.String("address", address.Hex()),
-			zap.String("balance", FromWei(feeTokenBalance, 6)),
+			zap.String("balance", currency.FromWei(feeTokenBalance, 6)),
 		)
 	}
 
@@ -148,7 +150,7 @@ func (f *fundsAdmin) Balances(ctx context.Context) error {
 	} else {
 		f.logger.Info(
 			"USDC balance of", zap.String("address", address.Hex()),
-			zap.String("balance", FromWei(underlyingTokenBalance, 6)),
+			zap.String("balance", currency.FromWei(underlyingTokenBalance, 6)),
 		)
 	}
 
@@ -159,7 +161,7 @@ func (f *fundsAdmin) Balances(ctx context.Context) error {
 		f.logger.Info(
 			"XMTP balance of",
 			zap.String("address", address.Hex()),
-			zap.String("balance", FromWei(appGasBalance, 18)),
+			zap.String("balance", currency.FromWei(appGasBalance, 18)),
 		)
 	}
 
@@ -369,36 +371,4 @@ func (f *fundsAdmin) ReceiveWithdrawal(
 	}
 
 	return nil
-}
-
-// FromWei converts a wei value into a decimal string with the given decimals.
-// For ETH, use decimals = 18.
-// For an ERC20, use its `decimals()` value.
-func FromWei(wei *big.Int, decimals int) string {
-	// divisor = 10^decimals
-	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
-
-	intPart := new(big.Int).Div(wei, divisor)
-	fracPart := new(big.Int).Mod(wei, divisor)
-
-	// Left-pad fractional part with zeros
-	fracStr := fracPart.String()
-	for len(fracStr) < decimals {
-		fracStr = "0" + fracStr
-	}
-
-	// Trim trailing zeros for nicer output
-	fracStr = trimTrailingZeros(fracStr)
-
-	if fracStr == "" {
-		return intPart.String()
-	}
-	return intPart.String() + "." + fracStr
-}
-
-func trimTrailingZeros(s string) string {
-	for len(s) > 0 && s[len(s)-1] == '0' {
-		s = s[:len(s)-1]
-	}
-	return s
 }

--- a/pkg/blockchain/funds_admin.go
+++ b/pkg/blockchain/funds_admin.go
@@ -285,7 +285,7 @@ func (f *fundsAdmin) Withdraw(
 	}
 	f.logger.Info("Current balance", zap.String("raw", appGasBalance.String()))
 
-	if appGasBalance.Cmp(amount) < 0 {
+	if appGasBalance.Cmp(amount) <= 0 {
 		return fmt.Errorf(
 			"insufficient balance: need %s tokens, have %s tokens",
 			amount.String(),

--- a/pkg/blockchain/funds_admin_test.go
+++ b/pkg/blockchain/funds_admin_test.go
@@ -2,19 +2,32 @@ package blockchain_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/xmtp/xmtpd/pkg/config"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	"github.com/xmtp/xmtpd/pkg/testutils/anvil"
+
+	"github.com/xmtp/xmtpd/pkg/abi/erc20"
 )
 
-func buildFundsAdmin(
+// --- local helper that also returns client + options so we can assert balances on-chain.
+func buildFundsAdminWithDeps(
 	t *testing.T,
-) (blockchain.IFundsAdmin, context.Context) {
+) (blockchain.IFundsAdmin, context.Context, *ethclient.Client, config.ContractsOptions) {
+	t.Helper()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
+
 	logger := testutils.NewLog(t)
 	wsURL, rpcURL := anvil.StartAnvil(t, false)
 	contractsOptions := testutils.NewContractsOptions(t, rpcURL, wsURL)
@@ -25,10 +38,7 @@ func buildFundsAdmin(
 	)
 	require.NoError(t, err)
 
-	client, err := blockchain.NewRPCClient(
-		ctx,
-		contractsOptions.SettlementChain.RPCURL,
-	)
+	client, err := blockchain.NewRPCClient(ctx, contractsOptions.SettlementChain.RPCURL)
 	require.NoError(t, err)
 
 	admin, err := blockchain.NewFundsAdmin(
@@ -47,9 +57,58 @@ func buildFundsAdmin(
 	)
 	require.NoError(t, err)
 
-	return admin, ctx
+	return admin, ctx, client, contractsOptions
 }
 
-func TestFundsAdmin(t *testing.T) {
-	_, _ = buildFundsAdmin(t)
+// Balances() should not error and should log current balances.
+func TestFundsAdmin_Balances_NoError(t *testing.T) {
+	admin, ctx, _, _ := buildFundsAdminWithDeps(t)
+	require.NoError(t, admin.Balances(ctx))
+}
+
+// MintMockUSDC: negative amount should be rejected immediately.
+func TestFundsAdmin_MintMockUSDC_RejectsNegative(t *testing.T) {
+	admin, ctx, _, _ := buildFundsAdminWithDeps(t)
+
+	addr := testutils.RandomAddress()
+	neg := big.NewInt(-1)
+
+	err := admin.MintMockUSDC(ctx, addr, neg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "amount must be positive")
+}
+
+// MintMockUSDC: > 10_000 * 1e6 (raw 10000000000) should be rejected.
+func TestFundsAdmin_MintMockUSDC_RejectsTooLarge(t *testing.T) {
+	admin, ctx, _, _ := buildFundsAdminWithDeps(t)
+
+	addr := testutils.RandomAddress()
+	tooLarge := big.NewInt(0).SetUint64(10000000001) // > 10_000e6
+
+	err := admin.MintMockUSDC(ctx, addr, tooLarge)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "amount must be less than 10000 mxUSDC")
+}
+
+// MintMockUSDC: successful mint should reflect in the ERC20 balance at UnderlyingFeeToken address.
+func TestFundsAdmin_MintMockUSDC_SetsBalance(t *testing.T) {
+	admin, ctx, client, opts := buildFundsAdminWithDeps(t)
+
+	underlyingAddr := common.HexToAddress(opts.SettlementChain.UnderlyingFeeToken)
+	underlying, err := erc20.NewERC20(underlyingAddr, client)
+	require.NoError(t, err)
+
+	recipient := testutils.RandomAddress()
+	amount := big.NewInt(1_234_567) // 1.234567 USDC, raw with 6 decimals
+
+	require.NoError(t, admin.MintMockUSDC(ctx, recipient, amount))
+
+	// The mock token implements ERC20; verify balance eventually (anvil + tx mining).
+	require.Eventually(t, func() bool {
+		bal, err := underlying.BalanceOf(&bind.CallOpts{Context: ctx}, recipient)
+		if err != nil {
+			return false
+		}
+		return bal.Cmp(amount) == 0
+	}, 2*time.Second, 50*time.Millisecond)
 }

--- a/pkg/currency/currency_test.go
+++ b/pkg/currency/currency_test.go
@@ -1,28 +1,60 @@
-package currency
+package currency_test
 
 import (
+	"math/big"
 	"testing"
+
+	"github.com/xmtp/xmtpd/pkg/currency"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestConversion(t *testing.T) {
-	initial, err := FromDollars(1.25)
+	initial, err := currency.FromDollars(1.25)
 	require.NoError(t, err)
-	require.Equal(t, PicoDollar(1250000000000), initial)
+	require.Equal(t, currency.PicoDollar(1250000000000), initial)
 
-	converted := initial.toDollarsTestOnly()
+	converted := initial.ToDollarsTestOnly()
 	require.Equal(t, 1.25, converted)
 }
 
 func TestString(t *testing.T) {
-	initial, err := FromDollars(1.25)
+	initial, err := currency.FromDollars(1.25)
 	require.NoError(t, err)
 	require.Equal(t, "1.250000000000", initial.String())
 }
 
 func TestToMicroDollars(t *testing.T) {
-	initial, err := FromDollars(1.25)
+	initial, err := currency.FromDollars(1.25)
 	require.NoError(t, err)
 	require.EqualValues(t, int64(1250000), initial.ToMicroDollars())
+}
+
+// FromWei: formatting & trimming behavior.
+func TestFromWei_Basic(t *testing.T) {
+	// 1 ether, 18 decimals -> "1"
+	require.Equal(
+		t,
+		"1",
+		currency.FromWei(big.NewInt(1).Mul(big.NewInt(1e18), big.NewInt(1)), 18),
+	)
+
+	// 1.5 ether -> "1.5"
+	v := big.NewInt(0).Add(
+		new(big.Int).Mul(big.NewInt(1), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
+		new(big.Int).Mul(big.NewInt(5), new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil)),
+	)
+	require.Equal(t, "1.5", currency.FromWei(v, 18))
+
+	// 1234567 with 6 decimals -> "1.234567"
+	require.Equal(t, "1.234567", currency.FromWei(big.NewInt(1_234_567), 6))
+
+	// 1000000 with 6 decimals -> "1"
+	require.Equal(t, "1", currency.FromWei(big.NewInt(1_000_000), 6))
+
+	// 1000010 with 6 decimals -> "1.00001" (trims trailing zero only)
+	require.Equal(t, "1.00001", currency.FromWei(big.NewInt(1_000_010), 6))
+
+	// 0 with any decimals -> "0"
+	require.Equal(t, "0", currency.FromWei(big.NewInt(0), 18))
 }

--- a/pkg/currency/exports_test.go
+++ b/pkg/currency/exports_test.go
@@ -1,0 +1,12 @@
+package currency
+
+import "fmt"
+
+// toDollarsTestOnly converts PicoDollars to a dollar amount (as a float)
+func (p PicoDollar) ToDollarsTestOnly() float64 {
+	return float64(p) / PicoDollarsPerDollar
+}
+
+func (p PicoDollar) String() string {
+	return fmt.Sprintf("%.12f", p.ToDollarsTestOnly())
+}

--- a/pkg/indexer/settlement_chain/contracts/payer_registry_storer.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_registry_storer.go
@@ -117,7 +117,7 @@ func (s *PayerRegistryStorer) handleDeposit(
 	s.logger.Info(
 		"deposit successful",
 		zap.String("payer_address", parsedEvent.Payer.Hex()),
-		zap.String("amount", amount.String()),
+		zap.Int64("amount", int64(amount)),
 		zap.String("event_id", eventID.String()),
 	)
 
@@ -157,7 +157,7 @@ func (s *PayerRegistryStorer) handleWithdrawalRequested(
 	s.logger.Info(
 		"withdrawal requested successful",
 		zap.String("payer_address", parsedEvent.Payer.Hex()),
-		zap.String("amount", amount.String()),
+		zap.Int64("amount", int64(amount)),
 		zap.String("event_id", eventID.String()),
 	)
 
@@ -192,7 +192,7 @@ func (s *PayerRegistryStorer) handleUsageSettled(
 	s.logger.Info(
 		"usage settled",
 		zap.String("payer_address", parsedEvent.Payer.Hex()),
-		zap.String("amount", amount.String()),
+		zap.Int64("amount", int64(amount)),
 		zap.String("event_id", eventID.String()),
 	)
 


### PR DESCRIPTION
### Finish CLI withdrawal flow by adding `commands.receiveWithdrawalCmd` and implementing `blockchain.fundsAdmin.Withdraw` and `blockchain.fundsAdmin.ReceiveWithdrawal` for app-chain initiation and settlement-chain receipt
This change completes the withdrawal flow in the CLI and blockchain layer by wiring app-chain initiation and settlement-chain receipt, updating command UX, and consolidating balance queries to the default signer.

- Add `blockchain.fundsAdmin.Withdraw(ctx, amount)` to initiate withdrawals via `acg.AppChainGateway.Withdraw` and `blockchain.fundsAdmin.ReceiveWithdrawal(ctx)` to finalize on the settlement chain, with constructor `blockchain.NewFundsAdmin` initializing the app-chain gateway ([funds_admin.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-099ef4ce6c7e757072b1d8a5c41edc86c29b0141023a0cebe76a14c0f9d868aa)).
- Replace the CLI withdraw options to accept only `--amount`, implement `commands.withdrawHandler`, and introduce `commands.receiveWithdrawalCmd` with `commands.receiveWithdrawalHandler`; remove `check-withdrawals` and address-based balances ([funds.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-b5b281f9568c863cbcb9336c97dd77dc4c72de95b7b5c3f9002f3be454068a86)).
- Move wei formatting to `currency.FromWei` and add tests and test-only exports for `PicoDollar` formatting ([currency.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-6e08835601ce01617590dc01f157b71b7a4a07f2240aa26c143f9f48de1743f3), [currency_test.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-fc37b967cc27d15265d1c04a8d9181b831cfe3da89390997b483b093838069e2), [exports_test.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-ba426d7e61789f0b6fa36965d41b7fd7fc13877e18512b821b8368b151def6a5)).
- Adjust indexer logging to record raw pico-dollar integers in payer registry event handlers ([payer_registry_storer.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-29eaede034c786e75c6dabe8f0d076c8742170dac41c84cc8eef4a1ee96c908c)).
- Add integration-style tests and helpers for `FundsAdmin` and coverage for minting and balances ([funds_admin_test.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-a83d32e195ae0e01d70be6909f7d43344db468117e66592a34457d0d61d7f99f)).

#### 📍Where to Start
Start with the CLI flow entry points in `commands.withdrawHandler` and `commands.receiveWithdrawalHandler` in [funds.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-b5b281f9568c863cbcb9336c97dd77dc4c72de95b7b5c3f9002f3be454068a86), then follow into `blockchain.fundsAdmin.Withdraw` and `blockchain.fundsAdmin.ReceiveWithdrawal` in [funds_admin.go](https://github.com/xmtp/xmtpd/pull/1170/files#diff-099ef4ce6c7e757072b1d8a5c41edc86c29b0141023a0cebe76a14c0f9d868aa).

----

_[Macroscope](https://app.macroscope.com) summarized 1e2ee84._