### PR TITLE
Sort signatures before submitting

### DIFF
--- a/pkg/blockchain/client.go
+++ b/pkg/blockchain/client.go
@@ -124,6 +124,7 @@ func ExecuteTransaction(
 
 	dryRunTx, err := txFunc(opts)
 	if err != nil {
+		logger.Error("failed to simulate tx", zap.Error(err))
 		return NewBlockchainError(fmt.Errorf("failed to simulate tx (NoSend=true): %w", err))
 	}
 


### PR DESCRIPTION
## tl;dr

- Sort signatures before submitting to ensure payer reports validate in the contract
- Add more logging on execution errors