### PR TITLE
Log fetch reports per worker

### DIFF
--- a/pkg/payerreport/store.go
+++ b/pkg/payerreport/store.go
@@ -111,7 +111,8 @@ func (s *Store) FetchReports(
 	if err != nil {
 		return nil, err
 	}
-	s.log.Info("Fetched reports", zap.Any("rows", rows))
+
+	s.log.Debug("fetched reports", zap.Any("rows", rows))
 
 	return convertPayerReports(rows)
 }

--- a/pkg/payerreport/workers/attestation.go
+++ b/pkg/payerreport/workers/attestation.go
@@ -129,6 +129,7 @@ func (w *AttestationWorker) AttestReports() error {
 // findReportsNeedingAttestation fetches all reports that are pending attestation and pending submission.
 // The only possible state where a report is needing attestation is when it's pending submission and attestation.
 func (w *AttestationWorker) findReportsNeedingAttestation() ([]*payerreport.PayerReportWithStatus, error) {
+	w.log.Debug("fetching reports needing attestation")
 	return w.store.FetchReports(
 		w.ctx,
 		payerreport.NewFetchReportsQuery().
@@ -174,6 +175,10 @@ func (w *AttestationWorker) attestReport(report *payerreport.PayerReportWithStat
 func (w *AttestationWorker) getPreviousReport(
 	currentReport *payerreport.PayerReportWithStatus,
 ) (*payerreport.PayerReportWithStatus, error) {
+	w.log.Debug("fetching previous report",
+		zap.Uint32("originator_node_id", currentReport.OriginatorNodeID),
+		zap.Uint64("start_sequence_id", currentReport.StartSequenceID),
+	)
 	prevReports, err := w.store.FetchReports(
 		w.ctx,
 		payerreport.NewFetchReportsQuery().

--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -137,6 +137,11 @@ func (w *GeneratorWorker) maybeGenerateReport(nodeID uint32) error {
 	// This will result in us missing the new report and generating a duplicate
 
 	// Fetch all reports for the originator that are pending and approved
+	w.log.Debug(
+		"maybe generating report, fetching existing reports",
+		zap.Uint32("node_id", nodeID),
+		zap.Uint64("existing_end_sequence_id", existingReportEndSequenceID),
+	)
 	existingReports, err := w.store.FetchReports(
 		w.ctx,
 		payerreport.NewFetchReportsQuery().
@@ -212,6 +217,9 @@ func (w *GeneratorWorker) generateReport(nodeID uint32, lastReportEndSequenceID 
 func (w *GeneratorWorker) getLastSubmittedReport(
 	nodeID uint32,
 ) (*payerreport.PayerReportWithStatus, error) {
+	w.log.Debug("fetching last submitted report",
+		zap.Uint32("node_id", nodeID),
+	)
 	reports, err := w.store.FetchReports(
 		w.ctx,
 		payerreport.NewFetchReportsQuery().

--- a/pkg/payerreport/workers/submitter.go
+++ b/pkg/payerreport/workers/submitter.go
@@ -84,6 +84,7 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 	}
 
 	// SubmitterWorker fetches all reports that are pending submission and approved attestation.
+	w.log.Debug("fetching reports to submit")
 	reports, err := w.payerReportStore.FetchReports(
 		ctx,
 		payerreport.NewFetchReportsQuery().


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Log fetch reports per worker by moving `payerreport.Store.FetchReports` to Debug level and adding Debug logs in `payerreport.workers.AttestationWorker`, `payerreport.workers.GeneratorWorker`, and `payerreport.workers.SubmitterWorker` methods
This change adjusts logging around report fetching across the payer report workers. It lowers the log level of the store fetch to Debug and adds new Debug logs with contextual fields in worker methods.

- Lower the log level of `payerreport.Store.FetchReports` from Info to Debug and update message casing in [store.go](https://github.com/xmtp/xmtpd/pull/1237/files#diff-1557531d1361293f11123bbcc86167d7a99f261d62a4a71af45f898ac3b5c770)
- Add a Debug log before fetching reports needing attestation in `payerreport.workers.AttestationWorker.findReportsNeedingAttestation` and before fetching previous reports with `originator_node_id` and `start_sequence_id` in `payerreport.workers.AttestationWorker.getPreviousReport` in [attestation.go](https://github.com/xmtp/xmtpd/pull/1237/files#diff-e878e7214f8d54fd2250fb682976303e3753543783c7e7b141e6b0eab479a537)
- Add Debug logs in `payerreport.workers.GeneratorWorker.maybeGenerateReport` with `node_id` and `existing_end_sequence_id`, and in `payerreport.workers.GeneratorWorker.getLastSubmittedReport` with `node_id` in [generator.go](https://github.com/xmtp/xmtpd/pull/1237/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e)
- Add a Debug log before fetching reports to submit in `payerreport.workers.SubmitterWorker.SubmitReports` in [submitter.go](https://github.com/xmtp/xmtpd/pull/1237/files#diff-bbe168761e1f4dce803d758c9db41c508ede9eab842d93a0117aae2de4545d8f)

#### 📍Where to Start
Start with the log level change in `payerreport.Store.FetchReports` in [store.go](https://github.com/xmtp/xmtpd/pull/1237/files#diff-1557531d1361293f11123bbcc86167d7a99f261d62a4a71af45f898ac3b5c770), then review the added Debug logs in worker methods beginning with `payerreport.workers.AttestationWorker.findReportsNeedingAttestation` in [attestation.go](https://github.com/xmtp/xmtpd/pull/1237/files#diff-e878e7214f8d54fd2250fb682976303e3753543783c7e7b141e6b0eab479a537).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 36d6a60. 4 files reviewed, 4 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/payerreport/workers/generator.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 116](https://github.com/xmtp/xmtpd/blob/36d6a6017886efac06c9747fe86959f61388926d/pkg/payerreport/workers/generator.go#L116): Time-of-check to time-of-use race can generate duplicate reports in `maybeGenerateReport`. Between fetching `lastSubmittedReport` and subsequently fetching `existingReports` filtered by `SubmissionPending`, a concurrent submitter can transition a report from pending to submitted. This makes the pending check miss the just-submitted report and allows `generateReport` to run, creating a duplicate report for the same range. The code even notes this hazard in comments. To fix, enforce a stronger atomicity: e.g., perform both checks and the potential creation within a single DB transaction using appropriate locks (SELECT ... FOR UPDATE) and/or a unique constraint on the report interval per originator, and handle uniqueness violations by re-reading; or take an advisory/row lock around the sequence window. <b>[ Out of scope ]</b>
</details>

<details>
<summary>pkg/payerreport/workers/submitter.go — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 73](https://github.com/xmtp/xmtpd/blob/36d6a6017886efac06c9747fe86959f61388926d/pkg/payerreport/workers/submitter.go#L73): `SubmitReports` inconsistently uses contexts: it acquires the advisory locker with `w.payerReportStore.GetAdvisoryLocker(w.ctx)` using the worker’s long-lived `w.ctx`, but uses the passed `ctx` for store operations (`FetchReports`, `SetReportSubmissionRejected`, `SetReportSubmitted`). This can lead to cancellation and timeout mismatches where the advisory lock acquisition/holding ignores the caller’s cancellation, or store operations cancel while the lock continues to be held. This inconsistency can cause prolonged lock holding or partial work when `ctx` is canceled. The function should use a consistent context, typically the passed `ctx`, for all operations, or document and intentionally separate lifetimes with explicit handling. <b>[ Low confidence ]</b>
- [line 101](https://github.com/xmtp/xmtpd/blob/36d6a6017886efac06c9747fe86959f61388926d/pkg/payerreport/workers/submitter.go#L101): The loop assumes all elements in `reports` are non-nil, but no guard enforces this. If `FetchReports` returns a slice containing a nil `*PayerReportWithStatus`, then `payerreport.AddReportLogFields(w.log, &report.PayerReport)` will dereference `report` and panic. Subsequent uses like `report.ID.String()` and passing `report` to `w.submitReport(report)` will also panic. You should add a nil check per element before dereferencing or using the report. <b>[ Low confidence ]</b>
- [line 141](https://github.com/xmtp/xmtpd/blob/36d6a6017886efac06c9747fe86959f61388926d/pkg/payerreport/workers/submitter.go#L141): Errors from `SetReportSubmitted` are only logged at `Warn` level and not propagated via the function return (`latestErr` is not set). This means the worker can return `nil` even when the report’s submitted state failed to persist, leading to inconsistent state and silent failure from the caller’s perspective (`Start` only logs returned errors). While the comment mentions a race the store should handle, failures unrelated to the race (e.g., DB errors) are suppressed. Consider including the error in the log (`zap.Error(err)`) and propagating it via `latestErr` to ensure visibility and retries/alerts behave correctly. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->