### PR TITLE
Fix ErrMessageAtStartSequenceIDNotFound during report generation

### DIFF
--- a/pkg/payerreport/generator.go
+++ b/pkg/payerreport/generator.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type payerMap map[common.Address]currency.PicoDollar
+type PayerMap map[common.Address]currency.PicoDollar
 
 type PayerReportGenerator struct {
 	log             *zap.Logger
@@ -141,7 +141,7 @@ func (p *PayerReportGenerator) getEndMinute(
 	return result.MinutesSinceEpoch, result.MaxSequenceID, nil
 }
 
-func buildPayersMap(rows []queries.BuildPayerReportRow) payerMap {
+func buildPayersMap(rows []queries.BuildPayerReportRow) PayerMap {
 	payersMap := make(map[common.Address]currency.PicoDollar)
 	for _, row := range rows {
 		payersMap[common.HexToAddress(row.PayerAddress)] = currency.PicoDollar(

--- a/pkg/payerreport/merkle.go
+++ b/pkg/payerreport/merkle.go
@@ -22,7 +22,7 @@ var payerLeaf = abi.Arguments{
 	},
 }
 
-func generateMerkleTree(payers payerMap) (*merkle.MerkleTree, error) {
+func generateMerkleTree(payers PayerMap) (*merkle.MerkleTree, error) {
 	leaves := make([]merkle.Leaf, 0, len(payers))
 	var (
 		leaf []byte

--- a/pkg/payerreport/merkle_test.go
+++ b/pkg/payerreport/merkle_test.go
@@ -1,7 +1,9 @@
-package payerreport
+package payerreport_test
 
 import (
 	"testing"
+
+	"github.com/xmtp/xmtpd/pkg/payerreport"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -10,12 +12,12 @@ import (
 func TestBuildMerkle(t *testing.T) {
 	cases := []struct {
 		name      string
-		payerMap  payerMap
+		payerMap  payerreport.PayerMap
 		expectErr bool
 	}{
 		{
 			name: "success",
-			payerMap: payerMap{
+			payerMap: payerreport.PayerMap{
 				common.HexToAddress("0x1"): 100,
 				common.HexToAddress("0x2"): 200,
 			},
@@ -23,14 +25,14 @@ func TestBuildMerkle(t *testing.T) {
 		},
 		{
 			name: "negative fee",
-			payerMap: payerMap{
+			payerMap: payerreport.PayerMap{
 				common.HexToAddress("0x1"): -100,
 			},
 			expectErr: true,
 		},
 		{
 			name: "zero fee",
-			payerMap: payerMap{
+			payerMap: payerreport.PayerMap{
 				common.HexToAddress("0x1"): 0,
 			},
 			expectErr: false,
@@ -39,7 +41,7 @@ func TestBuildMerkle(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := generateMerkleTree(c.payerMap)
+			_, err := payerreport.GenerateMerkleTreeTestBinding(c.payerMap)
 			if c.expectErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/payerreport/report_test.go
+++ b/pkg/payerreport/report_test.go
@@ -1,8 +1,10 @@
-package payerreport
+package payerreport_test
 
 import (
 	"crypto/rand"
 	"testing"
+
+	"github.com/xmtp/xmtpd/pkg/payerreport"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -22,15 +24,15 @@ func randomBytes32() [32]byte {
 func TestBuildPayerReport(t *testing.T) {
 	inputs := []struct {
 		name        string
-		params      BuildPayerReportParams
+		params      payerreport.BuildPayerReportParams
 		expectErr   bool
 		errContains string
 	}{
 		{
 			name: "full report",
-			params: BuildPayerReportParams{
+			params: payerreport.BuildPayerReportParams{
 				OriginatorNodeID:    1,
-				StartSequenceID:     1,
+				StartSequenceID:     0,
 				EndSequenceID:       10,
 				EndMinuteSinceEpoch: 10,
 				Payers: map[common.Address]currency.PicoDollar{
@@ -43,9 +45,9 @@ func TestBuildPayerReport(t *testing.T) {
 		},
 		{
 			name: "empty payers",
-			params: BuildPayerReportParams{
+			params: payerreport.BuildPayerReportParams{
 				OriginatorNodeID: 1,
-				StartSequenceID:  1,
+				StartSequenceID:  0,
 				EndSequenceID:    10,
 				DomainSeparator:  testutils.RandomDomainSeparator(),
 			},
@@ -53,9 +55,9 @@ func TestBuildPayerReport(t *testing.T) {
 		},
 		{
 			name: "empty domain separator",
-			params: BuildPayerReportParams{
+			params: payerreport.BuildPayerReportParams{
 				OriginatorNodeID: 1,
-				StartSequenceID:  1,
+				StartSequenceID:  0,
 				EndSequenceID:    10,
 			},
 			expectErr:   true,
@@ -65,7 +67,7 @@ func TestBuildPayerReport(t *testing.T) {
 
 	for _, input := range inputs {
 		t.Run(input.name, func(t *testing.T) {
-			_, err := BuildPayerReport(input.params)
+			_, err := payerreport.BuildPayerReport(input.params)
 			if input.expectErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), input.errContains)
@@ -102,7 +104,7 @@ func TestGetDigest(t *testing.T) {
 		"dbc3c9c77bfb8c8656e87b666d2b06300835634ecfb091e1925d30614ceb1e43",
 	)
 
-	builtID, err := BuildPayerReportID(
+	builtID, err := payerreport.BuildPayerReportID(
 		originatorNodeID,
 		startSequenceID,
 		endSequenceID,
@@ -112,7 +114,7 @@ func TestGetDigest(t *testing.T) {
 		domainSeparator,
 	)
 	require.NoError(t, err)
-	require.Equal(t, *builtID, ReportID(expectedDigest))
+	require.Equal(t, *builtID, payerreport.ReportID(expectedDigest))
 }
 
 func TestNodeOrderPacksToSameHash(t *testing.T) {

--- a/pkg/payerreport/testbindings_test.go
+++ b/pkg/payerreport/testbindings_test.go
@@ -1,0 +1,15 @@
+package payerreport
+
+import "github.com/xmtp/xmtpd/pkg/merkle"
+
+func GenerateMerkleTreeTestBinding(payerMap PayerMap) (*merkle.MerkleTree, error) {
+	return generateMerkleTree(payerMap)
+}
+
+func ValidateReportTransitionTestBinding(prevReport *PayerReport, newReport *PayerReport) error {
+	return validateReportTransition(prevReport, newReport)
+}
+
+func ValidateReportStructureTestBinding(report *PayerReport) error {
+	return validateReportStructure(report)
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix report verification to avoid `ErrMessageAtStartSequenceIDNotFound` by treating `StartSequenceID == 0` as the first report in `payerreport.PayerReportVerifier`
Update report verification to handle first reports without a start envelope and expose types required by tests.

- Modify `payerreport.PayerReportVerifier.getStartAndEndMessages` to return a nil start envelope when `startSequenceID == 0`, avoiding a lookup and error in [verifier.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8)
- Adjust `payerreport.PayerReportVerifier.verifyMerkleRoot` to set `startMinute = 0` when the start envelope is nil in [verifier.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8)
- Export `payerreport.PayerMap` and update call sites in [generator.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-e3acc56c9fb8afec4da54172140fe65ec94a792aaba7518de67e9baf3f3f52df) and [merkle.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-601d519c89a97b0117efe452112268b1d79f0cf1a6409527ceb73b6c8387b2a8)
- Add test-only bindings `payerreport.GenerateMerkleTreeTestBinding`, `payerreport.ValidateReportTransitionTestBinding`, and `payerreport.ValidateReportStructureTestBinding` in [testbindings_test.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-ecd59031a0da04429710947c0febef29e64a8348c0d2c0eed88429414970bf54)
- Update tests to use the external package style and new exported types/functions across [generator_test.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-944444e35edd502644861756f8711fa7ae1262b6cf54d1938a0f857f6ba66c5a), [merkle_test.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-103b86fc906aa3641bb42cb37c066089ba4365805fdec8abed8a6a42b2415a38), [report_test.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-759d8a8446dd6b48ea9222ba4877142da7fca28760bec3245f4245f441e267fe), [store_test.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-94a7081fd27e86f6a67a835f2155e7be32c60dc0e1741335042bc89c206895ef), and [verifier_test.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-dfc507ba90802b88d155b704710e620af4278b8f3ecb42df4356a4a4f73f696d)

#### 📍Where to Start
Start with `payerreport.PayerReportVerifier.getStartAndEndMessages` and `payerreport.PayerReportVerifier.verifyMerkleRoot` in [verifier.go](https://github.com/xmtp/xmtpd/pull/1206/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8).

----

_[Macroscope](https://app.macroscope.com) summarized f1bc7dd._
<!-- Macroscope's pull request summary ends here -->