### PR TITLE
Store submitted report index

### DIFF
--- a/pkg/blockchain/interface.go
+++ b/pkg/blockchain/interface.go
@@ -66,7 +66,10 @@ type IBlockchainPublisher interface {
 }
 
 type PayerReportsManager interface {
-	SubmitPayerReport(ctx context.Context, report *payerreport.PayerReportWithStatus) ProtocolError
+	SubmitPayerReport(
+		ctx context.Context,
+		report *payerreport.PayerReportWithStatus,
+	) (int32, ProtocolError)
 	GetReport(
 		ctx context.Context,
 		originatorNodeID uint32,

--- a/pkg/db/queries/models.go
+++ b/pkg/db/queries/models.go
@@ -78,16 +78,17 @@ type PayerLedgerEvent struct {
 }
 
 type PayerReport struct {
-	ID                  []byte
-	OriginatorNodeID    int32
-	StartSequenceID     int64
-	EndSequenceID       int64
-	EndMinuteSinceEpoch int32
-	PayersMerkleRoot    []byte
-	ActiveNodeIds       []int32
-	SubmissionStatus    int16
-	AttestationStatus   int16
-	CreatedAt           sql.NullTime
+	ID                   []byte
+	OriginatorNodeID     int32
+	StartSequenceID      int64
+	EndSequenceID        int64
+	EndMinuteSinceEpoch  int32
+	PayersMerkleRoot     []byte
+	ActiveNodeIds        []int32
+	SubmissionStatus     int16
+	AttestationStatus    int16
+	CreatedAt            sql.NullTime
+	SubmittedReportIndex sql.NullInt32
 }
 
 type PayerReportAttestation struct {

--- a/pkg/db/sqlc/payer_reports.sql
+++ b/pkg/db/sqlc/payer_reports.sql
@@ -192,6 +192,13 @@ SET submission_status = @new_status
 WHERE id = @report_id
 	AND submission_status = ANY(sqlc.arg(prev_status)::SMALLINT []);
 
+-- name: SetReportSubmitted :exec
+UPDATE payer_reports
+SET submission_status = @new_status,
+	submitted_report_index = sqlc.arg(submitted_report_index)::INTEGER
+WHERE id = @report_id
+	AND submission_status = ANY(sqlc.arg(prev_status)::SMALLINT []);
+
 -- name: FetchAttestations :many
 SELECT *
 FROM payer_report_attestations

--- a/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_report_manager_storer.go
@@ -234,7 +234,12 @@ func (s *PayerReportManagerStorer) setReportSubmitted(
 
 	// Will only set the status to Submitted if it was previously Pending.
 	// If it is already settled, this is a no-op
-	if err = s.store.SetReportSubmitted(ctx, *reportID); err != nil {
+	// Validate that the PayerReportIndex fits in an int32
+	reportIndex, err := payerreport.ValidateReportIndex(event.PayerReportIndex)
+	if err != nil {
+		return re.NewNonRecoverableError(ErrSetReportSubmissionStatus, err)
+	}
+	if err = s.store.SetReportSubmitted(ctx, *reportID, reportIndex); err != nil {
 		return re.NewRecoverableError(ErrSetReportSubmissionStatus, err)
 	}
 

--- a/pkg/migrations/00018_add_report_index.down.sql
+++ b/pkg/migrations/00018_add_report_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payer_reports DROP COLUMN submitted_report_index;

--- a/pkg/migrations/00018_add_report_index.up.sql
+++ b/pkg/migrations/00018_add_report_index.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payer_reports ADD COLUMN submitted_report_index INTEGER NULL;

--- a/pkg/mocks/blockchain/mock_PayerReportsManager.go
+++ b/pkg/mocks/blockchain/mock_PayerReportsManager.go
@@ -204,23 +204,33 @@ func (_c *MockPayerReportsManager_GetReportID_Call) RunAndReturn(run func(contex
 }
 
 // SubmitPayerReport provides a mock function with given fields: ctx, report
-func (_m *MockPayerReportsManager) SubmitPayerReport(ctx context.Context, report *payerreport.PayerReportWithStatus) blockchain.ProtocolError {
+func (_m *MockPayerReportsManager) SubmitPayerReport(ctx context.Context, report *payerreport.PayerReportWithStatus) (int32, blockchain.ProtocolError) {
 	ret := _m.Called(ctx, report)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SubmitPayerReport")
 	}
 
-	var r0 blockchain.ProtocolError
-	if rf, ok := ret.Get(0).(func(context.Context, *payerreport.PayerReportWithStatus) blockchain.ProtocolError); ok {
+	var r0 int32
+	var r1 blockchain.ProtocolError
+	if rf, ok := ret.Get(0).(func(context.Context, *payerreport.PayerReportWithStatus) (int32, blockchain.ProtocolError)); ok {
+		return rf(ctx, report)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *payerreport.PayerReportWithStatus) int32); ok {
 		r0 = rf(ctx, report)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(blockchain.ProtocolError)
+		r0 = ret.Get(0).(int32)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *payerreport.PayerReportWithStatus) blockchain.ProtocolError); ok {
+		r1 = rf(ctx, report)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(blockchain.ProtocolError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }
 
 // MockPayerReportsManager_SubmitPayerReport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SubmitPayerReport'
@@ -242,12 +252,12 @@ func (_c *MockPayerReportsManager_SubmitPayerReport_Call) Run(run func(ctx conte
 	return _c
 }
 
-func (_c *MockPayerReportsManager_SubmitPayerReport_Call) Return(_a0 blockchain.ProtocolError) *MockPayerReportsManager_SubmitPayerReport_Call {
-	_c.Call.Return(_a0)
+func (_c *MockPayerReportsManager_SubmitPayerReport_Call) Return(_a0 int32, _a1 blockchain.ProtocolError) *MockPayerReportsManager_SubmitPayerReport_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockPayerReportsManager_SubmitPayerReport_Call) RunAndReturn(run func(context.Context, *payerreport.PayerReportWithStatus) blockchain.ProtocolError) *MockPayerReportsManager_SubmitPayerReport_Call {
+func (_c *MockPayerReportsManager_SubmitPayerReport_Call) RunAndReturn(run func(context.Context, *payerreport.PayerReportWithStatus) (int32, blockchain.ProtocolError)) *MockPayerReportsManager_SubmitPayerReport_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/mocks/payerreport/mock_IPayerReportStore.go
+++ b/pkg/mocks/payerreport/mock_IPayerReportStore.go
@@ -550,17 +550,17 @@ func (_c *MockIPayerReportStore_SetReportSubmissionRejected_Call) RunAndReturn(r
 	return _c
 }
 
-// SetReportSubmitted provides a mock function with given fields: ctx, id
-func (_m *MockIPayerReportStore) SetReportSubmitted(ctx context.Context, id payerreport.ReportID) error {
-	ret := _m.Called(ctx, id)
+// SetReportSubmitted provides a mock function with given fields: ctx, id, reportIndex
+func (_m *MockIPayerReportStore) SetReportSubmitted(ctx context.Context, id payerreport.ReportID, reportIndex int32) error {
+	ret := _m.Called(ctx, id, reportIndex)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetReportSubmitted")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID) error); ok {
-		r0 = rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(context.Context, payerreport.ReportID, int32) error); ok {
+		r0 = rf(ctx, id, reportIndex)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -576,13 +576,14 @@ type MockIPayerReportStore_SetReportSubmitted_Call struct {
 // SetReportSubmitted is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id payerreport.ReportID
-func (_e *MockIPayerReportStore_Expecter) SetReportSubmitted(ctx interface{}, id interface{}) *MockIPayerReportStore_SetReportSubmitted_Call {
-	return &MockIPayerReportStore_SetReportSubmitted_Call{Call: _e.mock.On("SetReportSubmitted", ctx, id)}
+//   - reportIndex int32
+func (_e *MockIPayerReportStore_Expecter) SetReportSubmitted(ctx interface{}, id interface{}, reportIndex interface{}) *MockIPayerReportStore_SetReportSubmitted_Call {
+	return &MockIPayerReportStore_SetReportSubmitted_Call{Call: _e.mock.On("SetReportSubmitted", ctx, id, reportIndex)}
 }
 
-func (_c *MockIPayerReportStore_SetReportSubmitted_Call) Run(run func(ctx context.Context, id payerreport.ReportID)) *MockIPayerReportStore_SetReportSubmitted_Call {
+func (_c *MockIPayerReportStore_SetReportSubmitted_Call) Run(run func(ctx context.Context, id payerreport.ReportID, reportIndex int32)) *MockIPayerReportStore_SetReportSubmitted_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(payerreport.ReportID))
+		run(args[0].(context.Context), args[1].(payerreport.ReportID), args[2].(int32))
 	})
 	return _c
 }
@@ -592,7 +593,7 @@ func (_c *MockIPayerReportStore_SetReportSubmitted_Call) Return(_a0 error) *Mock
 	return _c
 }
 
-func (_c *MockIPayerReportStore_SetReportSubmitted_Call) RunAndReturn(run func(context.Context, payerreport.ReportID) error) *MockIPayerReportStore_SetReportSubmitted_Call {
+func (_c *MockIPayerReportStore_SetReportSubmitted_Call) RunAndReturn(run func(context.Context, payerreport.ReportID, int32) error) *MockIPayerReportStore_SetReportSubmitted_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/payerreport/interface.go
+++ b/pkg/payerreport/interface.go
@@ -62,7 +62,7 @@ type IPayerReportStore interface {
 		envelope *envelopes.OriginatorEnvelope,
 		payerID int32,
 	) error
-	SetReportSubmitted(ctx context.Context, id ReportID) error
+	SetReportSubmitted(ctx context.Context, id ReportID, reportIndex int32) error
 	SetReportSettled(ctx context.Context, id ReportID) error
 	SetReportSubmissionRejected(ctx context.Context, id ReportID) error
 	SetReportAttestationApproved(ctx context.Context, id ReportID) error

--- a/pkg/payerreport/report.go
+++ b/pkg/payerreport/report.go
@@ -85,6 +85,8 @@ type PayerReport struct {
 	PayersMerkleRoot common.Hash
 	// The active node IDs in the report
 	ActiveNodeIDs []uint32
+	// The index of the report on the blockchain (null if not yet submitted or submission status is not tracked)
+	SubmittedReportIndex *uint32
 }
 
 type BuildPayerReportParams struct {

--- a/pkg/payerreport/store_test.go
+++ b/pkg/payerreport/store_test.go
@@ -646,7 +646,7 @@ func TestSetReportSettled(t *testing.T) {
 		require.Equal(t, 11, countUnsettledUsage(originatorID))
 
 		// Set to submitted then settled
-		err = store.SetReportSubmitted(ctx, report.ID)
+		err = store.SetReportSubmitted(ctx, report.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, report.ID)
 		require.NoError(t, err)
@@ -681,7 +681,7 @@ func TestSetReportSettled(t *testing.T) {
 		numRows, err := store.StoreReport(ctx, firstReport)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), numRows)
-		err = store.SetReportSubmitted(ctx, firstReport.ID)
+		err = store.SetReportSubmitted(ctx, firstReport.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, firstReport.ID)
 		require.NoError(t, err)
@@ -711,7 +711,7 @@ func TestSetReportSettled(t *testing.T) {
 		require.Equal(t, 11, countUnsettledUsage(originatorID))
 
 		// Set second report to submitted then settled
-		err = store.SetReportSubmitted(ctx, secondReport.ID)
+		err = store.SetReportSubmitted(ctx, secondReport.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, secondReport.ID)
 		require.NoError(t, err)
@@ -746,7 +746,7 @@ func TestSetReportSettled(t *testing.T) {
 		numRows, err := store.StoreReport(ctx, report1)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), numRows)
-		err = store.SetReportSubmitted(ctx, report1.ID)
+		err = store.SetReportSubmitted(ctx, report1.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, report1.ID)
 		require.NoError(t, err)
@@ -764,7 +764,7 @@ func TestSetReportSettled(t *testing.T) {
 		numRows, err = store.StoreReport(ctx, report2)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), numRows)
-		err = store.SetReportSubmitted(ctx, report2.ID)
+		err = store.SetReportSubmitted(ctx, report2.ID, 0)
 		require.NoError(t, err)
 
 		// Create third report
@@ -794,7 +794,7 @@ func TestSetReportSettled(t *testing.T) {
 		require.Equal(t, 14, countUnsettledUsage(originatorID))
 
 		// Settle the third report
-		err = store.SetReportSubmitted(ctx, report3.ID)
+		err = store.SetReportSubmitted(ctx, report3.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, report3.ID)
 		require.NoError(t, err)
@@ -820,7 +820,7 @@ func TestSetReportSettled(t *testing.T) {
 		numRows, err := store.StoreReport(ctx, report1)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), numRows)
-		err = store.SetReportSubmitted(ctx, report1.ID)
+		err = store.SetReportSubmitted(ctx, report1.ID, 0)
 		require.NoError(t, err)
 
 		// Create second report
@@ -848,7 +848,7 @@ func TestSetReportSettled(t *testing.T) {
 		require.Equal(t, 11, countUnsettledUsage(originatorID))
 
 		// Settle the second report
-		err = store.SetReportSubmitted(ctx, report2.ID)
+		err = store.SetReportSubmitted(ctx, report2.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, report2.ID)
 		require.NoError(t, err)
@@ -896,7 +896,7 @@ func TestSetReportSettled(t *testing.T) {
 		require.Equal(t, 4, countUnsettledUsage(report2.OriginatorNodeID))
 
 		// Set first report to submitted then settled
-		err = store.SetReportSubmitted(ctx, report1.ID)
+		err = store.SetReportSubmitted(ctx, report1.ID, 0)
 		require.NoError(t, err)
 		err = store.SetReportSettled(ctx, report1.ID)
 		require.NoError(t, err)
@@ -965,7 +965,7 @@ func TestSetReportSettled(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(1), numRows)
 
-		err = store.SetReportSubmitted(ctx, report.ID)
+		err = store.SetReportSubmitted(ctx, report.ID, 0)
 		require.NoError(t, err)
 
 		// Verify status is submitted

--- a/pkg/payerreport/utils.go
+++ b/pkg/payerreport/utils.go
@@ -2,6 +2,8 @@ package payerreport
 
 import (
 	"context"
+	"math"
+	"math/big"
 
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/envelopes"
@@ -42,4 +44,13 @@ func AddReportLogFields(logger *zap.Logger, report *PayerReport) *zap.Logger {
 		zap.Uint64("end_sequence_id", report.EndSequenceID),
 		zap.Uint32("originator_node_id", report.OriginatorNodeID),
 	)
+}
+
+// ValidateReportIndex checks if a big.Int PayerReportIndex fits within int32 bounds.
+// Returns the validated int32 value or ErrReportIndexTooLarge if the value is too large.
+func ValidateReportIndex(index *big.Int) (int32, error) {
+	if !index.IsInt64() || index.Int64() > math.MaxInt32 {
+		return 0, ErrReportIndexTooLarge
+	}
+	return int32(index.Int64()), nil
 }

--- a/pkg/payerreport/workers/attestation_test.go
+++ b/pkg/payerreport/workers/attestation_test.go
@@ -120,13 +120,13 @@ func TestDontAttestReportsInNonPendingStates(t *testing.T) {
 			require.NoError(t, store.SetReportAttestationRejected(t.Context(), r.ID))
 
 		case stateSubmissionSubmitted:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 
 		case stateSubmissionRejected:
 			require.NoError(t, store.SetReportSubmissionRejected(t.Context(), r.ID))
 
 		case stateSubmissionSettled:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 			require.NoError(t, store.SetReportSettled(t.Context(), r.ID))
 
 		default:

--- a/pkg/payerreport/workers/integration_test.go
+++ b/pkg/payerreport/workers/integration_test.go
@@ -366,7 +366,7 @@ func TestValidSignature(t *testing.T) {
 	require.Equal(t, reportID, payerReport.ID)
 
 	// Submit the report to the blockchain
-	err = reportsManager.SubmitPayerReport(t.Context(), &reportWithStatus)
+	_, err = reportsManager.SubmitPayerReport(t.Context(), &reportWithStatus)
 	require.NoError(t, err)
 }
 
@@ -575,7 +575,7 @@ func TestCanRejectReport(t *testing.T) {
 	require.Equal(t, reportID, payerReport1.ID)
 
 	// Submit the report to the blockchain
-	err = reportsManager.SubmitPayerReport(t.Context(), &reportWithStatus1)
+	_, err = reportsManager.SubmitPayerReport(t.Context(), &reportWithStatus1)
 	require.NoError(t, err)
 
 	reportWithStatus2 := payerreport.PayerReportWithStatus{
@@ -583,7 +583,7 @@ func TestCanRejectReport(t *testing.T) {
 		AttestationSignatures: signatures,
 	}
 
-	chainErr := reportsManager.SubmitPayerReport(t.Context(), &reportWithStatus2)
+	_, chainErr := reportsManager.SubmitPayerReport(t.Context(), &reportWithStatus2)
 	require.Error(t, chainErr)
 	require.True(t, chainErr.IsErrInvalidSequenceIDs())
 	require.ErrorIs(t, chainErr.Unwrap(), blockchain.ErrInvalidStartSequenceID)

--- a/pkg/payerreport/workers/submitter_test.go
+++ b/pkg/payerreport/workers/submitter_test.go
@@ -114,32 +114,32 @@ func TestSubmitterStatesAndTransitions(t *testing.T) {
 
 		//	(1,0) - Already submitted, attestation pending
 		case stateSubmissionSubmittedAttestationPending:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 
 		//	(1,1) - Already submitted, attestation approved
 		case stateSubmissionSubmittedAttestationApproved:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 			require.NoError(t, store.SetReportAttestationApproved(t.Context(), r.ID))
 
 		//	(1,2) - Already submitted, attestation rejected
 		case stateSubmissionSubmittedAttestationRejected:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 			require.NoError(t, store.SetReportAttestationRejected(t.Context(), r.ID))
 
 		//	(2,0) - Already settled
 		case stateSubmissionSettledAttestationPending:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 			require.NoError(t, store.SetReportSettled(t.Context(), r.ID))
 
 		//	(2,1) - Already settled, attestation approved
 		case stateSubmissionSettledAttestationApproved:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 			require.NoError(t, store.SetReportSettled(t.Context(), r.ID))
 			require.NoError(t, store.SetReportAttestationApproved(t.Context(), r.ID))
 
 		//	(2,2) - Already settled, attestation rejected
 		case stateSubmissionSettledAttestationRejected:
-			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
 			require.NoError(t, store.SetReportSettled(t.Context(), r.ID))
 			require.NoError(t, store.SetReportAttestationRejected(t.Context(), r.ID))
 
@@ -344,7 +344,7 @@ func TestSubmitterStatesAndTransitions(t *testing.T) {
 
 				reportsManager.EXPECT().
 					SubmitPayerReport(mock.Anything, mock.Anything).
-					Return(blockchain.NewBlockchainError(chainError))
+					Return(int32(0), blockchain.NewBlockchainError(chainError))
 			}
 
 			err = worker.SubmitReports(t.Context())


### PR DESCRIPTION
### TL;DR

Added tracking of blockchain report indices when submitting payer reports.

### What changed?

- Modified `SubmitPayerReport` to return the report index from the blockchain
- Added a `submitted_report_index` column to the `payer_reports` table
- Created a new `SetReportSubmitted` database function that stores the report index
- Added validation for report indices to ensure they fit within int32 bounds
- Updated the blockchain event handling to extract and store report indices
- Modified mocks and interfaces to support the new functionality

### How to test?

1. Submit a payer report through the API
2. Verify the report index is correctly stored in the database
3. Query the report to confirm the `submitted_report_index` field is populated
4. Test with various report indices to ensure validation works correctly

### Why make this change?

This change enables tracking of on-chain report indices, which is important for:
- Correlating local reports with their on-chain counterparts
- Providing better debugging and auditing capabilities
- Enabling more precise tracking of report submission status
- Supporting future features that may need to reference reports by their blockchain index

The report index serves as a unique identifier on the blockchain, making it easier to track and reference reports across systems.