### PR TITLE
Add reports test scaffolding

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -70,8 +70,9 @@ func TestCreateServer(t *testing.T) {
 			PrivateKey:       privateKey1,
 			ContractsOptions: contractsOptions,
 			Services: serverTestUtils.EnabledServices{
-				API:  true,
-				Sync: true,
+				API:     true,
+				Reports: true,
+				Sync:    true,
 			},
 		},
 	)
@@ -84,8 +85,9 @@ func TestCreateServer(t *testing.T) {
 			PrivateKey:       privateKey2,
 			ContractsOptions: contractsOptions,
 			Services: serverTestUtils.EnabledServices{
-				API:  true,
-				Sync: true,
+				API:     true,
+				Reports: true,
+				Sync:    true,
 			},
 		},
 	)

--- a/pkg/testutils/server/server.go
+++ b/pkg/testutils/server/server.go
@@ -21,6 +21,7 @@ import (
 type EnabledServices struct {
 	API     bool
 	Indexer bool
+	Reports bool
 	Sync    bool
 }
 
@@ -54,6 +55,10 @@ func NewTestReplicationServer(
 			Contracts: cfg.ContractsOptions,
 			MlsValidation: config.MlsValidationOptions{
 				GrpcAddress: "http://localhost:60051",
+			},
+			PayerReport: config.PayerReportOptions{
+				Enable:                        cfg.Services.Reports,
+				AttestationWorkerPollInterval: 10 * time.Second,
 			},
 			Signer: config.SignerOptions{
 				PrivateKey: hex.EncodeToString(crypto.FromECDSA(cfg.PrivateKey)),


### PR DESCRIPTION
### Enable Reports service in test replication servers and gate `PayerReport` via `server.EnabledServices.Reports` with a 10s attestation poll interval to add reports test scaffolding
This change adds a `Reports` flag to `server.EnabledServices` and wires `PayerReport` configuration into test server construction, enabling the Reports service in tests with a fixed 10s attestation worker polling interval.

- Add `Reports` boolean to `server.EnabledServices` and use it to set `config.PayerReportOptions.Enable` with `AttestationWorkerPollInterval` set to 10s in `server.NewTestReplicationServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1177/files#diff-a1f50c3bc62428254bc65c36229e5bb91d1ff95fe483673bf6daed86d34ee221)
- Update `TestCreateServer` to enable the Reports service for both test replication servers in [server_test.go](https://github.com/xmtp/xmtpd/pull/1177/files#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4e)

#### 📍Where to Start
Start with `server.NewTestReplicationServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1177/files#diff-a1f50c3bc62428254bc65c36229e5bb91d1ff95fe483673bf6daed86d34ee221) to review how `PayerReport` options are configured, then see `TestCreateServer` in [server_test.go](https://github.com/xmtp/xmtpd/pull/1177/files#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4e).

----

_[Macroscope](https://app.macroscope.com) summarized d25f7eb._