### PR TITLE
PayerReportManager indexer storer: Fix attestaton status from chain

### DIFF
--- a/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer.go
@@ -26,6 +26,7 @@ const (
 	ErrBuildPayerReportID               = "error building payer report id"
 	ErrStoreReport                      = "error storing report"
 	ErrSetReportSubmissionStatus        = "error setting report submission status"
+	ErrSetReportAttestationStatus       = "error setting report attestation status"
 	ErrLoadReportByIndex                = "error loading report by index"
 
 	payerReportManagerPayerReportSubmittedEvent     = "PayerReportSubmitted"
@@ -233,9 +234,15 @@ func (s *PayerReportManagerStorer) setReportSubmitted(
 	}
 
 	// Will only set the status to Submitted if it was previously Pending.
-	// If it is already settled, this is a no-op
+	// If it is already settled, this is a no-op.
 	if err = s.store.SetReportSubmitted(ctx, *reportID); err != nil {
 		return re.NewRecoverableError(ErrSetReportSubmissionStatus, err)
+	}
+
+	// Sets attestation status to Approved, if it was previously Pending.
+	// If it is already approved or rejected, this is a no-op.
+	if err = s.store.SetReportAttestationApproved(ctx, *reportID); err != nil {
+		return re.NewRecoverableError(ErrSetReportAttestationStatus, err)
 	}
 
 	if numRows == 0 {

--- a/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer_test.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer_test.go
@@ -106,14 +106,27 @@ func TestStorePayerReportManagerPayerReportSubmittedIdempotency(t *testing.T) {
 	err := tester.storer.StoreLog(t.Context(), log)
 	require.NoError(t, err)
 
-	err = tester.storer.StoreLog(t.Context(), log)
-	require.NoError(t, err)
-
 	res, queryErr := tester.queries.FetchPayerReports(t.Context(), queries.FetchPayerReportsParams{
 		OriginatorNodeID: utils.NewNullInt32(&originatorNodeID),
 	})
 	require.Nil(t, queryErr)
 	require.Len(t, res, 1)
+	require.Equal(t, int16(1), res[0].SubmissionStatus)
+	require.Equal(t, int16(1), res[0].AttestationStatus)
+
+	expectedID := res[0].ID
+
+	err = tester.storer.StoreLog(t.Context(), log)
+	require.NoError(t, err)
+
+	res, queryErr = tester.queries.FetchPayerReports(t.Context(), queries.FetchPayerReportsParams{
+		OriginatorNodeID: utils.NewNullInt32(&originatorNodeID),
+	})
+	require.Nil(t, queryErr)
+	require.Len(t, res, 1)
+	require.Equal(t, int16(1), res[0].SubmissionStatus)
+	require.Equal(t, int16(1), res[0].AttestationStatus)
+	require.Equal(t, expectedID, res[0].ID)
 }
 
 func TestStorePayerReportManagerPayerReportSubsetSettled(t *testing.T) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix attestation status handling by setting `PayerReportManagerStorer.setReportSubmitted` to mark reports as Approved when processing `PayerReportSubmitted` events
This change adds an attestation status update to the report lifecycle when handling `PayerReportSubmitted` events. In `PayerReportManagerStorer.setReportSubmitted`, after storing the report and submission status, it calls `store.SetReportAttestationApproved` with the built report ID and wraps any resulting error with a new recoverable error constant. Tests verify idempotency and that both submission and attestation statuses equal `1` after the first and second store operations.

- Add `ErrSetReportAttestationStatus` error constant in [payer_report_manager_storer.go](https://github.com/xmtp/xmtpd/pull/1232/files#diff-baeb6b8fe1fd854c24eafd34f6ab3be9f62116130cb82a0db9c8d7aaac45bc10)
- Call `store.SetReportAttestationApproved` in `PayerReportManagerStorer.setReportSubmitted` and wrap errors with `ErrSetReportAttestationStatus` in [payer_report_manager_storer.go](https://github.com/xmtp/xmtpd/pull/1232/files#diff-baeb6b8fe1fd854c24eafd34f6ab3be9f62116130cb82a0db9c8d7aaac45bc10)
- Extend `TestStorePayerReportManagerPayerReportSubmittedIdempotency` to assert `SubmissionStatus == 1`, `AttestationStatus == 1`, and stable report ID across repeated `StoreLog` calls in [payer_report_manager_storer_test.go](https://github.com/xmtp/xmtpd/pull/1232/files#diff-1f672186f9d4179be30c291a435af8b1ff2ffd147ef02cda55ab90f69697926e)

#### 📍Where to Start
Start with the `PayerReportManagerStorer.setReportSubmitted` implementation in [payer_report_manager_storer.go](https://github.com/xmtp/xmtpd/pull/1232/files#diff-baeb6b8fe1fd854c24eafd34f6ab3be9f62116130cb82a0db9c8d7aaac45bc10), then review the updated idempotency test `TestStorePayerReportManagerPayerReportSubmittedIdempotency` in [payer_report_manager_storer_test.go](https://github.com/xmtp/xmtpd/pull/1232/files#diff-1f672186f9d4179be30c291a435af8b1ff2ffd147ef02cda55ab90f69697926e).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a28adec. 1 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->