### PR TITLE
Acquire HA generator lock

### DIFF
--- a/pkg/db/advisory_lock.go
+++ b/pkg/db/advisory_lock.go
@@ -18,7 +18,7 @@ const (
 	LockKindIdentityUpdateInsert LockKind = 0x00
 	LockKindAttestationWorker    LockKind = 0x01
 	LockKindSubmitterWorker      LockKind = 0x02
-	LockKindGeneratorWorker		LockKind = 0x04
+	LockKindGeneratorWorker      LockKind = 0x04
 )
 
 // AdvisoryLocker builds advisory-lock keys and acquires locks using the caller’s
@@ -79,7 +79,6 @@ type TransactionScopedAdvisoryLocker struct {
 }
 
 var _ ITransactionScopedAdvisoryLocker = (*TransactionScopedAdvisoryLocker)(nil)
-
 
 func NewTransactionScopedAdvisoryLocker(
 	ctx context.Context,

--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -107,7 +107,6 @@ func (w *GeneratorWorker) GenerateReports() error {
 		return err
 	}
 
-
 	w.log.Info("getting nodes from registry", zap.Any("registry", w.registry))
 	allNodes, err := w.registry.GetNodes()
 	if err != nil {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Acquire a high-availability generator worker advisory lock by adding `db.LockKindGeneratorWorker` with value `0x04` and invoking `payerreport.workers.GeneratorWorker.GenerateReports` to take the lock before report generation in [generator.go](https://github.com/xmtp/xmtpd/pull/1247/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e)
This change introduces a new advisory lock kind and methods to acquire it, and updates the generator worker to obtain the lock before generating reports. It adds the `db.LockKindGeneratorWorker` constant with value `0x04`, extends the advisory locker interfaces and implementations to support `LockGeneratorWorker`, and modifies `payerreport.workers.GeneratorWorker.GenerateReports` to acquire and release the transaction-scoped lock around its work.

- Update advisory lock constants and APIs in [advisory_lock.go](https://github.com/xmtp/xmtpd/pull/1247/files#diff-63dd2a5931a050ddb7ee8248bc816aad292dab7bf77ab6124a6fbdddb6f85965) by adding `db.LockKindGeneratorWorker` (`0x04`) and implementing `db.AdvisoryLocker.LockGeneratorWorker` and `db.TransactionScopedAdvisoryLocker.LockGeneratorWorker` using `queries.AdvisoryLockWithKey`.
- Modify [generator.go](https://github.com/xmtp/xmtpd/pull/1247/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e) to retrieve a transaction-scoped advisory locker via `w.store.GetAdvisoryLocker(w.ctx)`, defer `Release`, and call `LockGeneratorWorker()` before fetching nodes and iterating.

#### 📍Where to Start
Start with the `payerreport.workers.GeneratorWorker.GenerateReports` method in [generator.go](https://github.com/xmtp/xmtpd/pull/1247/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e), then review the lock kind and locker methods in [advisory_lock.go](https://github.com/xmtp/xmtpd/pull/1247/files#diff-63dd2a5931a050ddb7ee8248bc816aad292dab7bf77ab6124a6fbdddb6f85965).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 07f4943. 2 files reviewed, 3 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/db/advisory_lock.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 99](https://github.com/xmtp/xmtpd/blob/07f4943c1764acfb894f9c4ea1f09d2fd59bf6a0/pkg/db/advisory_lock.go#L99): `TransactionScopedAdvisoryLocker.Release()` always calls `tx.Rollback()` even on successful paths. While this releases a transaction-scoped advisory lock, if any writes are accidentally performed within the same transaction in future changes, they would be silently discarded. Given the current code confines the transaction to advisory lock acquisition, this works, but it couples correctness to a fragile assumption. Consider constraining the transaction strictly to advisory lock acquisition (and avoid using it for any other operations) or using a connection-level/session-level advisory lock to decouple from transaction semantics. At minimum, document that the transaction must not be used for any writes. <b>[ Low confidence ]</b>
</details>

<details>
<summary>pkg/payerreport/workers/generator.go — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 96](https://github.com/xmtp/xmtpd/blob/07f4943c1764acfb894f9c4ea1f09d2fd59bf6a0/pkg/payerreport/workers/generator.go#L96): GenerateReports holds a transaction-scoped advisory lock (and thus an open database transaction/connection) across non-database work, including registry access and per-node processing. The lock is acquired at the start via `GetAdvisoryLocker` and `LockGeneratorWorker`, and only released at function end via deferred `Release()` (rollback). This keeps a DB connection checked out for the entire duration of `registry.GetNodes()` and the loop over `allNodes` calling `maybeGenerateReport`. If these operations are slow or the node count is large, it can starve the DB connection pool and block other operations, causing timeouts or deadlocks. Advisory locks that are transaction-scoped should be held for the minimal critical section necessary to make a decision; otherwise, use a dedicated session-scoped advisory lock on a separate connection or restructure to acquire/release around a shorter critical section. <b>[ Low confidence ]</b>
- [line 101](https://github.com/xmtp/xmtpd/blob/07f4943c1764acfb894f9c4ea1f09d2fd59bf6a0/pkg/payerreport/workers/generator.go#L101): Errors from `Release()` are ignored in `GenerateReports` (`defer func(){ _ = haLock.Release() }()`). If the rollback fails (e.g., connection error) the transaction might not be closed cleanly, potentially leaking resources or leaving the lock state uncertain. At minimum, log the error; ideally, ensure the transaction is deterministically closed and the error is surfaced or handled. While `sql.Tx.Rollback()` commonly returns `sql.ErrTxDone` if already completed, ignoring all errors obscures real failures. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->