### PR TITLE
Fix Identity update StoreLog under HA

### DIFF
--- a/pkg/db/queries/identity_updates.sql.go
+++ b/pkg/db/queries/identity_updates.sql.go
@@ -12,19 +12,20 @@ import (
 	"github.com/lib/pq"
 )
 
-const advisoryLockSequence = `-- name: AdvisoryLockSequence :exec
+const advisoryLockIdentityUpdateInsert = `-- name: AdvisoryLockIdentityUpdateInsert :exec
 SELECT pg_advisory_xact_lock(
-               ($1::bigint << 32) | ($2 & 4294967295)
-       )
+    ($1::bigint << 32) | ($2 & 4294967295)
+)
 `
 
-type AdvisoryLockSequenceParams struct {
+type AdvisoryLockIdentityUpdateInsertParams struct {
 	NodeID     int64
 	SequenceID interface{}
 }
 
-func (q *Queries) AdvisoryLockSequence(ctx context.Context, arg AdvisoryLockSequenceParams) error {
-	_, err := q.db.ExecContext(ctx, advisoryLockSequence, arg.NodeID, arg.SequenceID)
+// only take the lowest 32 bits (mod 2^32-1)
+func (q *Queries) AdvisoryLockIdentityUpdateInsert(ctx context.Context, arg AdvisoryLockIdentityUpdateInsertParams) error {
+	_, err := q.db.ExecContext(ctx, advisoryLockIdentityUpdateInsert, arg.NodeID, arg.SequenceID)
 	return err
 }
 

--- a/pkg/db/queries/identity_updates.sql.go
+++ b/pkg/db/queries/identity_updates.sql.go
@@ -12,6 +12,22 @@ import (
 	"github.com/lib/pq"
 )
 
+const advisoryLockSequence = `-- name: AdvisoryLockSequence :exec
+SELECT pg_advisory_xact_lock(
+               ($1::bigint << 32) | ($2 & 4294967295)
+       )
+`
+
+type AdvisoryLockSequenceParams struct {
+	NodeID     int64
+	SequenceID interface{}
+}
+
+func (q *Queries) AdvisoryLockSequence(ctx context.Context, arg AdvisoryLockSequenceParams) error {
+	_, err := q.db.ExecContext(ctx, advisoryLockSequence, arg.NodeID, arg.SequenceID)
+	return err
+}
+
 const getAddressLogs = `-- name: GetAddressLogs :many
 SELECT
 	a.address,

--- a/pkg/db/sqlc/identity_updates.sql
+++ b/pkg/db/sqlc/identity_updates.sql
@@ -37,7 +37,8 @@ WHERE
 	address = @address
 	AND inbox_id = decode(@inbox_id, 'hex');
 
--- name: AdvisoryLockSequence :exec
+-- name: AdvisoryLockIdentityUpdateInsert :exec
 SELECT pg_advisory_xact_lock(
-               (@node_id::bigint << 32) | (@sequence_id & 4294967295)
-       );
+-- only take the lowest 32 bits (mod 2^32-1)
+    (@node_id::bigint << 32) | (@sequence_id & 4294967295)
+);

--- a/pkg/db/sqlc/identity_updates.sql
+++ b/pkg/db/sqlc/identity_updates.sql
@@ -36,3 +36,8 @@ SET
 WHERE
 	address = @address
 	AND inbox_id = decode(@inbox_id, 'hex');
+
+-- name: AdvisoryLockSequence :exec
+SELECT pg_advisory_xact_lock(
+               (@node_id::bigint << 32) | (@sequence_id & 4294967295)
+       );

--- a/pkg/indexer/app_chain/contracts/identity_update_storer.go
+++ b/pkg/indexer/app_chain/contracts/identity_update_storer.go
@@ -102,9 +102,9 @@ func (s *IdentityUpdateStorer) StoreLog(
 		s.db,
 		&sql.TxOptions{Isolation: sql.LevelReadCommitted},
 		func(ctx context.Context, querier *queries.Queries) error {
-			err := querier.AdvisoryLockSequence(
+			err := querier.AdvisoryLockIdentityUpdateInsert(
 				ctx,
-				queries.AdvisoryLockSequenceParams{
+				queries.AdvisoryLockIdentityUpdateInsertParams{
 					NodeID:     IDENTITY_UPDATE_ORIGINATOR_ID,
 					SequenceID: msgSent.SequenceId,
 				},


### PR DESCRIPTION
### Take a transaction-scoped advisory lock for identity update StoreLog under HA by calling `queries.Queries.AdvisoryLockSequence` and switching `IdentityUpdateStorer.StoreLog` to READ COMMITTED
- Add a new SQLC query `AdvisoryLockSequence` in [identity_updates.sql](https://github.com/xmtp/xmtpd/pull/1184/files#diff-4558d09ba3a749c92df38c9087258f190502cb9e749a36f261966df4c6da528e) that invokes `pg_advisory_xact_lock` using a composite key of `node_id` and `sequence_id`.
- Generate code in [identity_updates.sql.go](https://github.com/xmtp/xmtpd/pull/1184/files#diff-ad4993331be4939e7084547fb42cd62f33ffe4e5e5950c2af84733948da92b24) including `queries.advisoryLockSequence` SQL, `queries.AdvisoryLockSequenceParams` with `NodeID` and `SequenceID`, and `queries.Queries.AdvisoryLockSequence` method to execute the lock.
- Update `IdentityUpdateStorer.StoreLog` in [identity_update_storer.go](https://github.com/xmtp/xmtpd/pull/1184/files#diff-719fcd3f6b2a547b6c6f299d70464725ddf9c1161c104099b3c3cab140cb2354) to use `sql.LevelReadCommitted`, call `querier.AdvisoryLockSequence` with `IDENTITY_UPDATE_ORIGINATOR_ID` and `msgSent.SequenceId`, and return a non-recoverable error `ErrAdvisoryLockSequence` on lock failure.

#### 📍Where to Start
Start with the transaction flow in `IdentityUpdateStorer.StoreLog` in [identity_update_storer.go](https://github.com/xmtp/xmtpd/pull/1184/files#diff-719fcd3f6b2a547b6c6f299d70464725ddf9c1161c104099b3c3cab140cb2354), then review the new SQLC query `AdvisoryLockSequence` in [identity_updates.sql](https://github.com/xmtp/xmtpd/pull/1184/files#diff-4558d09ba3a749c92df38c9087258f190502cb9e749a36f261966df4c6da528e) and its generated method in [identity_updates.sql.go](https://github.com/xmtp/xmtpd/pull/1184/files#diff-ad4993331be4939e7084547fb42cd62f33ffe4e5e5950c2af84733948da92b24).



#### Changes since #1184 opened

- Renamed SQL advisory lock query and generated code from sequence-based to identity-update-specific naming [79cb8de]
- Updated advisory lock method calls in identity update processing [79cb8de]
----

_[Macroscope](https://app.macroscope.com) summarized 79cb8de._