### PR TITLE
Fix semantic merge conflict

### DIFF
--- a/pkg/payerreport/store_test.go
+++ b/pkg/payerreport/store_test.go
@@ -1006,7 +1006,7 @@ func TestCreateAttestationConcurrency(t *testing.T) {
 		ActiveNodeIDs:    []uint32{4},
 	}
 
-	err := store.StoreReport(ctx, &report)
+	_, err := store.StoreReport(ctx, &report)
 	require.NoError(t, err)
 
 	const numWorkers = 10


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix merge drift by updating `pkg/payerreport/store_test.go` test `TestCreateAttestationConcurrency` to call `store.StoreReport` with a two-value return, discarding the first result and capturing the error
Update the unit test to match the updated function signature by adjusting the call to `store.StoreReport` to handle two return values. The test assigns the first return value to the blank identifier and captures the error as the second value in [store_test.go](https://github.com/xmtp/xmtpd/pull/1224/files#diff-94a7081fd27e86f6a67a835f2155e7be32c60dc0e1741335042bc89c206895ef).

#### 📍Where to Start
Start with the changes in the `TestCreateAttestationConcurrency` test in [store_test.go](https://github.com/xmtp/xmtpd/pull/1224/files#diff-94a7081fd27e86f6a67a835f2155e7be32c60dc0e1741335042bc89c206895ef), focusing on the updated call to `store.StoreReport` and its two-value return handling.

----

_[Macroscope](https://app.macroscope.com) summarized b5e92c3._
<!-- Macroscope's pull request summary ends here -->