### PR TITLE
Hook up settlement worker

### DIFF
--- a/pkg/blockchain/interface.go
+++ b/pkg/blockchain/interface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	gm "github.com/xmtp/xmtpd/pkg/abi/groupmessagebroadcaster"
 	iu "github.com/xmtp/xmtpd/pkg/abi/identityupdatebroadcaster"
+	"github.com/xmtp/xmtpd/pkg/merkle"
 	"github.com/xmtp/xmtpd/pkg/payerreport"
 )
 
@@ -80,4 +81,15 @@ type PayerReportsManager interface {
 		ctx context.Context,
 		payerReport *payerreport.PayerReportWithStatus,
 	) (payerreport.ReportID, error)
+	SettleReport(
+		ctx context.Context,
+		originatorNodeID uint32,
+		index uint64,
+		proof *merkle.MultiProof,
+	) error
+	SettlementSummary(
+		ctx context.Context,
+		originatorNodeID uint32,
+		index uint64,
+	) (*SettlementSummary, error)
 }

--- a/pkg/db/queries/payer_reports.sql.go
+++ b/pkg/db/queries/payer_reports.sql.go
@@ -243,6 +243,7 @@ SELECT id, originator_node_id, start_sequence_id, end_sequence_id, end_minute_si
 FROM rpt
 WHERE $1::INT IS NULL
 	OR attestations_count >= $1::INT
+ORDER BY created_at ASC
 `
 
 type FetchPayerReportsParams struct {

--- a/pkg/db/sqlc/payer_reports.sql
+++ b/pkg/db/sqlc/payer_reports.sql
@@ -166,7 +166,8 @@ WITH rpt AS (
 SELECT *
 FROM rpt
 WHERE sqlc.narg(min_attestations)::INT IS NULL
-	OR attestations_count >= sqlc.narg(min_attestations)::INT;
+	OR attestations_count >= sqlc.narg(min_attestations)::INT
+ORDER BY created_at ASC;
 
 -- name: FetchPayerReport :one
 SELECT *

--- a/pkg/mocks/blockchain/mock_PayerReportsManager.go
+++ b/pkg/mocks/blockchain/mock_PayerReportsManager.go
@@ -8,6 +8,8 @@ import (
 
 	context "context"
 
+	merkle "github.com/xmtp/xmtpd/pkg/merkle"
+
 	mock "github.com/stretchr/testify/mock"
 
 	payerreport "github.com/xmtp/xmtpd/pkg/payerreport"
@@ -199,6 +201,115 @@ func (_c *MockPayerReportsManager_GetReportID_Call) Return(_a0 payerreport.Repor
 }
 
 func (_c *MockPayerReportsManager_GetReportID_Call) RunAndReturn(run func(context.Context, *payerreport.PayerReportWithStatus) (payerreport.ReportID, error)) *MockPayerReportsManager_GetReportID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SettleReport provides a mock function with given fields: ctx, originatorNodeID, index, proof
+func (_m *MockPayerReportsManager) SettleReport(ctx context.Context, originatorNodeID uint32, index uint64, proof *merkle.MultiProof) error {
+	ret := _m.Called(ctx, originatorNodeID, index, proof)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SettleReport")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint64, *merkle.MultiProof) error); ok {
+		r0 = rf(ctx, originatorNodeID, index, proof)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockPayerReportsManager_SettleReport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SettleReport'
+type MockPayerReportsManager_SettleReport_Call struct {
+	*mock.Call
+}
+
+// SettleReport is a helper method to define mock.On call
+//   - ctx context.Context
+//   - originatorNodeID uint32
+//   - index uint64
+//   - proof *merkle.MultiProof
+func (_e *MockPayerReportsManager_Expecter) SettleReport(ctx interface{}, originatorNodeID interface{}, index interface{}, proof interface{}) *MockPayerReportsManager_SettleReport_Call {
+	return &MockPayerReportsManager_SettleReport_Call{Call: _e.mock.On("SettleReport", ctx, originatorNodeID, index, proof)}
+}
+
+func (_c *MockPayerReportsManager_SettleReport_Call) Run(run func(ctx context.Context, originatorNodeID uint32, index uint64, proof *merkle.MultiProof)) *MockPayerReportsManager_SettleReport_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint32), args[2].(uint64), args[3].(*merkle.MultiProof))
+	})
+	return _c
+}
+
+func (_c *MockPayerReportsManager_SettleReport_Call) Return(_a0 error) *MockPayerReportsManager_SettleReport_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockPayerReportsManager_SettleReport_Call) RunAndReturn(run func(context.Context, uint32, uint64, *merkle.MultiProof) error) *MockPayerReportsManager_SettleReport_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SettlementSummary provides a mock function with given fields: ctx, originatorNodeID, index
+func (_m *MockPayerReportsManager) SettlementSummary(ctx context.Context, originatorNodeID uint32, index uint64) (*blockchain.SettlementSummary, error) {
+	ret := _m.Called(ctx, originatorNodeID, index)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SettlementSummary")
+	}
+
+	var r0 *blockchain.SettlementSummary
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint64) (*blockchain.SettlementSummary, error)); ok {
+		return rf(ctx, originatorNodeID, index)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint64) *blockchain.SettlementSummary); ok {
+		r0 = rf(ctx, originatorNodeID, index)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*blockchain.SettlementSummary)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint64) error); ok {
+		r1 = rf(ctx, originatorNodeID, index)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockPayerReportsManager_SettlementSummary_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SettlementSummary'
+type MockPayerReportsManager_SettlementSummary_Call struct {
+	*mock.Call
+}
+
+// SettlementSummary is a helper method to define mock.On call
+//   - ctx context.Context
+//   - originatorNodeID uint32
+//   - index uint64
+func (_e *MockPayerReportsManager_Expecter) SettlementSummary(ctx interface{}, originatorNodeID interface{}, index interface{}) *MockPayerReportsManager_SettlementSummary_Call {
+	return &MockPayerReportsManager_SettlementSummary_Call{Call: _e.mock.On("SettlementSummary", ctx, originatorNodeID, index)}
+}
+
+func (_c *MockPayerReportsManager_SettlementSummary_Call) Run(run func(ctx context.Context, originatorNodeID uint32, index uint64)) *MockPayerReportsManager_SettlementSummary_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint32), args[2].(uint64))
+	})
+	return _c
+}
+
+func (_c *MockPayerReportsManager_SettlementSummary_Call) Return(_a0 *blockchain.SettlementSummary, _a1 error) *MockPayerReportsManager_SettlementSummary_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockPayerReportsManager_SettlementSummary_Call) RunAndReturn(run func(context.Context, uint32, uint64) (*blockchain.SettlementSummary, error)) *MockPayerReportsManager_SettlementSummary_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/mocks/payerreport/mock_IPayerReportVerifier.go
+++ b/pkg/mocks/payerreport/mock_IPayerReportVerifier.go
@@ -22,6 +22,65 @@ func (_m *MockIPayerReportVerifier) EXPECT() *MockIPayerReportVerifier_Expecter 
 	return &MockIPayerReportVerifier_Expecter{mock: &_m.Mock}
 }
 
+// GetPayerMap provides a mock function with given fields: ctx, report
+func (_m *MockIPayerReportVerifier) GetPayerMap(ctx context.Context, report *payerreport.PayerReport) (payerreport.PayerMap, error) {
+	ret := _m.Called(ctx, report)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPayerMap")
+	}
+
+	var r0 payerreport.PayerMap
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *payerreport.PayerReport) (payerreport.PayerMap, error)); ok {
+		return rf(ctx, report)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *payerreport.PayerReport) payerreport.PayerMap); ok {
+		r0 = rf(ctx, report)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(payerreport.PayerMap)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *payerreport.PayerReport) error); ok {
+		r1 = rf(ctx, report)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockIPayerReportVerifier_GetPayerMap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPayerMap'
+type MockIPayerReportVerifier_GetPayerMap_Call struct {
+	*mock.Call
+}
+
+// GetPayerMap is a helper method to define mock.On call
+//   - ctx context.Context
+//   - report *payerreport.PayerReport
+func (_e *MockIPayerReportVerifier_Expecter) GetPayerMap(ctx interface{}, report interface{}) *MockIPayerReportVerifier_GetPayerMap_Call {
+	return &MockIPayerReportVerifier_GetPayerMap_Call{Call: _e.mock.On("GetPayerMap", ctx, report)}
+}
+
+func (_c *MockIPayerReportVerifier_GetPayerMap_Call) Run(run func(ctx context.Context, report *payerreport.PayerReport)) *MockIPayerReportVerifier_GetPayerMap_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*payerreport.PayerReport))
+	})
+	return _c
+}
+
+func (_c *MockIPayerReportVerifier_GetPayerMap_Call) Return(_a0 payerreport.PayerMap, _a1 error) *MockIPayerReportVerifier_GetPayerMap_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockIPayerReportVerifier_GetPayerMap_Call) RunAndReturn(run func(context.Context, *payerreport.PayerReport) (payerreport.PayerMap, error)) *MockIPayerReportVerifier_GetPayerMap_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsValidReport provides a mock function with given fields: ctx, prevReport, newReport
 func (_m *MockIPayerReportVerifier) IsValidReport(ctx context.Context, prevReport *payerreport.PayerReport, newReport *payerreport.PayerReport) (bool, error) {
 	ret := _m.Called(ctx, prevReport, newReport)

--- a/pkg/payerreport/interface.go
+++ b/pkg/payerreport/interface.go
@@ -35,6 +35,10 @@ type IPayerReportVerifier interface {
 		prevReport *PayerReport,
 		newReport *PayerReport,
 	) (bool, error)
+	GetPayerMap(
+		ctx context.Context,
+		report *PayerReport,
+	) (PayerMap, error)
 }
 
 type IPayerReportStore interface {

--- a/pkg/payerreport/merkle.go
+++ b/pkg/payerreport/merkle.go
@@ -22,7 +22,7 @@ var payerLeaf = abi.Arguments{
 	},
 }
 
-func generateMerkleTree(payers PayerMap) (*merkle.MerkleTree, error) {
+func GenerateMerkleTree(payers PayerMap) (*merkle.MerkleTree, error) {
 	leaves := make([]merkle.Leaf, 0, len(payers))
 	var (
 		leaf []byte

--- a/pkg/payerreport/merkle_test.go
+++ b/pkg/payerreport/merkle_test.go
@@ -41,7 +41,7 @@ func TestBuildMerkle(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := payerreport.GenerateMerkleTreeTestBinding(c.payerMap)
+			_, err := payerreport.GenerateMerkleTree(c.payerMap)
 			if c.expectErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/payerreport/report.go
+++ b/pkg/payerreport/report.go
@@ -179,7 +179,7 @@ func BuildPayerReportID(
 }
 
 func BuildPayerReport(params BuildPayerReportParams) (*PayerReportWithInputs, error) {
-	tree, err := generateMerkleTree(params.Payers)
+	tree, err := GenerateMerkleTree(params.Payers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/payerreport/testbindings_test.go
+++ b/pkg/payerreport/testbindings_test.go
@@ -1,11 +1,5 @@
 package payerreport
 
-import "github.com/xmtp/xmtpd/pkg/merkle"
-
-func GenerateMerkleTreeTestBinding(payerMap PayerMap) (*merkle.MerkleTree, error) {
-	return generateMerkleTree(payerMap)
-}
-
 func ValidateReportTransitionTestBinding(prevReport *PayerReport, newReport *PayerReport) error {
 	return validateReportTransition(prevReport, newReport)
 }

--- a/pkg/payerreport/verifier_test.go
+++ b/pkg/payerreport/verifier_test.go
@@ -378,17 +378,17 @@ func TestValidateMerkleRoot(t *testing.T) {
 		cost:         currency.PicoDollar(100),
 	})
 
-	validMerkleTree200, err := payerreport.GenerateMerkleTreeTestBinding(payerreport.PayerMap{
+	validMerkleTree200, err := payerreport.GenerateMerkleTree(payerreport.PayerMap{
 		payerAddress: currency.PicoDollar(200),
 	})
 	require.NoError(t, err)
-	validMerkleTree0, err := payerreport.GenerateMerkleTreeTestBinding(payerreport.PayerMap{})
+	validMerkleTree0, err := payerreport.GenerateMerkleTree(payerreport.PayerMap{})
 	require.NoError(t, err)
-	invalidAmountTree, err := payerreport.GenerateMerkleTreeTestBinding(payerreport.PayerMap{
+	invalidAmountTree, err := payerreport.GenerateMerkleTree(payerreport.PayerMap{
 		payerAddress: currency.PicoDollar(400),
 	})
 	require.NoError(t, err)
-	invalidPayerTree, err := payerreport.GenerateMerkleTreeTestBinding(payerreport.PayerMap{
+	invalidPayerTree, err := payerreport.GenerateMerkleTree(payerreport.PayerMap{
 		testutils.RandomAddress(): currency.PicoDollar(100),
 	})
 	require.NoError(t, err)
@@ -512,7 +512,7 @@ func TestValidateMinuteBoundaries(t *testing.T) {
 		cost:         currency.PicoDollar(100),
 	})
 
-	validMerkleTree, err := payerreport.GenerateMerkleTreeTestBinding(payerreport.PayerMap{
+	validMerkleTree, err := payerreport.GenerateMerkleTree(payerreport.PayerMap{
 		payerAddress: currency.PicoDollar(200),
 	})
 	require.NoError(t, err)

--- a/pkg/payerreport/workers/runner.go
+++ b/pkg/payerreport/workers/runner.go
@@ -202,11 +202,21 @@ func RunWorkers(cfg workerConfig) *WorkerWrapper {
 		cfg.registrant.NodeID(),
 	)
 
+	settlementWorker := NewSettlementWorker(
+		cfg.ctx,
+		cfg.log,
+		cfg.store,
+		payerreport.NewPayerReportVerifier(cfg.log, cfg.store),
+		cfg.reportsManager,
+		cfg.registrant.NodeID(),
+	)
+
 	attestationWorker.Start()
 	generatorWorker.Start()
 	submitterWorker.Start()
+	settlementWorker.Start()
 
 	return &WorkerWrapper{
-		workers: []stoppable{attestationWorker, generatorWorker, submitterWorker},
+		workers: []stoppable{attestationWorker, generatorWorker, submitterWorker, settlementWorker},
 	}
 }

--- a/pkg/payerreport/workers/settlement.go
+++ b/pkg/payerreport/workers/settlement.go
@@ -2,15 +2,21 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
+	"github.com/xmtp/xmtpd/pkg/blockchain"
 	"github.com/xmtp/xmtpd/pkg/payerreport"
 	"github.com/xmtp/xmtpd/pkg/tracing"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 )
 
-const settlementWorkerID = 3
+const (
+	settlementWorkerID = 3
+	MAX_PROOF_ELEMENTS = 100
+)
 
 type SettlementWorker struct {
 	log              *zap.Logger
@@ -18,6 +24,8 @@ type SettlementWorker struct {
 	cancel           context.CancelFunc
 	wg               *sync.WaitGroup
 	payerReportStore payerreport.IPayerReportStore
+	verifier         payerreport.IPayerReportVerifier
+	reportManager    blockchain.PayerReportsManager
 	myNodeID         uint32
 }
 
@@ -25,6 +33,8 @@ func NewSettlementWorker(
 	ctx context.Context,
 	log *zap.Logger,
 	payerReportStore payerreport.IPayerReportStore,
+	verifier payerreport.IPayerReportVerifier,
+	reportManager blockchain.PayerReportsManager,
 	myNodeID uint32,
 ) *SettlementWorker {
 	ctx, cancel := context.WithCancel(ctx)
@@ -35,6 +45,8 @@ func NewSettlementWorker(
 		wg:               &sync.WaitGroup{},
 		payerReportStore: payerReportStore,
 		myNodeID:         myNodeID,
+		verifier:         verifier,
+		reportManager:    reportManager,
 	}
 }
 
@@ -92,7 +104,7 @@ func (w *SettlementWorker) SettleReports(ctx context.Context) error {
 		reportLogger := payerreport.AddReportLogFields(w.log, &report.PayerReport)
 
 		reportLogger.Info("settling report")
-		settleErr := w.settleReport(report)
+		settleErr := w.settleReport(ctx, report)
 		if settleErr != nil {
 			reportLogger.Error(
 				"failed to settle report",
@@ -102,6 +114,8 @@ func (w *SettlementWorker) SettleReports(ctx context.Context) error {
 
 			latestErr = settleErr
 			continue
+		} else {
+			reportLogger.Info("report settled")
 		}
 
 		err = w.payerReportStore.SetReportSettled(ctx, report.ID)
@@ -117,8 +131,82 @@ func (w *SettlementWorker) SettleReports(ctx context.Context) error {
 }
 
 func (w *SettlementWorker) settleReport(
+	ctx context.Context,
 	report *payerreport.PayerReportWithStatus,
 ) error {
-	// TODO: Implement settlement logic
+	reportLogger := payerreport.AddReportLogFields(w.log, &report.PayerReport)
+
+	if report.SubmittedReportIndex == nil {
+		return errors.New("report index is nil")
+	}
+
+	payerMap, err := w.verifier.GetPayerMap(ctx, &report.PayerReport)
+	if err != nil {
+		return err
+	}
+
+	merkleTree, err := payerreport.GenerateMerkleTree(payerMap)
+	if err != nil {
+		return err
+	}
+
+	summary, err := w.reportManager.SettlementSummary(
+		ctx,
+		report.OriginatorNodeID,
+		uint64(*report.SubmittedReportIndex),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Return early if the report is already settled
+	if summary.IsSettled {
+		return nil
+	}
+
+	index := uint64(*report.SubmittedReportIndex)
+
+	offset := int(summary.Offset)
+	leafCount := merkleTree.LeafCount()
+	remaining := leafCount - offset
+
+	// This should never happen, but check just to be safe.
+	if offset > leafCount {
+		return errors.New("offset exceeds leaf count")
+	}
+
+	if remaining == 0 && !summary.IsSettled {
+		reportLogger.Warn(
+			"something is fishy. No items left to settle but report is not settled",
+		)
+	}
+
+	for remaining > 0 {
+		numElements := utils.MinInt(remaining, MAX_PROOF_ELEMENTS)
+		proof, err := merkleTree.GenerateMultiProofSequential(offset, numElements)
+		if err != nil {
+			return err
+		}
+
+		err = w.reportManager.SettleReport(
+			ctx,
+			report.OriginatorNodeID,
+			index,
+			proof,
+		)
+		if err != nil {
+			return err
+		}
+
+		offset += numElements
+		remaining -= numElements
+
+		reportLogger.Info(
+			"settled subset of report",
+			zap.Int("remaining_items", remaining),
+			zap.Int("num_settled", numElements),
+		)
+	}
+
 	return nil
 }

--- a/pkg/payerreport/workers/settlement_test.go
+++ b/pkg/payerreport/workers/settlement_test.go
@@ -1,0 +1,585 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/blockchain"
+	"github.com/xmtp/xmtpd/pkg/currency"
+	"github.com/xmtp/xmtpd/pkg/merkle"
+	blockchainMocks "github.com/xmtp/xmtpd/pkg/mocks/blockchain"
+	payerreportMocks "github.com/xmtp/xmtpd/pkg/mocks/payerreport"
+	"github.com/xmtp/xmtpd/pkg/payerreport"
+	"github.com/xmtp/xmtpd/pkg/testutils"
+)
+
+func testSettlementWorker(
+	t *testing.T,
+) (*SettlementWorker, *payerreport.Store, *blockchainMocks.MockPayerReportsManager, *payerreportMocks.MockIPayerReportVerifier) {
+	var (
+		log            = testutils.NewLog(t)
+		ctx            = t.Context()
+		db, _          = testutils.NewDB(t, ctx)
+		store          = payerreport.NewStore(db, log)
+		reportsManager = blockchainMocks.NewMockPayerReportsManager(t)
+		verifier       = payerreportMocks.NewMockIPayerReportVerifier(t)
+		myNodeID       = uint32(1)
+	)
+
+	worker := NewSettlementWorker(
+		ctx,
+		log,
+		store,
+		verifier,
+		reportsManager,
+		myNodeID,
+	)
+
+	return worker, store, reportsManager, verifier
+}
+
+// TestSettlementStatesAndTransitions covers all possible valid and invalid states for the settlement worker.
+//
+// Valid transitions:
+//
+//	(1,X) → (2,X) - SettlementWorker succeeds
+//
+// Invalid transitions:
+//
+//	(0,X) - Not submitted yet
+//	(2,X) - Already settled
+//	(3,X) - Submission rejected
+func TestSettlementStatesAndTransitions(t *testing.T) {
+	type reportState int
+	const (
+		stateSubmissionPending reportState = iota
+		stateSubmissionSubmittedNotSettled
+		stateSubmissionSubmittedAlreadySettled
+		stateSubmissionSettled
+		stateSubmissionRejected
+	)
+
+	prepareReport := func(
+		t *testing.T,
+		state reportState,
+		store payerreport.IPayerReportStore,
+		r *payerreport.PayerReportWithStatus,
+	) {
+		t.Helper()
+
+		switch state {
+		case stateSubmissionPending:
+			// Nothing to do, report is already in pending state
+
+		case stateSubmissionSubmittedNotSettled:
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
+
+		case stateSubmissionSubmittedAlreadySettled:
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
+
+		case stateSubmissionSettled:
+			require.NoError(t, store.SetReportSubmitted(t.Context(), r.ID, 0))
+			require.NoError(t, store.SetReportSettled(t.Context(), r.ID))
+
+		case stateSubmissionRejected:
+			require.NoError(t, store.SetReportSubmissionRejected(t.Context(), r.ID))
+
+		default:
+			t.Fatalf("unknown target state: %v", state)
+		}
+	}
+
+	testCases := []struct {
+		name                     string
+		state                    reportState
+		expectedSubmissionStatus payerreport.SubmissionStatus
+		alreadySettledOnChain    bool
+	}{
+		{
+			"don't settle pending report",
+			stateSubmissionPending,
+			payerreport.SubmissionPending,
+			false,
+		},
+		{
+			"settle submitted report",
+			stateSubmissionSubmittedNotSettled,
+			payerreport.SubmissionSubmitted,
+			false,
+		},
+		{
+			"settle submitted report that is already settled on chain",
+			stateSubmissionSubmittedAlreadySettled,
+			payerreport.SubmissionSubmitted,
+			true,
+		},
+		{
+			"don't settle already settled report",
+			stateSubmissionSettled,
+			payerreport.SubmissionSettled,
+			false,
+		},
+		{
+			"don't settle rejected report",
+			stateSubmissionRejected,
+			payerreport.SubmissionRejected,
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			worker, store, reportsManager, verifier := testSettlementWorker(t)
+
+			payers := map[common.Address]currency.PicoDollar{
+				common.HexToAddress("0x1"): 100,
+				common.HexToAddress("0x2"): 200,
+			}
+
+			report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+				OriginatorNodeID:    1,
+				StartSequenceID:     0,
+				EndSequenceID:       10,
+				EndMinuteSinceEpoch: 1000,
+				DomainSeparator:     domainSeparator,
+				NodeIDs:             []uint32{1, 2},
+				Payers:              payers,
+			})
+			require.NoError(t, err)
+
+			stored := storeReport(t, store, &report.PayerReport)
+			prepareReport(t, tc.state, store, stored)
+
+			if tc.state == stateSubmissionSubmittedNotSettled ||
+				tc.state == stateSubmissionSubmittedAlreadySettled {
+				verifier.EXPECT().
+					GetPayerMap(mock.Anything, mock.Anything).
+					Return(payers, nil)
+
+				if tc.alreadySettledOnChain {
+					reportsManager.EXPECT().
+						SettlementSummary(mock.Anything, uint32(1), uint64(0)).
+						Return(&blockchain.SettlementSummary{
+							Offset:    0,
+							IsSettled: true,
+						}, nil)
+				} else {
+					reportsManager.EXPECT().
+						SettlementSummary(mock.Anything, uint32(1), uint64(0)).
+						Return(&blockchain.SettlementSummary{
+							Offset:    0,
+							IsSettled: false,
+						}, nil)
+
+					reportsManager.EXPECT().
+						SettleReport(mock.Anything, uint32(1), uint64(0), mock.Anything).
+						Return(nil)
+				}
+			}
+
+			err = worker.SettleReports(t.Context())
+			require.NoError(t, err)
+
+			got, err := store.FetchReport(t.Context(), stored.ID)
+			require.NoError(t, err)
+
+			expectedFinalStatus := tc.expectedSubmissionStatus
+			if tc.state == stateSubmissionSubmittedNotSettled ||
+				tc.state == stateSubmissionSubmittedAlreadySettled {
+				expectedFinalStatus = payerreport.SubmissionSettled
+			}
+
+			require.Equal(t, expectedFinalStatus, got.SubmissionStatus)
+		})
+	}
+}
+
+func TestSettleReportWithMultipleBatches(t *testing.T) {
+	worker, store, reportsManager, verifier := testSettlementWorker(t)
+
+	// Create a report with many payers to test batching
+	payers := make(map[common.Address]currency.PicoDollar)
+	for i := range 250 {
+		// Create unique addresses
+		addr := common.BigToAddress(big.NewInt(int64(i + 1)))
+		payers[addr] = currency.PicoDollar(i + 1)
+	}
+
+	report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+		OriginatorNodeID:    1,
+		StartSequenceID:     0,
+		EndSequenceID:       10,
+		EndMinuteSinceEpoch: 1000,
+		DomainSeparator:     domainSeparator,
+		NodeIDs:             []uint32{1},
+		Payers:              payers,
+	})
+	require.NoError(t, err)
+
+	stored := storeReport(t, store, &report.PayerReport)
+	require.NoError(t, store.SetReportSubmitted(t.Context(), stored.ID, 0))
+
+	verifier.EXPECT().
+		GetPayerMap(mock.Anything, mock.Anything).
+		Return(payers, nil)
+
+	reportsManager.EXPECT().
+		SettlementSummary(mock.Anything, uint32(1), uint64(0)).
+		Return(&blockchain.SettlementSummary{
+			Offset:    0,
+			IsSettled: false,
+		}, nil)
+
+	// Expect multiple SettleReport calls due to MAX_PROOF_ELEMENTS limit
+	callCount := 0
+	reportsManager.EXPECT().
+		SettleReport(mock.Anything, uint32(1), uint64(0), mock.Anything).
+		Run(func(_ context.Context, _ uint32, _ uint64, _ *merkle.MultiProof) {
+			callCount++
+		}).
+		Return(nil).
+		Times(3) // 250 payers / 100 max = 3 batches
+
+	err = worker.SettleReports(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount)
+
+	got, err := store.FetchReport(t.Context(), stored.ID)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		payerreport.SubmissionStatus(payerreport.SubmissionSettled),
+		got.SubmissionStatus,
+	)
+}
+
+func TestSettleReportWithPartialOffset(t *testing.T) {
+	worker, store, reportsManager, verifier := testSettlementWorker(t)
+
+	payers := make(map[common.Address]currency.PicoDollar)
+	for i := range 150 {
+		// Create unique addresses
+		addr := common.BigToAddress(big.NewInt(int64(i + 1)))
+		payers[addr] = currency.PicoDollar(i + 1)
+	}
+
+	report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+		OriginatorNodeID:    1,
+		StartSequenceID:     0,
+		EndSequenceID:       10,
+		EndMinuteSinceEpoch: 1000,
+		DomainSeparator:     domainSeparator,
+		NodeIDs:             []uint32{1},
+		Payers:              payers,
+	})
+	require.NoError(t, err)
+
+	stored := storeReport(t, store, &report.PayerReport)
+	require.NoError(t, store.SetReportAttestationApproved(t.Context(), stored.ID))
+	require.NoError(t, store.SetReportSubmitted(t.Context(), stored.ID, 0))
+
+	verifier.EXPECT().
+		GetPayerMap(mock.Anything, mock.Anything).
+		Return(payers, nil)
+
+	// Settlement already partially completed (first 100 elements done)
+	reportsManager.EXPECT().
+		SettlementSummary(mock.Anything, uint32(1), uint64(0)).
+		Return(&blockchain.SettlementSummary{
+			Offset:    100,
+			IsSettled: false,
+		}, nil)
+
+	// Only expect one call for remaining 50 elements
+	reportsManager.EXPECT().
+		SettleReport(mock.Anything, uint32(1), uint64(0), mock.Anything).
+		Return(nil).
+		Once()
+
+	err = worker.SettleReports(t.Context())
+	require.NoError(t, err)
+
+	got, err := store.FetchReport(t.Context(), stored.ID)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		payerreport.SubmissionStatus(payerreport.SubmissionSettled),
+		got.SubmissionStatus,
+	)
+}
+
+func TestSettleReportErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setupMocks    func(*blockchainMocks.MockPayerReportsManager, *payerreportMocks.MockIPayerReportVerifier)
+		expectError   bool
+		expectedState payerreport.SubmissionStatus
+	}{
+		{
+			name: "error getting payer map",
+			setupMocks: func(rm *blockchainMocks.MockPayerReportsManager, v *payerreportMocks.MockIPayerReportVerifier) {
+				v.EXPECT().
+					GetPayerMap(mock.Anything, mock.Anything).
+					Return(payerreport.PayerMap(nil), errors.New("payer map error"))
+			},
+			expectError:   true,
+			expectedState: payerreport.SubmissionSubmitted,
+		},
+		{
+			name: "error getting settlement summary",
+			setupMocks: func(rm *blockchainMocks.MockPayerReportsManager, v *payerreportMocks.MockIPayerReportVerifier) {
+				v.EXPECT().
+					GetPayerMap(mock.Anything, mock.Anything).
+					Return(payerreport.PayerMap{common.HexToAddress("0x1"): 100}, nil)
+
+				rm.EXPECT().
+					SettlementSummary(mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, errors.New("settlement summary error"))
+			},
+			expectError:   true,
+			expectedState: payerreport.SubmissionSubmitted,
+		},
+		{
+			name: "error settling report",
+			setupMocks: func(rm *blockchainMocks.MockPayerReportsManager, v *payerreportMocks.MockIPayerReportVerifier) {
+				v.EXPECT().
+					GetPayerMap(mock.Anything, mock.Anything).
+					Return(payerreport.PayerMap{common.HexToAddress("0x1"): 100}, nil)
+
+				rm.EXPECT().
+					SettlementSummary(mock.Anything, mock.Anything, mock.Anything).
+					Return(&blockchain.SettlementSummary{Offset: 0, IsSettled: false}, nil)
+
+				rm.EXPECT().
+					SettleReport(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.New("settle error"))
+			},
+			expectError:   true,
+			expectedState: payerreport.SubmissionSubmitted,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			worker, store, reportsManager, verifier := testSettlementWorker(t)
+
+			payers := map[common.Address]currency.PicoDollar{
+				common.HexToAddress("0x1"): 100,
+			}
+
+			report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+				OriginatorNodeID:    1,
+				StartSequenceID:     0,
+				EndSequenceID:       10,
+				EndMinuteSinceEpoch: 1000,
+				DomainSeparator:     domainSeparator,
+				NodeIDs:             []uint32{1},
+				Payers:              payers,
+			})
+			require.NoError(t, err)
+
+			stored := storeReport(t, store, &report.PayerReport)
+			require.NoError(t, store.SetReportAttestationApproved(t.Context(), stored.ID))
+			require.NoError(t, store.SetReportSubmitted(t.Context(), stored.ID, 0))
+
+			tc.setupMocks(reportsManager, verifier)
+
+			err = worker.SettleReports(t.Context())
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			got, err := store.FetchReport(t.Context(), stored.ID)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedState, got.SubmissionStatus)
+		})
+	}
+}
+
+func TestSettleReportWithNilIndex(t *testing.T) {
+	worker, store, _, _ := testSettlementWorker(t)
+
+	payers := map[common.Address]currency.PicoDollar{
+		common.HexToAddress("0x1"): 100,
+	}
+
+	report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+		OriginatorNodeID:    1,
+		StartSequenceID:     0,
+		EndSequenceID:       10,
+		EndMinuteSinceEpoch: 1000,
+		DomainSeparator:     domainSeparator,
+		NodeIDs:             []uint32{1},
+		Payers:              payers,
+	})
+	require.NoError(t, err)
+
+	stored := storeReport(t, store, &report.PayerReport)
+
+	// Manually fetch and settle without setting SubmittedReportIndex
+	reportWithStatus, err := store.FetchReport(t.Context(), stored.ID)
+	require.NoError(t, err)
+	require.Nil(t, reportWithStatus.SubmittedReportIndex)
+
+	// Try to settle with nil index
+	err = worker.settleReport(t.Context(), reportWithStatus)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "report index is nil")
+}
+
+func TestSettleMultipleReports(t *testing.T) {
+	worker, store, reportsManager, verifier := testSettlementWorker(t)
+
+	// Create multiple reports
+	reports := make([]*payerreport.PayerReportWithInputs, 3)
+	for i := range 3 {
+		payers := map[common.Address]currency.PicoDollar{
+			common.HexToAddress("0x1"): currency.PicoDollar(100 * (i + 1)),
+		}
+
+		report, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+			OriginatorNodeID:    1,
+			StartSequenceID:     uint64(i * 10),
+			EndSequenceID:       uint64((i + 1) * 10),
+			EndMinuteSinceEpoch: uint32(1000 + i),
+			DomainSeparator:     domainSeparator,
+			NodeIDs:             []uint32{1},
+			Payers:              payers,
+		})
+		require.NoError(t, err)
+
+		reports[i] = report
+		stored := storeReport(t, store, &report.PayerReport)
+		require.NoError(t, store.SetReportAttestationApproved(t.Context(), stored.ID))
+		require.NoError(t, store.SetReportSubmitted(t.Context(), stored.ID, int32(i)))
+
+		verifier.EXPECT().
+			GetPayerMap(mock.Anything, mock.Anything).
+			Return(payers, nil)
+
+		reportsManager.EXPECT().
+			SettlementSummary(mock.Anything, uint32(1), uint64(i)).
+			Return(&blockchain.SettlementSummary{
+				Offset:    0,
+				IsSettled: false,
+			}, nil)
+
+		reportsManager.EXPECT().
+			SettleReport(mock.Anything, uint32(1), uint64(i), mock.Anything).
+			Return(nil)
+	}
+
+	err := worker.SettleReports(t.Context())
+	require.NoError(t, err)
+
+	// Verify all reports are settled
+	for _, report := range reports {
+		got, err := store.FetchReport(t.Context(), report.ID)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			payerreport.SubmissionStatus(payerreport.SubmissionSettled),
+			got.SubmissionStatus,
+		)
+	}
+}
+
+func TestSettleReportsWithPartialFailure(t *testing.T) {
+	worker, store, reportsManager, verifier := testSettlementWorker(t)
+
+	// Create two reports, first will fail, second will succeed
+	payers1 := map[common.Address]currency.PicoDollar{
+		common.HexToAddress("0x1"): 100,
+	}
+	report1, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+		OriginatorNodeID:    1,
+		StartSequenceID:     0,
+		EndSequenceID:       10,
+		EndMinuteSinceEpoch: 1000,
+		DomainSeparator:     domainSeparator,
+		NodeIDs:             []uint32{1},
+		Payers:              payers1,
+	})
+	require.NoError(t, err)
+	stored1 := storeReport(t, store, &report1.PayerReport)
+	require.NoError(t, store.SetReportAttestationApproved(t.Context(), stored1.ID))
+	require.NoError(t, store.SetReportSubmitted(t.Context(), stored1.ID, 0))
+	// Make sure the created_at is different between the two reports
+	time.Sleep(1 * time.Millisecond)
+
+	payers2 := map[common.Address]currency.PicoDollar{
+		common.HexToAddress("0x2"): 200,
+	}
+	report2, err := payerreport.BuildPayerReport(payerreport.BuildPayerReportParams{
+		OriginatorNodeID:    2,
+		StartSequenceID:     10,
+		EndSequenceID:       20,
+		EndMinuteSinceEpoch: 2000,
+		DomainSeparator:     domainSeparator,
+		NodeIDs:             []uint32{1},
+		Payers:              payers2,
+	})
+	require.NoError(t, err)
+	stored2 := storeReport(t, store, &report2.PayerReport)
+	require.NoError(t, store.SetReportAttestationApproved(t.Context(), stored2.ID))
+	require.NoError(t, store.SetReportSubmitted(t.Context(), stored2.ID, 1))
+
+	// Reports are processed in database order, so we need to set up expectations for both
+	// First report (index 0) will fail on GetPayerMap
+	verifier.EXPECT().
+		GetPayerMap(mock.Anything, mock.MatchedBy(func(report *payerreport.PayerReport) bool {
+			return report.OriginatorNodeID == 1
+		})).
+		Return(payerreport.PayerMap(nil), errors.New("verifier error")).
+		Once()
+
+	// Second report (index 1) will succeed
+	verifier.EXPECT().
+		GetPayerMap(mock.Anything, mock.MatchedBy(func(report *payerreport.PayerReport) bool {
+			return report.OriginatorNodeID == 2
+		})).
+		Return(payers2, nil).
+		Once()
+
+	// We need to accept either index 0 or 1 for settlement summary since database order is not guaranteed
+	reportsManager.EXPECT().
+		SettlementSummary(mock.Anything, uint32(2), mock.Anything).
+		Return(&blockchain.SettlementSummary{
+			Offset:    0,
+			IsSettled: false,
+		}, nil).
+		Maybe()
+
+	reportsManager.EXPECT().
+		SettleReport(mock.Anything, uint32(2), mock.Anything, mock.Anything).
+		Return(nil).
+		Maybe()
+
+	err = worker.SettleReports(t.Context())
+	require.Error(t, err) // Should return the latest error
+	// First report should still be submitted
+	got1, err := store.FetchReport(t.Context(), stored1.ID)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		payerreport.SubmissionStatus(payerreport.SubmissionSubmitted),
+		got1.SubmissionStatus,
+	)
+
+	// Second report should be settled
+	got2, err := store.FetchReport(t.Context(), stored2.ID)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		payerreport.SubmissionStatus(payerreport.SubmissionSettled),
+		got2.SubmissionStatus,
+	)
+}

--- a/pkg/utils/number.go
+++ b/pkg/utils/number.go
@@ -34,3 +34,10 @@ func Uint32FromBytes(b []byte) (uint32, error) {
 	}
 	return binary.LittleEndian.Uint32(b), nil
 }
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
### TL;DR

Added support for settling payer reports on-chain by implementing the settlement worker and related blockchain interfaces.

### What changed?

- Added `SettleReport` and `SettlementSummary` methods to the `PayerReportsManager` interface
- Implemented these methods in the blockchain package to interact with smart contracts
- Added a `SettlementSummary` struct to track settlement status
- Enhanced the `PayerReport` struct to include the submitted report index
- Implemented the settlement worker logic to process reports in batches
- Added `GetPayerMap` method to the report verifier interface
- Created helper functions to prepare merkle proofs for on-chain settlement
- Updated mocks to support the new interfaces

### How to test?

- Run the integration test `TestFullReportLifecycle` which now includes settlement verification
- The test verifies that reports can be generated, attested, submitted, and settled
- After settlement, the test checks that the report is marked as settled both in the database and on-chain

### Why make this change?

This change completes the payer report lifecycle by adding the final settlement step. After reports are submitted to the blockchain, they need to be settled by providing merkle proofs for the payers. This allows the smart contract to verify and process payments for message delivery. The implementation supports batched settlement to handle large reports efficiently.