### PR TITLE
Add more logging around report attestations and submission

### DIFF
--- a/pkg/payerreport/utils.go
+++ b/pkg/payerreport/utils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/envelopes"
 	"github.com/xmtp/xmtpd/pkg/utils"
+	"go.uber.org/zap"
 )
 
 func getMinuteFromSequenceID(
@@ -32,4 +33,13 @@ func getMinuteFromSequenceID(
 
 func getMinuteFromEnvelope(envelope *envelopes.OriginatorEnvelope) (int32, error) {
 	return utils.MinutesSinceEpoch(envelope.OriginatorTime()), nil
+}
+
+func AddReportLogFields(logger *zap.Logger, report *PayerReport) *zap.Logger {
+	return logger.With(
+		zap.String("report_id", report.ID.String()),
+		zap.Uint64("start_sequence_id", report.StartSequenceID),
+		zap.Uint64("end_sequence_id", report.EndSequenceID),
+		zap.Uint32("originator_node_id", report.OriginatorNodeID),
+	)
 }

--- a/pkg/payerreport/verifier.go
+++ b/pkg/payerreport/verifier.go
@@ -60,11 +60,8 @@ func (p *PayerReportVerifier) IsValidReport(
 	newReport *PayerReport,
 ) (bool, error) {
 	var err error
-	newReportID := newReport.ID
 
-	log := p.log.With(
-		zap.String("new_report_id", newReportID.String()),
-	)
+	log := AddReportLogFields(p.log, newReport)
 
 	if err = validateReportTransition(prevReport, newReport); err != nil {
 		log.Warn("invalid report transition", zap.Error(err))
@@ -85,6 +82,9 @@ func (p *PayerReportVerifier) IsValidReport(
 		if isValidMerkleRoot, err = p.verifyMerkleRoot(ctx, newReport); err != nil {
 			return false, err
 		}
+	}
+	if !isValidMerkleRoot {
+		log.Warn("invalid merkle root")
 	}
 
 	return isValidMerkleRoot, nil

--- a/pkg/payerreport/workers/submitter.go
+++ b/pkg/payerreport/workers/submitter.go
@@ -87,9 +87,11 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 	}
 
 	for _, report := range reports {
-		w.log.Info("submitting report", zap.String("reportID", report.ID.String()))
+		reportLogger := payerreport.AddReportLogFields(w.log, &report.PayerReport)
+
+		reportLogger.Info("submitting report")
 		if err = w.submitReport(report); err != nil {
-			w.log.Error(
+			reportLogger.Error(
 				"failed to submit report",
 				zap.String("report_id", report.ID.String()),
 				zap.Error(err),


### PR DESCRIPTION
### TL;DR

Added structured logging for payer reports to improve observability and debugging.

### What changed?

- Created a new utility function `AddReportLogFields` that adds consistent report-related fields to log entries
- Implemented this function across the codebase in:
  - `PayerReportVerifier.IsValidReport` to add report details to logs
  - `AttestationWorker` to improve error and status logging
  - `SubmitterWorker` to enhance report submission logs
- Added a warning log when a merkle root is invalid
- Added more informative log messages during the attestation process

### How to test?

1. Run the application and trigger payer report operations
2. Check logs to verify they now contain consistent report fields:
   - `report_id`
   - `start_sequence_id`
   - `end_sequence_id`
   - `originator_node_id`
3. Verify that invalid merkle roots and attestation decisions are properly logged

### Why make this change?

Standardized logging with consistent report identifiers makes it easier to:
- Track report processing through the system
- Debug issues by correlating log entries across different components
- Understand the flow of report validation, attestation, and submission
- Quickly identify problematic reports during operations