### PR TITLE
Log minutes for better debuggability

### DIFF
--- a/pkg/payerreport/verifier.go
+++ b/pkg/payerreport/verifier.go
@@ -189,6 +189,7 @@ func (p *PayerReportVerifier) isAtMinuteEnd(
 		p.log.Info(
 			"sequence id is not the last message in the minute",
 			zap.Int64("last_sequence_id", lastSequenceID),
+			zap.Int32("minute", minute),
 			zap.Int64("expected_sequence_id", expectedSequenceID),
 		)
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add minute value to informational log in `payerreport.PayerReportVerifier.isAtMinuteEnd` for better debuggability
This change updates the informational log emitted by `payerreport.PayerReportVerifier.isAtMinuteEnd` when the sequence ID is not the last in the minute to include an additional structured field `zap.Int32("minute", minute)` in [verifier.go](https://github.com/xmtp/xmtpd/pull/1231/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8).

#### 📍Where to Start
Start with the `isAtMinuteEnd` method implementation in [verifier.go](https://github.com/xmtp/xmtpd/pull/1231/files#diff-d3beb4e8aa9d915dbc817b4636d94a2db669a320bcfa34aa705739352d64b4e8).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 11d46cd. 1 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->