### PR TITLE
Speed up pruner by adding a fully covering index

### DIFF
--- a/pkg/migrations/00017_prune_index.down.sql
+++ b/pkg/migrations/00017_prune_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS gateway_envelopes_expiry_idx;

--- a/pkg/migrations/00017_prune_index.up.sql
+++ b/pkg/migrations/00017_prune_index.up.sql
@@ -1,0 +1,7 @@
+-- Run without timeout, needed as the table can contain up to millions of rows
+SET statement_timeout = 0;
+
+CREATE INDEX gateway_envelopes_expiry_idx
+    ON gateway_envelopes (expiry)
+    INCLUDE (originator_node_id, originator_sequence_id)
+    WHERE expiry IS NOT NULL;


### PR DESCRIPTION
Our pruner in us-east-2 dev was failing. The prune query was taking more than 5ish minutes.

The index creation here is the same as in 00016 and does not use concurrently, which might eventually become a problem. But so far its the pattern, so I am keeping it going.