### PR TITLE
Update GetNodes endpoint

### DIFF
--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -95,13 +95,13 @@ func (s *Service) GetNodes(
 		return nil, status.Errorf(codes.Unavailable, "no nodes available")
 	}
 
-	nodeURLs := make([]string, 0, len(nodes))
+	nodeMap := make(map[uint32]string, len(nodes))
 	for _, node := range nodes {
-		nodeURLs = append(nodeURLs, node.HTTPAddress)
+		nodeMap[node.NodeID] = node.HTTPAddress
 	}
 
 	return &payer_api.GetNodesResponse{
-		Nodes: nodeURLs,
+		Nodes: nodeMap,
 	}, nil
 }
 

--- a/pkg/proto/openapi/xmtpv4/payer_api/payer_api.swagger.json
+++ b/pkg/proto/openapi/xmtpv4/payer_api/payer_api.swagger.json
@@ -535,8 +535,8 @@
       "type": "object",
       "properties": {
         "nodes": {
-          "type": "array",
-          "items": {
+          "type": "object",
+          "additionalProperties": {
             "type": "string"
           }
         }

--- a/pkg/proto/xmtpv4/payer_api/payer_api.pb.go
+++ b/pkg/proto/xmtpv4/payer_api/payer_api.pb.go
@@ -151,7 +151,7 @@ func (*GetNodesRequest) Descriptor() ([]byte, []int) {
 
 type GetNodesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Nodes         []string               `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	Nodes         map[uint32]string      `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -186,7 +186,7 @@ func (*GetNodesResponse) Descriptor() ([]byte, []int) {
 	return file_xmtpv4_payer_api_payer_api_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *GetNodesResponse) GetNodes() []string {
+func (x *GetNodesResponse) GetNodes() map[uint32]string {
 	if x != nil {
 		return x.Nodes
 	}
@@ -202,9 +202,13 @@ const file_xmtpv4_payer_api_payer_api_proto_rawDesc = "" +
 	"\tenvelopes\x18\x01 \x03(\v2%.xmtp.xmtpv4.envelopes.ClientEnvelopeR\tenvelopes\"~\n" +
 	"\x1ePublishClientEnvelopesResponse\x12\\\n" +
 	"\x14originator_envelopes\x18\x01 \x03(\v2).xmtp.xmtpv4.envelopes.OriginatorEnvelopeR\x13originatorEnvelopes\"\x11\n" +
-	"\x0fGetNodesRequest\"(\n" +
-	"\x10GetNodesResponse\x12\x14\n" +
-	"\x05nodes\x18\x01 \x03(\tR\x05nodes2\xc6\x02\n" +
+	"\x0fGetNodesRequest\"\x96\x01\n" +
+	"\x10GetNodesResponse\x12H\n" +
+	"\x05nodes\x18\x01 \x03(\v22.xmtp.xmtpv4.payer_api.GetNodesResponse.NodesEntryR\x05nodes\x1a8\n" +
+	"\n" +
+	"NodesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x012\xc6\x02\n" +
 	"\bPayerApi\x12\xb8\x01\n" +
 	"\x16PublishClientEnvelopes\x124.xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest\x1a5.xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/mls/v2/payer/publish-client-envelopes\x12\x7f\n" +
 	"\bGetNodes\x12&.xmtp.xmtpv4.payer_api.GetNodesRequest\x1a'.xmtp.xmtpv4.payer_api.GetNodesResponse\"\"\x82\xd3\xe4\x93\x02\x1c:\x01*\"\x17/mls/v2/payer/get-nodesB\xce\x01\n" +
@@ -222,27 +226,29 @@ func file_xmtpv4_payer_api_payer_api_proto_rawDescGZIP() []byte {
 	return file_xmtpv4_payer_api_payer_api_proto_rawDescData
 }
 
-var file_xmtpv4_payer_api_payer_api_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_xmtpv4_payer_api_payer_api_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_xmtpv4_payer_api_payer_api_proto_goTypes = []any{
 	(*PublishClientEnvelopesRequest)(nil),  // 0: xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest
 	(*PublishClientEnvelopesResponse)(nil), // 1: xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse
 	(*GetNodesRequest)(nil),                // 2: xmtp.xmtpv4.payer_api.GetNodesRequest
 	(*GetNodesResponse)(nil),               // 3: xmtp.xmtpv4.payer_api.GetNodesResponse
-	(*envelopes.ClientEnvelope)(nil),       // 4: xmtp.xmtpv4.envelopes.ClientEnvelope
-	(*envelopes.OriginatorEnvelope)(nil),   // 5: xmtp.xmtpv4.envelopes.OriginatorEnvelope
+	nil,                                    // 4: xmtp.xmtpv4.payer_api.GetNodesResponse.NodesEntry
+	(*envelopes.ClientEnvelope)(nil),       // 5: xmtp.xmtpv4.envelopes.ClientEnvelope
+	(*envelopes.OriginatorEnvelope)(nil),   // 6: xmtp.xmtpv4.envelopes.OriginatorEnvelope
 }
 var file_xmtpv4_payer_api_payer_api_proto_depIdxs = []int32{
-	4, // 0: xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest.envelopes:type_name -> xmtp.xmtpv4.envelopes.ClientEnvelope
-	5, // 1: xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse.originator_envelopes:type_name -> xmtp.xmtpv4.envelopes.OriginatorEnvelope
-	0, // 2: xmtp.xmtpv4.payer_api.PayerApi.PublishClientEnvelopes:input_type -> xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest
-	2, // 3: xmtp.xmtpv4.payer_api.PayerApi.GetNodes:input_type -> xmtp.xmtpv4.payer_api.GetNodesRequest
-	1, // 4: xmtp.xmtpv4.payer_api.PayerApi.PublishClientEnvelopes:output_type -> xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse
-	3, // 5: xmtp.xmtpv4.payer_api.PayerApi.GetNodes:output_type -> xmtp.xmtpv4.payer_api.GetNodesResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	5, // 0: xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest.envelopes:type_name -> xmtp.xmtpv4.envelopes.ClientEnvelope
+	6, // 1: xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse.originator_envelopes:type_name -> xmtp.xmtpv4.envelopes.OriginatorEnvelope
+	4, // 2: xmtp.xmtpv4.payer_api.GetNodesResponse.nodes:type_name -> xmtp.xmtpv4.payer_api.GetNodesResponse.NodesEntry
+	0, // 3: xmtp.xmtpv4.payer_api.PayerApi.PublishClientEnvelopes:input_type -> xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest
+	2, // 4: xmtp.xmtpv4.payer_api.PayerApi.GetNodes:input_type -> xmtp.xmtpv4.payer_api.GetNodesRequest
+	1, // 5: xmtp.xmtpv4.payer_api.PayerApi.PublishClientEnvelopes:output_type -> xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse
+	3, // 6: xmtp.xmtpv4.payer_api.PayerApi.GetNodes:output_type -> xmtp.xmtpv4.payer_api.GetNodesResponse
+	5, // [5:7] is the sub-list for method output_type
+	3, // [3:5] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_xmtpv4_payer_api_payer_api_proto_init() }
@@ -256,7 +262,7 @@ func file_xmtpv4_payer_api_payer_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_xmtpv4_payer_api_payer_api_proto_rawDesc), len(file_xmtpv4_payer_api_payer_api_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
### Update the `Service.GetNodes` endpoint to return a map of node IDs to HTTP addresses for the GetNodes endpoint
This change updates the `Service.GetNodes` handler to return a map keyed by node ID to HTTP address and regenerates associated protocol and OpenAPI definitions to reflect the new response shape.

- Modify `Service.GetNodes` to build and return `map[uint32]string` keyed by `node.NodeID` instead of a `[]string` of HTTP addresses in [service.go](https://github.com/xmtp/xmtpd/pull/1199/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280)
- Update generated Protobuf to switch `GetNodesResponse.Nodes` from `[]string` to `map[uint32]string` with `NodesEntry` in [payer_api.pb.go](https://github.com/xmtp/xmtpd/pull/1199/files#diff-33dbabd792c0a769ddc7e0fb09eb3d8eddfd04a094ba2f2aa1bd5d06b6d71579)
- Update OpenAPI schema to represent `GetNodesResponse.nodes` as an object with `additionalProperties` in [payer_api.swagger.json](https://github.com/xmtp/xmtpd/pull/1199/files#diff-9146cd0204f36da1a0e743caed8a149ed66f894efc54362b9be6ab129b53a31b)

#### 📍Where to Start
Start with the `Service.GetNodes` handler in [service.go](https://github.com/xmtp/xmtpd/pull/1199/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280).

----

_[Macroscope](https://app.macroscope.com) summarized f176dd9._