### PR TITLE
Sort nodeIDs before packing

### DIFF
--- a/pkg/payerreport/report.go
+++ b/pkg/payerreport/report.go
@@ -155,7 +155,7 @@ func BuildPayerReportID(
 		return nil, errors.New("domain separator is required")
 	}
 
-	nodeIdsHash := utils.PackAndHashNodeIDs(activeNodeIDs)
+	nodeIdsHash := utils.PackSortAndHashNodeIDs(activeNodeIDs)
 
 	packedBytes, err := payerReportMessageHash.Pack(
 		payerReportDigestTypeHash,

--- a/pkg/payerreport/report_test.go
+++ b/pkg/payerreport/report_test.go
@@ -91,7 +91,7 @@ func TestGetDigest(t *testing.T) {
 		"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 	)
 	nodeIDs := []uint32{100, 200, 300, 400, 500}
-	nodeIDsHash := utils.PackAndHashNodeIDs(nodeIDs)
+	nodeIDsHash := utils.PackSortAndHashNodeIDs(nodeIDs)
 	require.Equal(t, nodeIDsHash, common.BytesToHash(expectedNodeIDsHash))
 
 	originatorNodeID := uint32(1)

--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/binary"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -57,7 +58,13 @@ func encodePackedUint32Slice(input []uint32) []byte {
 	return result
 }
 
-func PackAndHashNodeIDs(nodeIDs []uint32) common.Hash {
+func PackSortAndHashNodeIDs(nodeIDs []uint32) common.Hash {
+	if !slices.IsSorted(nodeIDs) {
+		sortedNodeIDs := slices.Clone(nodeIDs)
+		slices.Sort(sortedNodeIDs)
+		nodeIDs = sortedNodeIDs
+	}
+
 	packed := encodePackedUint32Slice(nodeIDs)
 
 	return common.BytesToHash(ethcrypto.Keccak256(packed))


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Make payer report ID generation deterministic by sorting node IDs before packing and hashing in `payerreport.BuildPayerReportID`
Introduce ordered hashing for node IDs and update call sites to use the new utility.

- Add `utils.PackSortAndHashNodeIDs` to sort node IDs before packing and hashing in [hash.go](https://github.com/xmtp/xmtpd/pull/1202/files#diff-7ffd86f59f106bf42eeed272b78afd1d070f392bd375f058aae45d35ee079609)
- Switch `payerreport.BuildPayerReportID` to `utils.PackSortAndHashNodeIDs` in [report.go](https://github.com/xmtp/xmtpd/pull/1202/files#diff-dd0050a86ebf68aab034bddc5e7546e74fa048e3545b5b5cafa7b78f2814e124)
- Update `payerreport.TestGetDigest` to use `utils.PackSortAndHashNodeIDs` in [report_test.go](https://github.com/xmtp/xmtpd/pull/1202/files#diff-759d8a8446dd6b48ea9222ba4877142da7fca28760bec3245f4245f441e267fe)

#### 📍Where to Start
Start with the `utils.PackSortAndHashNodeIDs` implementation in [hash.go](https://github.com/xmtp/xmtpd/pull/1202/files#diff-7ffd86f59f106bf42eeed272b78afd1d070f392bd375f058aae45d35ee079609), then review its usage in `payerreport.BuildPayerReportID` in [report.go](https://github.com/xmtp/xmtpd/pull/1202/files#diff-dd0050a86ebf68aab034bddc5e7546e74fa048e3545b5b5cafa7b78f2814e124).

----

_[Macroscope](https://app.macroscope.com) summarized bd85fbd._
<!-- Macroscope's pull request summary ends here -->