### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/pkg/blockchain/noncemanager/redis/manager_test.go
+++ b/pkg/blockchain/noncemanager/redis/manager_test.go
@@ -89,9 +89,7 @@ func TestRedisGetNonce_ConsumeManyConcurrent(t *testing.T) {
 	errCh := make(chan error, numClients)
 
 	for range numClients {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			nonce, err := nonceManager.GetNonce(t.Context())
 			if err != nil {
 				errCh <- err
@@ -102,7 +100,7 @@ func TestRedisGetNonce_ConsumeManyConcurrent(t *testing.T) {
 				errCh <- err
 				return
 			}
-		}()
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION

use WaitGroup.Go to simplify code.

More info can see: https://github.com/golang/go/issues/63796

