### PR TITLE
Allow gateway to enable gRPC reflection

### DIFF
--- a/pkg/config/gateway.go
+++ b/pkg/config/gateway.go
@@ -1,11 +1,12 @@
 package config
 
 type GatewayConfig struct {
-	API       APIOptions       `group:"API Options"            namespace:"api"`
-	Contracts ContractsOptions `group:"Contracts Options"      namespace:"contracts"`
-	Log       LogOptions       `group:"Log Options"            namespace:"log"`
-	Metrics   MetricsOptions   `group:"Metrics Options"        namespace:"metrics"`
-	Payer     PayerOptions     `group:"Payer Options"          namespace:"payer"`
-	Redis     RedisOptions     `group:"Redis Options"          namespace:"redis"`
-	Tracing   TracingOptions   `group:"DD APM Tracing Options" namespace:"tracing"`
+	API        APIOptions        `group:"API Options"            namespace:"api"`
+	Contracts  ContractsOptions  `group:"Contracts Options"      namespace:"contracts"`
+	Log        LogOptions        `group:"Log Options"            namespace:"log"`
+	Metrics    MetricsOptions    `group:"Metrics Options"        namespace:"metrics"`
+	Payer      PayerOptions      `group:"Payer Options"          namespace:"payer"`
+	Redis      RedisOptions      `group:"Redis Options"          namespace:"redis"`
+	Tracing    TracingOptions    `group:"DD APM Tracing Options" namespace:"tracing"`
+	Reflection ReflectionOptions `group:"Reflection Options"     namespace:"reflection"`
 }

--- a/pkg/gateway/builder.go
+++ b/pkg/gateway/builder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 var (
@@ -115,6 +116,11 @@ func (b *GatewayServiceBuilder) WithClientMetrics(
 	clientMetrics *grpcprom.ClientMetrics,
 ) IGatewayServiceBuilder {
 	b.clientMetrics = clientMetrics
+	return b
+}
+
+func (b *GatewayServiceBuilder) WithReflection(enabled bool) IGatewayServiceBuilder {
+	b.config.Reflection.Enable = enabled
 	return b
 }
 
@@ -222,6 +228,11 @@ func (b *GatewayServiceBuilder) buildGatewayService(
 			return err
 		}
 		payer_api.RegisterPayerApiServer(grpcServer, gatewayAPIService)
+
+		if b.config.Reflection.Enable {
+			reflection.Register(grpcServer)
+			b.logger.Info("enabled gRPC Server Reflection")
+		}
 
 		return nil
 	}


### PR DESCRIPTION
### Add gateway configuration and builder support to enable gRPC server reflection for the Gateway service
- Add `Reflection` field to `config.GatewayConfig` with struct tags `group:"Reflection Options"` and `namespace:"reflection"` in [gateway.go](https://github.com/xmtp/xmtpd/pull/1185/files#diff-79af78983749015479ea26d687893200bbfad7448eef8f0b97b9f178d3a18c8c)
- Add `gateway.GatewayServiceBuilder.WithReflection` to set `b.config.Reflection.Enable` in [builder.go](https://github.com/xmtp/xmtpd/pull/1185/files#diff-27a239accb0576c3da95c1fea41bd81227bc4355f38be11a66d7b15135ea8e61)
- Update `gateway.GatewayServiceBuilder.buildGatewayService` to conditionally register gRPC reflection via `reflection.Register(grpcServer)` and log when enabled in [builder.go](https://github.com/xmtp/xmtpd/pull/1185/files#diff-27a239accb0576c3da95c1fea41bd81227bc4355f38be11a66d7b15135ea8e61)

#### 📍Where to Start
Start with the service registration path in `gateway.GatewayServiceBuilder.buildGatewayService` in [builder.go](https://github.com/xmtp/xmtpd/pull/1185/files#diff-27a239accb0576c3da95c1fea41bd81227bc4355f38be11a66d7b15135ea8e61).

----

_[Macroscope](https://app.macroscope.com) summarized 27d35bc._