### PR TITLE
Link together workers with a channel

### DIFF
--- a/pkg/payerreport/workers/runner.go
+++ b/pkg/payerreport/workers/runner.go
@@ -173,6 +173,8 @@ func (w *WorkerWrapper) Stop() {
 // The configuration should be created using NewWorkerConfigBuilder().Build().
 // Returns a WorkerWrapper that can be used to stop all workers.
 func RunWorkers(cfg workerConfig) *WorkerWrapper {
+	submissionNotifyCh := make(chan struct{}, 1)
+
 	attestationWorker := NewAttestationWorker(
 		cfg.ctx,
 		cfg.log,
@@ -200,6 +202,7 @@ func RunWorkers(cfg workerConfig) *WorkerWrapper {
 		cfg.registry,
 		cfg.reportsManager,
 		cfg.registrant.NodeID(),
+		submissionNotifyCh,
 	)
 
 	settlementWorker := NewSettlementWorker(
@@ -209,6 +212,7 @@ func RunWorkers(cfg workerConfig) *WorkerWrapper {
 		payerreport.NewPayerReportVerifier(cfg.log, cfg.store),
 		cfg.reportsManager,
 		cfg.registrant.NodeID(),
+		submissionNotifyCh,
 	)
 
 	attestationWorker.Start()

--- a/pkg/payerreport/workers/settlement_test.go
+++ b/pkg/payerreport/workers/settlement_test.go
@@ -32,6 +32,7 @@ func testSettlementWorker(
 		myNodeID       = uint32(1)
 	)
 
+	submissionNotifyCh := make(chan struct{}, 10)
 	worker := NewSettlementWorker(
 		ctx,
 		log,
@@ -39,6 +40,7 @@ func testSettlementWorker(
 		verifier,
 		reportsManager,
 		myNodeID,
+		submissionNotifyCh,
 	)
 
 	return worker, store, reportsManager, verifier

--- a/pkg/payerreport/workers/submitter_test.go
+++ b/pkg/payerreport/workers/submitter_test.go
@@ -43,6 +43,7 @@ func testSubmitterWorker(
 
 	mockRegistrant.EXPECT().NodeID().Return(uint32(1)).Maybe()
 
+	submissionNotifyCh := make(chan struct{}, 10)
 	worker := NewSubmitterWorker(
 		ctx,
 		log,
@@ -50,6 +51,7 @@ func testSubmitterWorker(
 		registry,
 		reportsManager,
 		myNodeID,
+		submissionNotifyCh,
 	)
 
 	return worker, store, reportsManager


### PR DESCRIPTION
### TL;DR

Added a notification channel between the SubmitterWorker and SettlementWorker to trigger immediate settlement after report submission.

### What changed?

- Added a `submissionNotifyCh` channel to both the `SubmitterWorker` and `SettlementWorker` to enable communication between them
- Modified the `SubmitterWorker` to notify the `SettlementWorker` after successfully submitting reports
- Updated the `SettlementWorker` to listen for notifications and immediately process settlements when notified
- Updated the `RunWorkers` function to create and pass the notification channel to both workers
- Modified integration tests to accommodate these changes

### How to test?

Run the integration tests to verify that the settlement process is triggered immediately after submission:

```
go test -v ./pkg/payerreport/workers/...
```

### Why make this change?

This change improves the responsiveness of the settlement process. Previously, the `SettlementWorker` would only check for reports to settle on a fixed schedule. Now, it will immediately process settlements when notified that new reports have been submitted, reducing latency in the report lifecycle while maintaining the scheduled checks as a fallback.