### PR TITLE
Start sequence ID at 1

### DIFF
--- a/pkg/payerreport/constants.go
+++ b/pkg/payerreport/constants.go
@@ -11,3 +11,5 @@ import "github.com/ethereum/go-ethereum/common"
 var payerReportDigestTypeHash = common.HexToHash(
 	"3737a2cced99bb28fc5aede45aa81d3ce0aa9137c5f417641835d0d71d303346",
 )
+
+const MinimumSequenceID int64 = 1

--- a/pkg/payerreport/generator_test.go
+++ b/pkg/payerreport/generator_test.go
@@ -98,7 +98,7 @@ func TestFirstReport(t *testing.T) {
 
 	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
 		OriginatorID:            uint32(originatorID),
-		LastReportEndSequenceID: 0,
+		LastReportEndSequenceID: uint64(MinimumSequenceID),
 	})
 	require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestReportWithMultiplePayers(t *testing.T) {
 
 	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
 		OriginatorID:            uint32(originatorID),
-		LastReportEndSequenceID: 0,
+		LastReportEndSequenceID: uint64(MinimumSequenceID),
 	})
 	require.NoError(t, err)
 
@@ -138,13 +138,13 @@ func TestReportWithNoMessages(t *testing.T) {
 
 	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
 		OriginatorID:            uint32(originatorID),
-		LastReportEndSequenceID: 0,
+		LastReportEndSequenceID: uint64(MinimumSequenceID),
 	})
 	require.NoError(t, err)
 
 	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
-	require.Equal(t, uint64(0), report.StartSequenceID)
-	require.Equal(t, uint64(0), report.EndSequenceID)
+	require.Equal(t, uint64(MinimumSequenceID), report.StartSequenceID)
+	require.Equal(t, uint64(MinimumSequenceID), report.EndSequenceID)
 	require.Equal(t, 0, len(report.Payers))
 }
 
@@ -179,12 +179,12 @@ func TestSecondReport(t *testing.T) {
 
 	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
 		OriginatorID:            uint32(originatorID),
-		LastReportEndSequenceID: 0,
+		LastReportEndSequenceID: uint64(MinimumSequenceID),
 	})
 	require.NoError(t, err)
 
 	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
-	require.Equal(t, uint64(0), report.StartSequenceID)
+	require.Equal(t, uint64(MinimumSequenceID), report.StartSequenceID)
 	require.Equal(t, uint64(2), report.EndSequenceID)
 	require.Equal(t, currency.PicoDollar(200), report.Payers[payerAddress])
 
@@ -216,12 +216,12 @@ func TestReportWithNoEnvelopesFromOriginator(t *testing.T) {
 
 	report, err := generator.GenerateReport(context.Background(), PayerReportGenerationParams{
 		OriginatorID:            uint32(originatorID),
-		LastReportEndSequenceID: 0,
+		LastReportEndSequenceID: uint64(MinimumSequenceID),
 	})
 	require.NoError(t, err)
 
 	require.Equal(t, uint32(originatorID), report.OriginatorNodeID)
-	require.Equal(t, uint64(0), report.StartSequenceID)
-	require.Equal(t, uint64(0), report.EndSequenceID)
+	require.Equal(t, uint64(MinimumSequenceID), report.StartSequenceID)
+	require.Equal(t, uint64(MinimumSequenceID), report.EndSequenceID)
 	require.Equal(t, 0, len(report.Payers))
 }

--- a/pkg/payerreport/verifier.go
+++ b/pkg/payerreport/verifier.go
@@ -99,9 +99,9 @@ func (p *PayerReportVerifier) verifyMerkleRoot(
 	if err != nil {
 		return false, err
 	}
-	// If the start sequence ID is 0, it is the first report and we should start from minute 0 since there are no preceding reports
+	// If the start sequence ID is 1, it is the first report and we should start from minute 0 since there are no preceding reports
 	var startMinute int32
-	if startEnvelope.OriginatorSequenceID() == 0 {
+	if startEnvelope.OriginatorSequenceID() == uint64(MinimumSequenceID) {
 		startMinute = 0
 	} else {
 		startMinute, err = getMinuteFromEnvelope(startEnvelope)
@@ -249,7 +249,7 @@ func (p *PayerReportVerifier) getStartAndEndMessages(
 func validateReportTransition(prevReport *PayerReport, newReport *PayerReport) error {
 	// Special validations for the first report
 	if prevReport == nil {
-		if newReport.StartSequenceID != 0 {
+		if newReport.StartSequenceID != uint64(MinimumSequenceID) {
 			return ErrInvalidReportStart
 		}
 
@@ -273,6 +273,10 @@ func validateReportTransition(prevReport *PayerReport, newReport *PayerReport) e
 // Validates that the report is well-formed and doesn't have any logical
 // errors or invalid fields that can be detected without further processing.
 func validateReportStructure(report *PayerReport) error {
+	if report.StartSequenceID < uint64(MinimumSequenceID) {
+		return ErrInvalidSequenceID
+	}
+
 	// The Originator Node ID is required
 	if report.OriginatorNodeID == 0 {
 		return ErrInvalidOriginatorID

--- a/pkg/payerreport/workers/attestation.go
+++ b/pkg/payerreport/workers/attestation.go
@@ -127,7 +127,7 @@ func (w *AttestationWorker) attestReport(report *payerreport.PayerReportWithStat
 	log := payerreport.AddReportLogFields(w.log, &report.PayerReport)
 	var prevReport *payerreport.PayerReport
 	var err error
-	if report.StartSequenceID > 0 {
+	if report.StartSequenceID > uint64(payerreport.MinimumSequenceID) {
 		var prevReportWithStatus *payerreport.PayerReportWithStatus
 		if prevReportWithStatus, err = w.getPreviousReport(report); err != nil {
 			return err

--- a/pkg/payerreport/workers/attestation_test.go
+++ b/pkg/payerreport/workers/attestation_test.go
@@ -62,7 +62,7 @@ func TestFindReport(t *testing.T) {
 
 	report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
 		OriginatorNodeID: 1,
-		StartSequenceID:  1,
+		StartSequenceID:  uint64(payerreport.MinimumSequenceID),
 		EndSequenceID:    10,
 		DomainSeparator:  domainSeparator,
 		NodeIDs:          []uint32{1},
@@ -93,7 +93,7 @@ func TestAttestFirstReport(t *testing.T) {
 
 	report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
 		OriginatorNodeID: 1,
-		StartSequenceID:  0,
+		StartSequenceID:  uint64(payerreport.MinimumSequenceID),
 		EndSequenceID:    10,
 		NodeIDs:          []uint32{1},
 		DomainSeparator:  domainSeparator,

--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -122,7 +122,7 @@ func (w *GeneratorWorker) maybeGenerateReport(nodeID uint32) error {
 		return nil
 	}
 
-	existingReportEndSequenceID := uint64(0)
+	existingReportEndSequenceID := uint64(payerreport.MinimumSequenceID)
 	if lastSubmittedReport != nil {
 		existingReportEndSequenceID = lastSubmittedReport.EndSequenceID
 	}

--- a/pkg/payerreport/workers/integration_test.go
+++ b/pkg/payerreport/workers/integration_test.go
@@ -335,7 +335,7 @@ func TestValidSignature(t *testing.T) {
 
 	payerReport, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
 		OriginatorNodeID:    100,
-		StartSequenceID:     0,
+		StartSequenceID:     uint64(payerreport.MinimumSequenceID),
 		EndSequenceID:       1,
 		EndMinuteSinceEpoch: 10,
 		Payers:              map[common.Address]currency.PicoDollar{},
@@ -513,7 +513,7 @@ func TestCanGenerateAndAttestReport(t *testing.T) {
 	require.Len(t, fetchedReports, 1)
 	fetchedReportID := fetchedReports[0].ID
 
-	report, err := scaffold.reportsManager.GetReport(t.Context(), scaffold.nodeIDs[0], 0)
+	report, err := scaffold.reportsManager.GetReport(t.Context(), scaffold.nodeIDs[0], 1)
 	require.NoError(t, err)
 	require.Equal(
 		t,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set payer report sequence ID minimum to 1 and enforce validation across generator, verifier, and workers
Introduce a canonical `MinimumSequenceID` constant and update report generation, verification, and worker logic to treat 1 as the first valid sequence ID. Key validations now reject sequence IDs less than 1 and tests are updated accordingly.

- Add `MinimumSequenceID = 1` in [constants.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-dc9fb2ee5f24389ad842bc5154e6b89d9d96f7d9d2ed1effb5422091e64bfcbd)
- Update `payerreport.PayerReportGenerator.GenerateReport` and `payerreport.PayerReportGenerator.getStartMinute` to validate `LastReportEndSequenceID >= MinimumSequenceID`, return `ErrInvalidSequenceID` for values < 1, and treat 1 as initial in [generator.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-e3acc56c9fb8afec4da54172140fe65ec94a792aaba7518de67e9baf3f3f52df)
- Enforce structure and transition checks for start sequence ID >= 1 and treat 1 as first report in [verifier.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8)
- Adjust worker logic to handle first reports at sequence ID 1 in [workers/attestation.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-e878e7214f8d54fd2250fb682976303e3753543783c7e7b141e6b0eab479a537) and [workers/generator.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e)
- Update tests to use `MinimumSequenceID` and add invalid start sequence coverage in [generator_test.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-944444e35edd502644861756f8711fa7ae1262b6cf54d1938a0f857f6ba66c5a), [verifier_test.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-dfc507ba90802b88d155b704710e620af4278b8f3ecb42df4356a4a4f73f696d), and [workers/integration_test.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-6a4fd18b8b7d7f7b8f3edaecda594c6292ed4e3ad093b24d72ccd14b80f79e5c)

#### 📍Where to Start
Start with `payerreport.PayerReportGenerator.GenerateReport` in [generator.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-e3acc56c9fb8afec4da54172140fe65ec94a792aaba7518de67e9baf3f3f52df), then review validation paths in `validateReportStructure` and `validateReportTransition` in [verifier.go](https://github.com/xmtp/xmtpd/pull/1204/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8).

----

_[Macroscope](https://app.macroscope.com) summarized 5a2d77e._
<!-- Macroscope's pull request summary ends here -->