### PR TITLE
Make activeNodeIDs order predictable and fix broken test

### DIFF
--- a/pkg/payerreport/generator.go
+++ b/pkg/payerreport/generator.go
@@ -2,6 +2,7 @@ package payerreport
 
 import (
 	"context"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/xmtp/xmtpd/pkg/currency"
@@ -156,5 +157,8 @@ func extractActiveNodeIDs(nodes []registry.Node) []uint32 {
 	for i, node := range nodes {
 		activeNodeIDs[i] = node.NodeID
 	}
+
+	sort.Slice(activeNodeIDs, func(i, j int) bool { return activeNodeIDs[i] < activeNodeIDs[j] })
+
 	return activeNodeIDs
 }

--- a/pkg/payerreport/workers/submitter.go
+++ b/pkg/payerreport/workers/submitter.go
@@ -91,6 +91,8 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 		return err
 	}
 
+	var latestErr error
+
 	for _, report := range reports {
 		reportLogger := payerreport.AddReportLogFields(w.log, &report.PayerReport)
 
@@ -107,6 +109,7 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 				zap.String("report_id", report.ID.String()),
 				zap.Error(err),
 			)
+			latestErr = err
 			continue
 		}
 
@@ -122,7 +125,7 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return latestErr
 }
 
 func (w *SubmitterWorker) submitReport(report *payerreport.PayerReportWithStatus) error {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Sort active node IDs in `pkg/payerreport/generator.go::extractActiveNodeIDs` to make ordering predictable and return the last submission error from `pkg/payerreport/workers/submitter.go::SubmitterWorker.SubmitReports` to fix the broken test
This change introduces deterministic ordering for active node IDs and updates report submission error handling to return the last encountered error after processing all reports.

- Update `extractActiveNodeIDs` to sort collected node IDs in ascending order after population in [generator.go](https://github.com/xmtp/xmtpd/pull/1230/files#diff-e3acc56c9fb8afec4da54172140fe65ec94a792aaba7518de67e9baf3f3f52df)
- Modify `SubmitterWorker.SubmitReports` to track and return the most recent submission error instead of always returning `nil` in [submitter.go](https://github.com/xmtp/xmtpd/pull/1230/files#diff-bbe168761e1f4dce803d758c9db41c508ede9eab842d93a0117aae2de4545d8f)

#### 📍Where to Start
Start with `extractActiveNodeIDs` in [generator.go](https://github.com/xmtp/xmtpd/pull/1230/files#diff-e3acc56c9fb8afec4da54172140fe65ec94a792aaba7518de67e9baf3f3f52df), then review `SubmitterWorker.SubmitReports` in [submitter.go](https://github.com/xmtp/xmtpd/pull/1230/files#diff-bbe168761e1f4dce803d758c9db41c508ede9eab842d93a0117aae2de4545d8f).

----

_[Macroscope](https://app.macroscope.com) summarized 703b30f._
<!-- Macroscope's pull request summary ends here -->