### PR TITLE
Add settlement worker

### DIFF
--- a/pkg/db/advisory_lock.go
+++ b/pkg/db/advisory_lock.go
@@ -18,6 +18,7 @@ const (
 	LockKindIdentityUpdateInsert LockKind = 0x00
 	LockKindAttestationWorker    LockKind = 0x01
 	LockKindSubmitterWorker      LockKind = 0x02
+	LockKindSettlementWorker     LockKind = 0x03
 	LockKindGeneratorWorker      LockKind = 0x04
 )
 
@@ -62,11 +63,20 @@ func (a *AdvisoryLocker) LockSubmitterWorker(
 	return queries.AdvisoryLockWithKey(ctx, key)
 }
 
+func (a *AdvisoryLocker) LockSettlementWorker(
+	ctx context.Context,
+	queries *queries.Queries,
+) error {
+	key := int64(LockKindSettlementWorker)
+	return queries.AdvisoryLockWithKey(ctx, key)
+}
+
 type ITransactionScopedAdvisoryLocker interface {
 	Release() error
 	LockGeneratorWorker() error
 	LockAttestationWorker() error
 	LockSubmitterWorker() error
+	LockSettlementWorker() error
 	LockIdentityUpdateInsert(nodeId uint32) error
 }
 
@@ -106,6 +116,10 @@ func (a *TransactionScopedAdvisoryLocker) LockAttestationWorker() error {
 
 func (a *TransactionScopedAdvisoryLocker) LockSubmitterWorker() error {
 	return a.locker.LockSubmitterWorker(a.ctx, queries.New(a.tx))
+}
+
+func (a *TransactionScopedAdvisoryLocker) LockSettlementWorker() error {
+	return a.locker.LockSettlementWorker(a.ctx, queries.New(a.tx))
 }
 
 func (a *TransactionScopedAdvisoryLocker) LockIdentityUpdateInsert(nodeId uint32) error {

--- a/pkg/payerreport/workers/settlement.go
+++ b/pkg/payerreport/workers/settlement.go
@@ -1,0 +1,124 @@
+package workers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/xmtp/xmtpd/pkg/payerreport"
+	"github.com/xmtp/xmtpd/pkg/tracing"
+	"go.uber.org/zap"
+)
+
+const settlementWorkerID = 3
+
+type SettlementWorker struct {
+	log              *zap.Logger
+	ctx              context.Context
+	cancel           context.CancelFunc
+	wg               *sync.WaitGroup
+	payerReportStore payerreport.IPayerReportStore
+	myNodeID         uint32
+}
+
+func NewSettlementWorker(
+	ctx context.Context,
+	log *zap.Logger,
+	payerReportStore payerreport.IPayerReportStore,
+	myNodeID uint32,
+) *SettlementWorker {
+	ctx, cancel := context.WithCancel(ctx)
+	return &SettlementWorker{
+		log:              log.Named("reportsettlement"),
+		ctx:              ctx,
+		cancel:           cancel,
+		wg:               &sync.WaitGroup{},
+		payerReportStore: payerReportStore,
+		myNodeID:         myNodeID,
+	}
+}
+
+func (w *SettlementWorker) Start() {
+	tracing.GoPanicWrap(w.ctx, w.wg, "payerreport-settlement", func(ctx context.Context) {
+		for {
+			nextRun := findNextRunTime(w.myNodeID, settlementWorkerID)
+			wait := time.Until(nextRun)
+			select {
+			case <-w.ctx.Done():
+				return
+			case <-time.After(wait):
+				if err := w.SettleReports(ctx); err != nil {
+					w.log.Error("error settling reports", zap.Error(err))
+				}
+			}
+		}
+	})
+}
+
+func (w *SettlementWorker) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+}
+
+func (w *SettlementWorker) SettleReports(ctx context.Context) error {
+	haLock, err := w.payerReportStore.GetAdvisoryLocker(w.ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = haLock.Release()
+	}()
+
+	err = haLock.LockSettlementWorker()
+	if err != nil {
+		return err
+	}
+
+	// SettlementWorker fetches all reports that have been submitted but not yet settled.
+	w.log.Debug("fetching reports to settle")
+	reports, err := w.payerReportStore.FetchReports(
+		ctx,
+		payerreport.NewFetchReportsQuery().
+			WithSubmissionStatus(payerreport.SubmissionSubmitted),
+	)
+	if err != nil {
+		return err
+	}
+
+	var latestErr error
+
+	for _, report := range reports {
+		reportLogger := payerreport.AddReportLogFields(w.log, &report.PayerReport)
+
+		reportLogger.Info("settling report")
+		settleErr := w.settleReport(report)
+		if settleErr != nil {
+			reportLogger.Error(
+				"failed to settle report",
+				zap.String("report_id", report.ID.String()),
+				zap.Error(settleErr),
+			)
+
+			latestErr = settleErr
+			continue
+		}
+
+		err = w.payerReportStore.SetReportSettled(ctx, report.ID)
+		if err != nil {
+			reportLogger.Warn(
+				"failed to set report settled",
+				zap.String("report_id", report.ID.String()),
+			)
+		}
+	}
+
+	return latestErr
+}
+
+func (w *SettlementWorker) settleReport(
+	report *payerreport.PayerReportWithStatus,
+) error {
+	// TODO: Implement settlement logic
+	return nil
+}


### PR DESCRIPTION
### TL;DR

Added a new settlement worker for payer reports to handle the settlement process after reports have been submitted.

### What changed?

- Added a new `LockKindSettlementWorker` constant to the advisory lock system
- Implemented new lock methods for the settlement worker in the advisory locker
- Created a new `SettlementWorker` in the `payerreport/workers` package that:
  - Runs on a schedule based on node ID
  - Fetches submitted but unsettled reports
  - Attempts to settle each report (with a placeholder for actual settlement logic)
  - Updates report status to settled upon successful settlement

### How to test?

1. Run the node with the settlement worker enabled
2. Submit payer reports through the normal flow
3. Verify that the settlement worker picks up submitted reports
4. Check logs for "settling report" messages
5. Verify that report status changes from "submitted" to "settled" in the database

### Why make this change?

This change adds the necessary infrastructure for the final step in the payer report lifecycle. After reports are submitted, they need to be settled to complete the payment process. The settlement worker provides a scheduled, locked process to ensure reports are properly settled without conflicts between nodes.