### PR TITLE
Trace failed transactions

### DIFF
--- a/pkg/blockchain/app_chain_admin.go
+++ b/pkg/blockchain/app_chain_admin.go
@@ -2,7 +2,6 @@ package blockchain
 
 import (
 	"context"
-	"strings"
 
 	acg "github.com/xmtp/xmtpd/pkg/abi/appchaingateway"
 
@@ -130,7 +129,7 @@ func (a appChainAdmin) UpdateIdentityUpdateBootstrapper(
 		},
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "0xa88ee577") {
+		if err.IsNoChange() {
 			a.logger.Info("No update needed")
 			return nil
 		}
@@ -174,7 +173,7 @@ func (a appChainAdmin) UpdateGroupMessageBootstrapper(
 		},
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "0xa88ee577") {
+		if err.IsNoChange() {
 			a.logger.Info("No update needed")
 			return nil
 		}

--- a/pkg/blockchain/app_chain_admin_test.go
+++ b/pkg/blockchain/app_chain_admin_test.go
@@ -329,11 +329,11 @@ func TestPayloadSizeParams_ReadDefault_WriteThenRead(t *testing.T) {
 
 				switch tc.name {
 				case "group/max":
-					require.ErrorContains(t, err, "0x1d8e7a4a") // invalid max
+					require.ErrorContains(t, err, "InvalidMaxPayloadSize()")
 				case "group/min":
 					require.NoError(t, err)
 				case "identity/max":
-					require.ErrorContains(t, err, "0x1d8e7a4a")
+					require.ErrorContains(t, err, "InvalidMaxPayloadSize()")
 				case "identity/min":
 					require.NoError(t, err)
 				}

--- a/pkg/blockchain/client.go
+++ b/pkg/blockchain/client.go
@@ -2,23 +2,28 @@ package blockchain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
 	"net/http"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
-
 	"github.com/gorilla/websocket"
 	"github.com/xmtp/xmtpd/pkg/metrics"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"go.uber.org/zap"
+)
+
+var (
+	ErrTxFailed        = fmt.Errorf("transaction failed")
+	ErrTxFailedNoError = fmt.Errorf("transaction failed but no error found")
 )
 
 type WebsocketClientOption func(*websocketClientConfig)
@@ -79,11 +84,11 @@ func NewRPCClient(ctx context.Context, rpcURL string) (*ethclient.Client, error)
 }
 
 // ExecuteTransaction is a helper function that:
-// - estimates the gas required for the transaction
-// - checks if the sender has enough balance to cover the gas cost
-// - executes a transaction
-// - waits for it to be mined
-// - processes the event logs
+// - checks if the sender has enough balance.
+// - executes a transaction.
+// - waits for it to be mined.
+// - if the transaction fails, it tries to get the error code from the transaction receipt.
+// - processes the event logs.
 func ExecuteTransaction(
 	ctx context.Context,
 	signer TransactionSigner,
@@ -99,7 +104,6 @@ func ExecuteTransaction(
 
 	from := signer.FromAddress()
 
-	// Step 1: Check balance before sending.
 	balance, err := client.BalanceAt(ctx, from, nil)
 	if err != nil {
 		return NewBlockchainError(fmt.Errorf("failed to check balance: %w", err))
@@ -114,82 +118,48 @@ func ExecuteTransaction(
 		zap.String("balance", balance.String()),
 	)
 
-	// Step 2: Prepare dry-run tx for gas estimation.
 	opts := &bind.TransactOpts{
-		Context: ctx,
-		From:    from,
-		Signer:  signer.SignerFunc(),
-		NoSend:  true,
+		Context:  ctx,
+		From:     from,
+		Signer:   signer.SignerFunc(),
+		GasLimit: 300_000,
 	}
 
-	dryRunTx, err := txFunc(opts)
-	if err != nil {
-		logger.Error("failed to simulate tx", zap.Error(err))
-		return NewBlockchainError(fmt.Errorf("failed to simulate tx (NoSend=true): %w", err))
-	}
-
-	// Step 3: Estimate gas using ethclient.EstimateGas.
-	msg := ethereum.CallMsg{
-		From:  from,
-		To:    dryRunTx.To(),
-		Data:  dryRunTx.Data(),
-		Value: dryRunTx.Value(),
-	}
-
-	// Step 4: Fallback for GasPrice.
-	gasPrice := dryRunTx.GasPrice()
-	if gasPrice == nil {
-		gasPrice, err = client.SuggestGasPrice(ctx)
-		if err != nil {
-			return NewBlockchainError(fmt.Errorf("failed to get gas price: %w", err))
-		}
-	}
-
-	estimatedGas, err := client.EstimateGas(ctx, msg)
-	if err != nil {
-		return NewBlockchainError(fmt.Errorf("gas estimation failed: %w", err))
-	}
-
-	logger.Debug(
-		"Gas estimation",
-		zap.String("address", from.Hex()),
-		zap.Uint64("gas", estimatedGas),
-	)
-
-	// Step 5: Check for balance sufficiency.
-	required := new(big.Int).Mul(big.NewInt(int64(estimatedGas)), gasPrice)
-	if balance.Cmp(required) < 0 {
-		return NewBlockchainError(fmt.Errorf(
-			"insufficient funds: need %s, have %s",
-			required.String(),
-			balance.String(),
-		))
-	}
-
-	// Step 6: Send the real tx.
-	opts.NoSend = false
-	opts.GasLimit = estimatedGas
-	opts.GasPrice = gasPrice
-
+	// transactions that are not simulated will always return a tx.Hash().
+	// The error will be returned if the transaction fails to be mined.
 	tx, err := txFunc(opts)
 	if err != nil {
 		return NewBlockchainError(err)
 	}
 
-	// Step 7: Wait for receipt.
 	receipt, err := WaitForTransaction(
 		ctx,
 		logger,
 		client,
-		10*time.Second,
+		60*time.Second,
 		250*time.Millisecond,
 		tx.Hash(),
 	)
 	if err != nil {
-		return NewBlockchainError(err)
+		switch {
+		case errors.Is(err, ErrTxFailed):
+			code, err := tryGetTxError(
+				ctx,
+				client,
+				tx.Hash(),
+				60*time.Second,
+				250*time.Millisecond,
+			)
+			if err != nil {
+				return NewBlockchainError(err)
+			}
+			return NewBlockchainError(errors.New(code))
+
+		default:
+			return NewBlockchainError(err)
+		}
 	}
 
-	// Step 8: Parse and handle logs.
 	for _, log := range receipt.Logs {
 		event, err := eventParser(log)
 		if err != nil {
@@ -210,12 +180,9 @@ func WaitForTransaction(
 	pollSleep time.Duration,
 	hash common.Hash,
 ) (*types.Receipt, error) {
-	// Enforce the timeout with a context so that slow requests get aborted if the function has
-	// run out of time
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
 	defer cancel()
 
-	// Ticker to track polling interval
 	ticker := time.NewTicker(pollSleep)
 	defer ticker.Stop()
 
@@ -226,20 +193,75 @@ func WaitForTransaction(
 
 	for {
 		receipt, err := client.TransactionReceipt(ctx, hash)
-		if err != nil {
-			if err.Error() != "not found" {
-				logger.Error("waiting for transaction", zap.String("hash", hash.String()))
-			}
-		} else if receipt != nil {
+
+		switch {
+		case err == nil && receipt != nil:
 			if receipt.Status == types.ReceiptStatusSuccessful {
 				return receipt, nil
 			}
-			return nil, fmt.Errorf("transaction failed")
+
+			if receipt.Status == types.ReceiptStatusFailed {
+				return receipt, ErrTxFailed
+			}
+
+		case err != nil:
+			if errors.Is(err, ethereum.NotFound) {
+				logger.Debug("waiting for transaction", zap.String("hash", hash.String()))
+			} else {
+				return nil, ErrTxFailed
+			}
 		}
 
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("timed out")
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+func tryGetTxError(
+	ctx context.Context,
+	client *ethclient.Client,
+	hash common.Hash,
+	timeout time.Duration,
+	pollSleep time.Duration,
+) (string, error) {
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
+	defer cancel()
+
+	ticker := time.NewTicker(pollSleep)
+	defer ticker.Stop()
+
+	now := time.Now()
+	defer func() {
+		metrics.EmitBlockchainWaitForTransaction(time.Since(now).Seconds())
+	}()
+
+	type replayTransactionResult struct {
+		Output string `json:"output"`
+	}
+
+	for {
+		var result replayTransactionResult
+
+		err := client.Client().
+			CallContext(ctx, &result, "trace_replayTransaction", hash, []string{"trace"})
+
+		switch {
+		case err == nil && result.Output != "":
+			return result.Output, nil
+
+		case err != nil:
+			if err.Error() != "transaction not found" {
+				return "", err
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("timed out")
 		case <-ticker.C:
 			continue
 		}

--- a/pkg/blockchain/client.go
+++ b/pkg/blockchain/client.go
@@ -239,15 +239,22 @@ func tryGetTxError(
 		metrics.EmitBlockchainWaitForTransaction(time.Since(now).Seconds())
 	}()
 
-	type replayTransactionResult struct {
+	type traceTransactionResult struct {
 		Output string `json:"output"`
 	}
 
+	// https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtracetransaction
+	type traceConfig struct {
+		Tracer string `json:"tracer"`
+	}
+
+	tracerCfg := traceConfig{Tracer: "callTracer"}
+
 	for {
-		var result replayTransactionResult
+		var result traceTransactionResult
 
 		err := client.Client().
-			CallContext(ctx, &result, "trace_replayTransaction", hash, []string{"trace"})
+			CallContext(ctx, &result, "debug_traceTransaction", hash, tracerCfg)
 
 		switch {
 		case err == nil && result.Output != "":

--- a/pkg/blockchain/errors.go
+++ b/pkg/blockchain/errors.go
@@ -136,7 +136,7 @@ func (e BlockchainError) Error() string {
 	case ErrCodeNotFound.Error(), ErrCodeNotInDic.Error(), ErrCompileRegex.Error():
 		return e.err.Error()
 	default:
-		return fmt.Sprintf("%s, original error: %s", e.msg, e.err.Error())
+		return e.msg
 	}
 }
 

--- a/pkg/blockchain/node_registry_admin.go
+++ b/pkg/blockchain/node_registry_admin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -250,9 +249,7 @@ func (n *nodeRegistryAdmin) SetMaxCanonical(
 		},
 	)
 	if err != nil {
-		// 0xa88ee577 is the error code for NoChange
-		// cast sig "NoChange()"
-		if strings.Contains(err.Error(), "0xa88ee577") {
+		if err.IsNoChange() {
 			n.logger.Info("No update needed",
 				zap.Uint8("limit", limit),
 			)

--- a/pkg/blockchain/node_registry_admin_test.go
+++ b/pkg/blockchain/node_registry_admin_test.go
@@ -96,6 +96,5 @@ func TestSetMaxCanonical(t *testing.T) {
 
 	// do it again to make sure the command does not fail with NoChange
 	err = registry.SetMaxCanonical(ctx, 16)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "NoChange()")
+	require.NoError(t, err)
 }

--- a/pkg/blockchain/node_registry_admin_test.go
+++ b/pkg/blockchain/node_registry_admin_test.go
@@ -96,5 +96,6 @@ func TestSetMaxCanonical(t *testing.T) {
 
 	// do it again to make sure the command does not fail with NoChange
 	err = registry.SetMaxCanonical(ctx, 16)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NoChange()")
 }

--- a/pkg/blockchain/settlement_chain_admin_test.go
+++ b/pkg/blockchain/settlement_chain_admin_test.go
@@ -406,7 +406,7 @@ func TestPayerRegistry_Uint96Params_ReadDefault_WriteThenRead(t *testing.T) {
 
 				switch tc.name {
 				case "minimumDeposit":
-					require.ErrorContains(t, err, "0x5bc1c4a0") // invalid min
+					require.ErrorContains(t, err, "ZeroMinimumDeposit()")
 				}
 			})
 		})
@@ -483,5 +483,5 @@ func TestPayerReportManager_ProtocolFeeAbove100Perc(t *testing.T) {
 		),
 	)
 	err := scAdmin.UpdatePayerReportManagerProtocolFeeRate(ctx)
-	require.ErrorContains(t, err, "0x82eeb3b2")
+	require.ErrorContains(t, err, "InvalidProtocolFeeRate()")
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Trace failed blockchain transactions and return revert output in `pkg/blockchain/client.ExecuteTransaction` with a fixed gas limit of 5,000,000 and a 20s wait timeout
- Add sentinel errors `ErrTxFailed`, `ErrTxFailedNoError`, `ErrTxNotFound`, and `ErrTxGenesisNotTraceable` in [client.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-10bd63d42f0476b000d46c9ab0629a13fcd0d38283206ae0202a52992073d990)
- Modify `pkg/blockchain/client.ExecuteTransaction` to remove gas estimation and NoSend flow, set `GasLimit` to 5,000,000, extend wait timeout to 20s, and on mined failure trace via `debug_traceTransaction` to return revert output as a `BlockchainError` in [client.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-10bd63d42f0476b000d46c9ab0629a13fcd0d38283206ae0202a52992073d990)
- Update `pkg/blockchain/client.WaitForTransaction` to return `ErrTxFailed` on failed receipts, treat `ethereum.NotFound` as a wait condition, and adjust polling behavior in [client.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-10bd63d42f0476b000d46c9ab0629a13fcd0d38283206ae0202a52992073d990)
- Add `traceTransactionOutput` helper to poll `debug_traceTransaction` with `callTracer` and return the `output` field in [client.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-10bd63d42f0476b000d46c9ab0629a13fcd0d38283206ae0202a52992073d990)
- Change `BlockchainError.Error` to return only the high-level message in [errors.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-ab170895982dd4ada75b480013cd68a3cffbb7b1d8178f2bc1151756b425dcca)
- Update tests to assert human-readable custom error names instead of hex selectors in [app_chain_admin_test.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-cfbd03e3f0b21c4c9203231c2e32273d030bf1bde209cba78b92d9fdabd77035), [node_registry_admin_test.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-460421fcbac96a468f985dcdf6df04844c222d02dc7ca6c5acc965fe956231cc), and [settlement_chain_admin_test.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-02123af6be6b55e9272ee20dc0166941b0baa39322499a9bd2541137a8e0212d)

#### 📍Where to Start
Start with the transaction flow in `ExecuteTransaction` in [client.go](https://github.com/xmtp/xmtpd/pull/1211/files#diff-10bd63d42f0476b000d46c9ab0629a13fcd0d38283206ae0202a52992073d990), then review `WaitForTransaction` and `traceTransactionOutput` in the same file.



#### Changes since #1211 opened

- Standardized error handling across blockchain admin components by replacing string-based error detection with IsNoChange() method calls [c5a26ff]
- Refactored control flow in blockchain client transaction handling functions by replacing switch statements with explicit conditional checks [c5a26ff]
- Updated test expectations to align with standardized no-change error handling [c5a26ff]
----

_[Macroscope](https://app.macroscope.com) summarized c5a26ff._
<!-- Macroscope's pull request summary ends here -->