### PR TITLE
Add Redis rate limiter

### DIFF
--- a/pkg/ratelimiter/README.md
+++ b/pkg/ratelimiter/README.md
@@ -1,0 +1,222 @@
+# Rate Limiter
+
+A Redis-backed token bucket rate limiter that supports multiple concurrent limits with atomic operations.
+
+## Features
+
+- **Token Bucket Algorithm**: Continuously refilling token buckets with configurable capacity and refill rates
+- **Multiple Concurrent Limits**: Check multiple rate limits atomically (e.g., per-minute and per-hour limits)
+- **Atomic Operations**: All limits are checked and decremented atomically - if any limit fails, none are decremented
+- **Variable Cost**: Support for requests with different costs (e.g., batch operations)
+- **Retry-After Calculation**: Automatically calculates when a blocked request can be retried
+- **Subject Isolation**: Each subject (user, IP, etc.) has independent rate limit tracking
+- **TTL Management**: Keys automatically expire based on refill periods to minimize Redis memory usage
+
+## Usage
+
+### Basic Example
+
+```go
+import (
+    "context"
+    "time"
+
+    "github.com/redis/go-redis/v9"
+    "github.com/xmtp/xmtpd/pkg/ratelimiter"
+    "go.uber.org/zap"
+)
+
+// Create a Redis client
+client := redis.NewClient(&redis.Options{
+    Addr: "localhost:6379",
+})
+
+// Define rate limits
+limits := []ratelimiter.Limit{
+    {
+        Capacity:    10,              // 10 requests
+        RefillEvery: time.Minute,     // per minute
+    },
+    {
+        Capacity:    100,             // 100 requests
+        RefillEvery: time.Hour,       // per hour
+    },
+}
+
+// Create the rate limiter
+logger := zap.NewNop()
+limiter, err := ratelimiter.NewRedisLimiter(
+    logger,
+    client,
+    "myapp:ratelimit",  // Redis key prefix
+    limits,
+)
+if err != nil {
+    panic(err)
+}
+
+// Check if a request is allowed
+ctx := context.Background()
+result, err := limiter.Allow(ctx, "user:123", 1)
+if err != nil {
+    panic(err)
+}
+
+if result.Allowed {
+    // Process the request
+    fmt.Println("Request allowed")
+    for i, balance := range result.Balances {
+        fmt.Printf("Limit %d: %.2f tokens remaining\n", i, balance.Remaining)
+    }
+} else {
+    // Reject the request
+    fmt.Printf("Request blocked by limit: %+v\n", result.FailedLimit)
+    if result.RetryAfter != nil {
+        fmt.Printf("Retry after: %v\n", *result.RetryAfter)
+    }
+}
+```
+
+### Variable Cost Requests
+
+For requests that consume multiple tokens (e.g., batch operations):
+
+```go
+// A batch request that costs 5 tokens
+result, err := limiter.Allow(ctx, "user:123", 5)
+```
+
+### Handling Rate Limit Responses
+
+The `Result` struct provides information about the rate limit check:
+
+```go
+type Result struct {
+    Allowed     bool                // Whether the request is allowed
+    FailedLimit *Limit              // The limit that was exceeded (nil if allowed)
+    RetryAfter  *time.Duration      // Time until retry is possible (nil if allowed)
+    Balances    []LimitBalance      // Current balance for each limit
+}
+
+type LimitBalance struct {
+    Limit     Limit      // The limit configuration
+    Remaining float64    // Remaining tokens after this check
+}
+```
+
+## How It Works
+
+### Token Bucket Algorithm
+
+Each limit operates as a token bucket:
+
+1. **Initial State**: Bucket starts full with `Capacity` tokens
+2. **Request Processing**: Each request consumes `cost` tokens
+3. **Refill**: Tokens continuously refill at a rate of `Capacity / RefillEvery`
+4. **Blocking**: If insufficient tokens are available, the request is blocked
+
+**Example:**
+- Limit: 10 tokens per second
+- Refill rate: 10 tokens / 1000ms = 0.01 tokens/ms = 1 token per 100ms
+- If 7 tokens remain and a request costs 5 tokens:
+  - After success: 2 tokens remain
+  - After 800ms: 10 tokens available (bucket is full)
+
+### Atomic Multi-Limit Checking
+
+When multiple limits are configured, all limits are checked atomically:
+
+1. Check all limits to ensure sufficient tokens
+2. If **any** limit fails, **no** tokens are decremented
+3. If **all** limits pass, **all** tokens are decremented
+
+This ensures consistent state across all limits.
+
+### Retry-After Calculation
+
+When a request is blocked, `RetryAfter` tells you how long to wait:
+
+```
+RetryAfter = (tokens_needed - tokens_available) × (RefillEvery / Capacity)
+```
+
+The duration is capped at `RefillEvery` since the bucket can never exceed its capacity.
+
+**Example:**
+- Limit: 10 tokens per second
+- Available: 3 tokens
+- Cost: 5 tokens
+- Calculation: (5 - 3) × (1000ms / 10) = 2 × 100ms = 200ms
+
+### Redis Key Management
+
+Keys are automatically managed with TTLs:
+
+- **Timestamp key** (`prefix:subject:ts`): Expires after the longest `RefillEvery`
+- **Limit keys** (`prefix:subject:1`, `prefix:subject:2`, etc.): Expire based on time to refill to capacity
+
+This ensures Redis memory is automatically cleaned up for inactive subjects.
+
+## Performance Considerations
+
+### Redis Operations
+
+Each `Allow()` call executes a single Lua script in Redis:
+- **O(n)** complexity where n = number of limits
+- Atomic execution (no race conditions)
+- Typically completes in < 1ms
+
+### Memory Usage
+
+Redis memory usage depends on the number of keys and values stored. Each subject creates:
+- 1 timestamp key
+- N limit keys (where N = number of configured limits)
+
+**Calculation for keyPrefix="rl", subject="192.168.1.1" (IPv4), 2 limits:**
+
+Keys and values per subject:
+1. `rl:192.168.1.1:ts` → `1735689600000` (13-byte timestamp)
+2. `rl:192.168.1.1:1` → `7.5` (floating point, ~3-4 bytes)
+3. `rl:192.168.1.1:2` → `95.0` (floating point, ~4 bytes)
+
+**Memory overhead per key:**
+Redis (v7+) with jemalloc allocator has significant per-key overhead:
+- Redis object header: ~16 bytes
+- String metadata (SDS): ~8 bytes
+- Dict entry: ~24 bytes (can be 32-40 bytes with jemalloc alignment)
+- **Base overhead per key: ~64 bytes** (before key/value data)
+
+**Per-key calculation (approximate):**
+- Timestamp key: 64 (overhead) + 18 (key) + 13 (value) = **~95 bytes**
+- Limit key 1: 64 (overhead) + 16 (key) + 3 (value) = **~83 bytes**
+- Limit key 2: 64 (overhead) + 16 (key) + 4 (value) = **~84 bytes**
+- **Total per subject: ~262 bytes**
+
+**For 10,000 active IPv4 subjects with 2 limits:**
+- 10,000 × 262 bytes = **~2.62 MB**
+```
+
+**Notes:**
+- Keys automatically expire based on inactivity, so memory usage reflects only active subjects
+
+## Implementation Details
+
+### Lua Script
+
+The rate limiter uses a single Lua script (`script.lua`) for atomic operations:
+1. Read current timestamp and token balances
+2. Calculate refilled tokens based on elapsed time
+3. Check if all limits have sufficient tokens
+4. If yes: decrement all limits and return success
+5. If no: return failure with the first failing limit
+
+### Token Precision
+
+Tokens are stored and calculated as floating-point numbers to support:
+- Sub-second refill rates (e.g., 1 token per 100ms)
+- Precise remaining token counts
+- Accurate Retry-After calculations
+
+## License
+
+See the root LICENSE file for license information.

--- a/pkg/ratelimiter/errors.go
+++ b/pkg/ratelimiter/errors.go
@@ -1,0 +1,10 @@
+package ratelimiter
+
+import "errors"
+
+var (
+	ErrCostMustBeGreaterThanZero = errors.New("cost must be > 0")
+	ErrUnexpectedScriptResponse  = errors.New("unexpected script response")
+	ErrNoLimitsProvided          = errors.New("no limits provided")
+	ErrInvalidFailedLimit        = errors.New("invalid failed limit")
+)

--- a/pkg/ratelimiter/interface.go
+++ b/pkg/ratelimiter/interface.go
@@ -1,0 +1,27 @@
+package ratelimiter
+
+import (
+	"context"
+	"time"
+)
+
+type Limit struct {
+	Capacity    int           // Maximum number of tokens in the bucket (e.g. 10)
+	RefillEvery time.Duration // Time to fully refill the bucket from 0 to Capacity (e.g. 1 * time.Minute)
+}
+
+type LimitBalance struct {
+	Limit     Limit
+	Remaining float64 // remaining tokens
+}
+
+type Result struct {
+	Allowed     bool
+	FailedLimit *Limit         // The limit that was exceeded (nil if allowed)
+	RetryAfter  *time.Duration // Time until the failed limit will allow the request (nil if allowed)
+	Balances    []LimitBalance // remaining tokens after this check (post-decrement on success; current on reject)
+}
+
+type RateLimiter interface {
+	Allow(ctx context.Context, subject string, cost uint64) (*Result, error)
+}

--- a/pkg/ratelimiter/redis_limiter.go
+++ b/pkg/ratelimiter/redis_limiter.go
@@ -1,0 +1,200 @@
+package ratelimiter
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+//go:embed script.lua
+var luaScript string
+
+type RedisLimiter struct {
+	client    redis.UniversalClient
+	script    *redis.Script
+	keyPrefix string
+	log       *zap.Logger
+	limits    []Limit
+}
+
+func NewRedisLimiter(
+	log *zap.Logger,
+	client redis.UniversalClient,
+	keyPrefix string,
+	limits []Limit,
+) (*RedisLimiter, error) {
+	if err := validateLimits(limits); err != nil {
+		return nil, err
+	}
+
+	return &RedisLimiter{
+		client:    client,
+		script:    redis.NewScript(luaScript),
+		keyPrefix: keyPrefix,
+		log:       log,
+		limits:    limits,
+	}, nil
+}
+
+func (l *RedisLimiter) baseKey(subject string) string {
+	return fmt.Sprintf("%s:%s", l.keyPrefix, subject)
+}
+
+func (l *RedisLimiter) buildKeys(subject string) []string {
+	baseKey := l.baseKey(subject)
+	// First key is timestamp, then one key per limit
+	keys := make([]string, 1+len(l.limits))
+	keys[0] = fmt.Sprintf("%s:ts", baseKey)
+	for i := range l.limits {
+		keys[i+1] = fmt.Sprintf("%s:%d", baseKey, i+1)
+	}
+	return keys
+}
+
+func (l *RedisLimiter) buildArgs(requestTime time.Time, cost uint64) []any {
+	args := make([]interface{}, 0, 3+len(l.limits)*2)
+	args = append(args, requestTime.UnixMilli(), len(l.limits), cost)
+	for _, lim := range l.limits {
+		args = append(args, lim.Capacity, lim.RefillEvery.Milliseconds())
+	}
+
+	return args
+}
+
+func (l *RedisLimiter) Allow(ctx context.Context, subject string, cost uint64) (*Result, error) {
+	if cost == 0 {
+		return nil, ErrCostMustBeGreaterThanZero
+	}
+	now := time.Now()
+	keys := l.buildKeys(subject)
+	args := l.buildArgs(now, cost)
+
+	raw, err := l.script.Run(ctx, l.client, keys, args...).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	arr, ok := raw.([]any)
+	if !ok || len(arr) < 1 {
+		return nil, ErrUnexpectedScriptResponse
+	}
+
+	res, err := l.transformResult(arr, cost)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (l *RedisLimiter) transformResult(arr []any, cost uint64) (*Result, error) {
+	var err error
+
+	allowed := arr[0].(int64) == 1
+	res := &Result{
+		Allowed: allowed,
+	}
+
+	if allowed {
+		// {1, rem1, rem2, ...}
+		if res.Balances, err = l.parseBalances(arr[1:]); err != nil {
+			return nil, err
+		}
+	} else {
+		// {0, failed_index, rem1, rem2, ...}
+		if len(arr) != 2+len(l.limits) {
+			return nil, ErrUnexpectedScriptResponse
+		}
+
+		failedIndex := int(arr[1].(int64)) - 1 // Convert from 1-based to 0-based
+		// Make sure the failed index is within bounds
+		if failedIndex < 0 || failedIndex >= len(l.limits) {
+			return nil, ErrInvalidFailedLimit
+		}
+
+		limit := l.limits[failedIndex]
+		res.FailedLimit = &limit
+
+		// Calculate how long until the limit refills enough for this request
+		remaining := toFloat(arr[2+failedIndex])
+		res.RetryAfter = calculateRetryAfter(limit, remaining, cost)
+
+		if res.Balances, err = l.parseBalances(arr[2:]); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
+func (l *RedisLimiter) parseBalances(arr []any) ([]LimitBalance, error) {
+	if len(arr) != len(l.limits) {
+		return nil, ErrUnexpectedScriptResponse
+	}
+
+	balances := make([]LimitBalance, len(l.limits))
+	for i := range l.limits {
+		balances[i] = LimitBalance{
+			Limit:     l.limits[i],
+			Remaining: toFloat(arr[i]),
+		}
+	}
+	return balances, nil
+}
+
+func validateLimits(limits []Limit) error {
+	if len(limits) == 0 {
+		return ErrNoLimitsProvided
+	}
+
+	for i, lim := range limits {
+		if lim.Capacity <= 0 || lim.RefillEvery <= 0 {
+			return fmt.Errorf("invalid limit at index %d", i)
+		}
+	}
+
+	return nil
+}
+
+func toFloat(v any) float64 {
+	switch t := v.(type) {
+	case float64:
+		return t
+	case string:
+		f, _ := strconv.ParseFloat(t, 64)
+		return f
+	case int64:
+		return float64(t)
+	default:
+		return 0
+	}
+}
+
+// calculateRetryAfter computes the duration until a limit will have enough tokens
+// for a request with the given cost to succeed.
+// The returned duration is capped at RefillEvery since that's when the bucket is full.
+func calculateRetryAfter(limit Limit, remaining float64, cost uint64) *time.Duration {
+	tokensNeeded := float64(cost) - remaining
+	if tokensNeeded <= 0 {
+		return nil
+	}
+
+	// Cap tokens needed at capacity, since the bucket can't hold more
+	if tokensNeeded > float64(limit.Capacity) {
+		tokensNeeded = float64(limit.Capacity)
+	}
+
+	// Time to refill = (tokens_needed / capacity) * refill_every
+	refillRate := float64(limit.RefillEvery.Nanoseconds()) / float64(limit.Capacity)
+	retryAfterNanos := tokensNeeded * refillRate
+
+	// RetryAfter cannot be longer than the time it takes to refill the bucket
+	retryAfter := min(time.Duration(retryAfterNanos), limit.RefillEvery)
+
+	return &retryAfter
+}

--- a/pkg/ratelimiter/redis_limiter_test.go
+++ b/pkg/ratelimiter/redis_limiter_test.go
@@ -1,0 +1,643 @@
+package ratelimiter_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/ratelimiter"
+	redistestutils "github.com/xmtp/xmtpd/pkg/testutils/redis"
+	"go.uber.org/zap"
+)
+
+func TestRedisLimiter_BasicLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		limits    []ratelimiter.Limit
+		requests  []uint64
+		wantAllow []bool
+	}{
+		{
+			name:      "single limit allows within capacity",
+			limits:    []ratelimiter.Limit{{Capacity: 10, RefillEvery: time.Minute}},
+			requests:  []uint64{5, 5},
+			wantAllow: []bool{true, true},
+		},
+		{
+			name:      "single limit blocks over capacity",
+			limits:    []ratelimiter.Limit{{Capacity: 10, RefillEvery: time.Minute}},
+			requests:  []uint64{10, 1},
+			wantAllow: []bool{true, false},
+		},
+		{
+			name: "multiple limits all pass",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Minute},
+				{Capacity: 100, RefillEvery: time.Hour},
+			},
+			requests:  []uint64{5, 5},
+			wantAllow: []bool{true, true},
+		},
+		{
+			name: "first limit blocks",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Minute},
+				{Capacity: 100, RefillEvery: time.Hour},
+			},
+			requests:  []uint64{10, 1},
+			wantAllow: []bool{true, false},
+		},
+		{
+			name: "second limit blocks",
+			limits: []ratelimiter.Limit{
+				{Capacity: 100, RefillEvery: time.Hour},
+				{Capacity: 10, RefillEvery: time.Minute},
+			},
+			requests:  []uint64{10, 1},
+			wantAllow: []bool{true, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, keyPrefix := redistestutils.NewRedisForTest(t)
+			logger := zap.NewNop()
+			limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix, tt.limits)
+			require.NoError(t, err)
+
+			for i, cost := range tt.requests {
+				res, err := limiter.Allow(context.Background(), "test-subject", cost)
+				require.NoError(t, err)
+				require.Equal(t, tt.wantAllow[i], res.Allowed, "request %d", i)
+			}
+		})
+	}
+}
+
+func TestRedisLimiter_Atomicity(t *testing.T) {
+	tests := []struct {
+		name               string
+		limits             []ratelimiter.Limit
+		cost               uint64
+		wantAllow          bool
+		wantRemaining      []float64
+		wantFailedLimitIdx *int
+	}{
+		{
+			name: "all limits pass - all decremented",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Minute},
+				{Capacity: 20, RefillEvery: time.Minute},
+			},
+			cost:               5,
+			wantAllow:          true,
+			wantRemaining:      []float64{5, 15},
+			wantFailedLimitIdx: nil,
+		},
+		{
+			name: "first limit fails - none decremented",
+			limits: []ratelimiter.Limit{
+				{Capacity: 3, RefillEvery: time.Minute},
+				{Capacity: 20, RefillEvery: time.Minute},
+			},
+			cost:               5,
+			wantAllow:          false,
+			wantRemaining:      []float64{3, 20},
+			wantFailedLimitIdx: func() *int { i := 0; return &i }(),
+		},
+		{
+			name: "second limit fails - none decremented",
+			limits: []ratelimiter.Limit{
+				{Capacity: 20, RefillEvery: time.Minute},
+				{Capacity: 3, RefillEvery: time.Minute},
+			},
+			cost:               5,
+			wantAllow:          false,
+			wantRemaining:      []float64{20, 3},
+			wantFailedLimitIdx: func() *int { i := 1; return &i }(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, keyPrefix := redistestutils.NewRedisForTest(t)
+			logger := zap.NewNop()
+			limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix, tt.limits)
+			require.NoError(t, err)
+
+			res, err := limiter.Allow(context.Background(), "test-subject", tt.cost)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAllow, res.Allowed)
+
+			if tt.wantFailedLimitIdx == nil {
+				require.Nil(t, res.FailedLimit)
+				require.Nil(t, res.RetryAfter)
+			} else {
+				require.NotNil(t, res.FailedLimit)
+				require.Equal(t, tt.limits[*tt.wantFailedLimitIdx], *res.FailedLimit)
+				require.NotNil(t, res.RetryAfter)
+				require.Greater(t, *res.RetryAfter, time.Duration(0))
+			}
+
+			require.Len(t, res.Balances, len(tt.limits))
+			for i, want := range tt.wantRemaining {
+				require.Equal(t, tt.limits[i], res.Balances[i].Limit, "balance[%d].Limit", i)
+				require.InDelta(
+					t,
+					want,
+					res.Balances[i].Remaining,
+					0.01,
+					"balance[%d].Remaining",
+					i,
+				)
+			}
+
+			// Second request with cost=1 to verify state wasn't modified on failure
+			// After a failed request, the state should remain unchanged
+			res2, err := limiter.Allow(context.Background(), "test-subject", 1)
+			if tt.wantAllow {
+				// First request succeeded, so second request should reflect deducted tokens
+				require.NoError(t, err)
+				for i, want := range tt.wantRemaining {
+					require.InDelta(
+						t,
+						want-1,
+						res2.Balances[i].Remaining,
+						0.01,
+						"balance[%d].Remaining after second check",
+						i,
+					)
+				}
+			} else {
+				// First request failed, state unchanged, so check with another attempt
+				// Result depends on whether limits still have enough tokens
+				require.NoError(t, err)
+				for i, want := range tt.wantRemaining {
+					// If the original cost was more than capacity, this will still fail
+					// Otherwise, verify remaining is unchanged
+					if want >= 1 {
+						require.InDelta(
+							t,
+							want-1,
+							res2.Balances[i].Remaining,
+							0.01,
+							"balance[%d].Remaining after second check",
+							i,
+						)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRedisLimiter_RemainingAccuracy(t *testing.T) {
+	tests := []struct {
+		name          string
+		limits        []ratelimiter.Limit
+		requests      []uint64
+		wantRemaining [][]float64
+	}{
+		{
+			name:     "single limit tracks remaining correctly",
+			limits:   []ratelimiter.Limit{{Capacity: 10, RefillEvery: time.Minute}},
+			requests: []uint64{3, 2, 4},
+			wantRemaining: [][]float64{
+				{7},
+				{5},
+				{1},
+			},
+		},
+		{
+			name: "multiple limits track independently",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Minute},
+				{Capacity: 100, RefillEvery: time.Hour},
+			},
+			requests: []uint64{5, 3},
+			wantRemaining: [][]float64{
+				{5, 95},
+				{2, 92},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, keyPrefix := redistestutils.NewRedisForTest(t)
+			logger := zap.NewNop()
+			limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix, tt.limits)
+			require.NoError(t, err)
+
+			for i, cost := range tt.requests {
+				res, err := limiter.Allow(context.Background(), "test-subject", cost)
+				require.NoError(t, err)
+				require.True(t, res.Allowed, "request %d should be allowed", i)
+				require.Len(t, res.Balances, len(tt.limits))
+				for j, want := range tt.wantRemaining[i] {
+					require.Equal(
+						t,
+						tt.limits[j],
+						res.Balances[j].Limit,
+						"request %d, balance[%d].Limit",
+						i,
+						j,
+					)
+					require.InDelta(
+						t,
+						want,
+						res.Balances[j].Remaining,
+						0.01,
+						"request %d, balance[%d].Remaining",
+						i,
+						j,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestRedisLimiter_TTL(t *testing.T) {
+	tests := []struct {
+		name          string
+		limits        []ratelimiter.Limit
+		cost          uint64
+		wantTsTTL     time.Duration
+		wantLimitTTLs []time.Duration // Expected TTL for each limit key
+		wantTTLDelta  time.Duration
+	}{
+		{
+			name:      "single limit sets TTL to refill time",
+			limits:    []ratelimiter.Limit{{Capacity: 10, RefillEvery: 5 * time.Second}},
+			cost:      1,
+			wantTsTTL: 5 * time.Second,
+			wantLimitTTLs: []time.Duration{
+				500 * time.Millisecond,
+			}, // (10-1)/10 * 5s = 4.5s remaining, but after deduction
+			wantTTLDelta: 200 * time.Millisecond,
+		},
+		{
+			name: "multiple limits use max refill time for timestamp",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: 2 * time.Second},
+				{Capacity: 20, RefillEvery: 10 * time.Second},
+			},
+			cost:      1,
+			wantTsTTL: 10 * time.Second,
+			wantLimitTTLs: []time.Duration{
+				200 * time.Millisecond, // (10-1)/10 * 2s = 1.8s
+				500 * time.Millisecond, // (20-1)/20 * 10s = 9.5s
+			},
+			wantTTLDelta: 300 * time.Millisecond,
+		},
+		{
+			name: "full bucket expires at refill period",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: 3 * time.Second},
+			},
+			cost:      10, // Consume all tokens
+			wantTsTTL: 3 * time.Second,
+			wantLimitTTLs: []time.Duration{
+				3 * time.Second,
+			}, // Bucket empty, will be full in refill_ms
+			wantTTLDelta: 200 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, keyPrefix := redistestutils.NewRedisForTest(t)
+			logger := zap.NewNop()
+			limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix, tt.limits)
+			require.NoError(t, err)
+
+			// Make a request to trigger key creation
+			_, err = limiter.Allow(context.Background(), "test-subject", tt.cost)
+			require.NoError(t, err)
+
+			// Check TTL on the timestamp key (which has the max refill time)
+			tsKey := keyPrefix + ":test-subject:ts"
+			tsTTL, err := client.PTTL(context.Background(), tsKey).Result()
+			require.NoError(t, err)
+			require.Greater(t, tsTTL, time.Duration(0), "timestamp key should have a TTL set")
+			require.InDelta(
+				t,
+				float64(tt.wantTsTTL.Milliseconds()),
+				float64(tsTTL.Milliseconds()),
+				float64(tt.wantTTLDelta.Milliseconds()),
+				"timestamp TTL should match max refill time",
+			)
+
+			// Check TTL on each individual limit key
+			for i, wantLimitTTL := range tt.wantLimitTTLs {
+				limitKey := keyPrefix + ":test-subject:" + fmt.Sprintf("%d", i+1)
+				limitTTL, err := client.PTTL(context.Background(), limitKey).Result()
+				require.NoError(t, err)
+				require.Greater(
+					t,
+					limitTTL,
+					time.Duration(0),
+					"limit %d key should have a TTL set",
+					i+1,
+				)
+				require.InDelta(
+					t,
+					float64(wantLimitTTL.Milliseconds()),
+					float64(limitTTL.Milliseconds()),
+					float64(tt.wantTTLDelta.Milliseconds()),
+					"limit %d TTL should be based on time to refill", i+1,
+				)
+			}
+		})
+	}
+}
+
+func TestRedisLimiter_IndependentKeyExpiration(t *testing.T) {
+	client, keyPrefix := redistestutils.NewRedisForTest(t)
+	logger := zap.NewNop()
+
+	// Create limiter with two limits: short (1 second) and long (10 seconds)
+	// After consuming 5 tokens:
+	// - Limit 1: 5/10 tokens remaining, needs 500ms to refill
+	// - Limit 2: 15/20 tokens remaining, needs 2500ms to refill
+	limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix,
+		[]ratelimiter.Limit{
+			{Capacity: 10, RefillEvery: 1 * time.Second},
+			{Capacity: 20, RefillEvery: 10 * time.Second},
+		})
+	require.NoError(t, err)
+
+	// Make a request to consume 5 tokens from each bucket
+	res, err := limiter.Allow(context.Background(), "test-subject", 5)
+	require.NoError(t, err)
+	require.True(t, res.Allowed)
+	require.InDelta(
+		t,
+		5.0,
+		res.Balances[0].Remaining,
+		0.01,
+		"limit 1 should have 5 tokens remaining",
+	)
+	require.InDelta(
+		t,
+		15.0,
+		res.Balances[1].Remaining,
+		0.01,
+		"limit 2 should have 15 tokens remaining",
+	)
+
+	// Check that both limit keys exist and have TTLs
+	limit1Key := keyPrefix + ":test-subject:1"
+	limit2Key := keyPrefix + ":test-subject:2"
+	tsKey := keyPrefix + ":test-subject:ts"
+
+	ttl1, err := client.PTTL(context.Background(), limit1Key).Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl1, time.Duration(0), "limit 1 key should have TTL")
+
+	ttl2, err := client.PTTL(context.Background(), limit2Key).Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl2, time.Duration(0), "limit 2 key should have TTL")
+
+	tsTTL, err := client.PTTL(context.Background(), tsKey).Result()
+	require.NoError(t, err)
+	require.Greater(t, tsTTL, time.Duration(0), "timestamp key should have TTL")
+
+	// Verify specific TTL values
+	// Limit 1: (10-5)/10 * 1000ms = 500ms to refill
+	expectedTTL1 := 500 * time.Millisecond
+	require.InDelta(t,
+		float64(expectedTTL1.Milliseconds()),
+		float64(ttl1.Milliseconds()),
+		float64(100*time.Millisecond.Milliseconds()),
+		"limit 1 should expire after time to refill 5 tokens (~500ms)")
+
+	// Limit 2: (20-15)/20 * 10000ms = 2500ms to refill
+	expectedTTL2 := 2500 * time.Millisecond
+	require.InDelta(t,
+		float64(expectedTTL2.Milliseconds()),
+		float64(ttl2.Milliseconds()),
+		float64(200*time.Millisecond.Milliseconds()),
+		"limit 2 should expire after time to refill 5 tokens (~2500ms)")
+
+	// Timestamp key should have the longest TTL (10 seconds = max refill time)
+	expectedTsTTL := 10 * time.Second
+	require.InDelta(t,
+		float64(expectedTsTTL.Milliseconds()),
+		float64(tsTTL.Milliseconds()),
+		float64(200*time.Millisecond.Milliseconds()),
+		"timestamp should expire at max refill time (10s)")
+
+	// Verify that limit 1 expires much sooner than limit 2
+	require.Less(t, ttl1, ttl2, "short refill limit should expire before long refill limit")
+
+	// Verify both limits expire before timestamp
+	require.Less(t, ttl1, tsTTL, "limit 1 should expire before timestamp")
+	require.Less(t, ttl2, tsTTL, "limit 2 should expire before timestamp")
+}
+
+func TestRedisLimiter_Refill(t *testing.T) {
+	client, keyPrefix := redistestutils.NewRedisForTest(t)
+	logger := zap.NewNop()
+	limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix,
+		[]ratelimiter.Limit{{Capacity: 10, RefillEvery: 100 * time.Millisecond}})
+	require.NoError(t, err)
+
+	// Consume all tokens
+	res, err := limiter.Allow(context.Background(), "test-subject", 10)
+	require.NoError(t, err)
+	require.True(t, res.Allowed)
+	require.InDelta(t, 0, res.Balances[0].Remaining, 0.01)
+
+	// Should be blocked immediately
+	res, err = limiter.Allow(context.Background(), "test-subject", 1)
+	require.NoError(t, err)
+	require.False(t, res.Allowed)
+
+	// Wait for partial refill
+	time.Sleep(50 * time.Millisecond)
+	res, err = limiter.Allow(context.Background(), "test-subject", 1)
+	require.NoError(t, err)
+	require.True(t, res.Allowed, "should allow after partial refill")
+	require.Greater(t, res.Balances[0].Remaining, 3.0, "should have refilled ~5 tokens")
+}
+
+func TestRedisLimiter_RetryAfter(t *testing.T) {
+	tests := []struct {
+		name              string
+		limits            []ratelimiter.Limit
+		cost              uint64
+		wantRetryAfter    time.Duration
+		wantRetryAfterMax time.Duration
+	}{
+		{
+			name: "exact cost equals capacity",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Second},
+			},
+			cost: 11,
+			// Need 1 token, refill rate is 1 second / 10 tokens = 100ms per token
+			wantRetryAfter:    100 * time.Millisecond,
+			wantRetryAfterMax: 110 * time.Millisecond,
+		},
+		{
+			name: "cost is double capacity",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Second},
+			},
+			cost: 30,
+			// Need 10 tokens, refill rate is 1 second / 10 tokens = 100ms per token
+			wantRetryAfter:    time.Second,
+			wantRetryAfterMax: 1100 * time.Millisecond,
+		},
+		{
+			name: "partial tokens remaining",
+			limits: []ratelimiter.Limit{
+				{Capacity: 100, RefillEvery: 10 * time.Second},
+			},
+			cost: 50,
+			// First consume 60 tokens, leaving 40, then try to consume 50
+			// Need 10 more tokens, refill rate is 10s / 100 = 100ms per token
+			wantRetryAfter:    time.Second,
+			wantRetryAfterMax: 1100 * time.Millisecond,
+		},
+		{
+			name: "multiple limits - first fails",
+			limits: []ratelimiter.Limit{
+				{Capacity: 5, RefillEvery: 500 * time.Millisecond},
+				{Capacity: 100, RefillEvery: time.Hour},
+			},
+			cost: 10,
+			// First limit needs 5 tokens, refill rate is 500ms / 5 = 100ms per token
+			wantRetryAfter:    500 * time.Millisecond,
+			wantRetryAfterMax: 550 * time.Millisecond,
+		},
+		{
+			name: "cost exceeds capacity",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Second},
+			},
+			cost: 100,
+			// Cost exceeds capacity, so need to wait full refill period
+			wantRetryAfter:    time.Second,
+			wantRetryAfterMax: 1100 * time.Millisecond,
+		},
+		{
+			name: "cost far exceeds capacity",
+			limits: []ratelimiter.Limit{
+				{Capacity: 5, RefillEvery: 200 * time.Millisecond},
+			},
+			cost: 1000,
+			// Cost far exceeds capacity, capped at refill period
+			wantRetryAfter:    200 * time.Millisecond,
+			wantRetryAfterMax: 220 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, keyPrefix := redistestutils.NewRedisForTest(t)
+			logger := zap.NewNop()
+			limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix, tt.limits)
+			require.NoError(t, err)
+
+			// For "partial tokens remaining" test, first consume some tokens
+			if tt.name == "partial tokens remaining" {
+				_, err := limiter.Allow(context.Background(), "test-subject", 60)
+				require.NoError(t, err)
+			}
+
+			// Make the request that should fail
+			res, err := limiter.Allow(context.Background(), "test-subject", tt.cost)
+			require.NoError(t, err)
+			require.False(t, res.Allowed, "request should be blocked")
+			require.NotNil(t, res.FailedLimit)
+			require.NotNil(t, res.RetryAfter)
+
+			// Verify RetryAfter is in expected range
+			require.GreaterOrEqual(t, *res.RetryAfter, tt.wantRetryAfter,
+				"RetryAfter should be at least %v, got %v", tt.wantRetryAfter, *res.RetryAfter)
+			require.LessOrEqual(t, *res.RetryAfter, tt.wantRetryAfterMax,
+				"RetryAfter should be at most %v, got %v", tt.wantRetryAfterMax, *res.RetryAfter)
+		})
+	}
+}
+
+func TestRedisLimiter_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		limits  []ratelimiter.Limit
+		wantErr string
+	}{
+		{
+			name:    "empty limits",
+			limits:  []ratelimiter.Limit{},
+			wantErr: "no limits provided",
+		},
+		{
+			name:    "zero capacity",
+			limits:  []ratelimiter.Limit{{Capacity: 0, RefillEvery: time.Minute}},
+			wantErr: "invalid limit at index 0",
+		},
+		{
+			name:    "negative capacity",
+			limits:  []ratelimiter.Limit{{Capacity: -1, RefillEvery: time.Minute}},
+			wantErr: "invalid limit at index 0",
+		},
+		{
+			name:    "zero refill time",
+			limits:  []ratelimiter.Limit{{Capacity: 10, RefillEvery: 0}},
+			wantErr: "invalid limit at index 0",
+		},
+		{
+			name:    "negative refill time",
+			limits:  []ratelimiter.Limit{{Capacity: 10, RefillEvery: -1}},
+			wantErr: "invalid limit at index 0",
+		},
+		{
+			name: "invalid second limit",
+			limits: []ratelimiter.Limit{
+				{Capacity: 10, RefillEvery: time.Minute},
+				{Capacity: 0, RefillEvery: time.Minute},
+			},
+			wantErr: "invalid limit at index 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, keyPrefix := redistestutils.NewRedisForTest(t)
+			logger := zap.NewNop()
+			_, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix, tt.limits)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestRedisLimiter_SubjectIsolation(t *testing.T) {
+	client, keyPrefix := redistestutils.NewRedisForTest(t)
+	logger := zap.NewNop()
+	limiter, err := ratelimiter.NewRedisLimiter(logger, client, keyPrefix,
+		[]ratelimiter.Limit{{Capacity: 10, RefillEvery: time.Minute}})
+	require.NoError(t, err)
+
+	// Subject 1 consumes all tokens
+	res, err := limiter.Allow(context.Background(), "subject1", 10)
+	require.NoError(t, err)
+	require.True(t, res.Allowed)
+
+	// Subject 1 should be blocked
+	res, err = limiter.Allow(context.Background(), "subject1", 1)
+	require.NoError(t, err)
+	require.False(t, res.Allowed)
+
+	// Subject 2 should still have full capacity
+	res, err = limiter.Allow(context.Background(), "subject2", 10)
+	require.NoError(t, err)
+	require.True(t, res.Allowed)
+	require.InDelta(t, 0, res.Balances[0].Remaining, 0.01)
+}

--- a/pkg/ratelimiter/script.lua
+++ b/pkg/ratelimiter/script.lua
@@ -1,0 +1,177 @@
+-- ============================================================================
+-- Multi-Limit Token Bucket Rate Limiter
+-- ============================================================================
+-- This Lua script implements a rate limiter that can enforce multiple limits
+-- simultaneously using the token bucket algorithm with continuous refill.
+--
+-- INPUTS:
+--   KEYS[1]           = Timestamp key for this subject (e.g., "rl:gateway:user123:ts")
+--   KEYS[2..N+1]      = Token bucket keys for each limit (e.g., "rl:gateway:user123:1", ":2", ...)
+--   ARGV[1]           = now_ms - Current timestamp in milliseconds
+--   ARGV[2]           = num_limits (N) - Number of rate limits to enforce
+--   ARGV[3]           = cost - Number of tokens to consume for this request
+--   ARGV[4..4+2N-1]   = Flattened array of limit configurations:
+--                       [capacity_1, refill_ms_1, capacity_2, refill_ms_2, ..., capacity_N, refill_ms_N]
+--
+-- REDIS STORAGE:
+--   KEYS[1]     : Last update timestamp (integer ms) - expires at max(refill_ms)
+--   KEYS[2..N+1]: Current token count for each limit (float) - expires at refill_ms[i] when full
+--
+-- RETURN VALUES:
+--   On success: {1, remaining_1, remaining_2, ..., remaining_N}
+--     - 1 indicates the request is allowed
+--     - remaining_i is the token count AFTER deduction for each limit
+--   On failure: {0, failed_index, remaining_1, remaining_2, ..., remaining_N}
+--     - 0 indicates the request is denied
+--     - failed_index is the 1-based index of the first limit that failed
+--     - remaining_i is the CURRENT token count (no deduction) for each limit
+--
+-- BEHAVIOR:
+--   - ALL limits must have sufficient tokens for the request to be allowed
+--   - If ANY limit fails, NO tokens are deducted (atomic operation)
+--   - Tokens refill continuously based on elapsed time since last update
+--   - Each limit key expires independently when bucket is full for efficient cleanup
+--   - Timestamp key expires at max(refill_ms) to track last activity
+-- ============================================================================
+
+-- Parse input arguments
+local ts_key    = KEYS[1]           -- Timestamp key (shared across all limits)
+local now_ms    = tonumber(ARGV[1]) -- Current time in milliseconds
+local n         = tonumber(ARGV[2]) -- Number of limits to check
+local cost      = tonumber(ARGV[3]) -- Tokens to consume
+
+-- Initialize arrays to store limit configurations and current state
+local caps      = {} -- Maximum capacity for each limit (e.g., 100 tokens)
+local refill_ms = {} -- Time in ms to fully refill each limit (e.g., 60000 for 1 minute)
+local tokens    = {} -- Current token count for each limit (after refill)
+
+-- Parse limit configurations from ARGV
+-- Arguments come in pairs: [capacity, refill_time, capacity, refill_time, ...]
+local idx       = 4 -- Start after the first 3 arguments
+for i = 1, n do
+    caps[i] = tonumber(ARGV[idx])
+    idx = idx + 1
+    refill_ms[i] = tonumber(ARGV[idx])
+    idx = idx + 1
+end
+
+-- ============================================================================
+-- STEP 1: Fetch existing state from Redis
+-- ============================================================================
+-- Retrieve the shared timestamp and all token counts in a single pipeline
+-- Using MGET: [ts, tokens_1, tokens_2, ..., tokens_N]
+local keys_to_fetch = { ts_key }
+for i = 1, n do
+    table.insert(keys_to_fetch, KEYS[i + 1])
+end
+
+local raw = redis.call("MGET", unpack(keys_to_fetch))
+local last_ts = raw[1] and tonumber(raw[1]) or now_ms -- Shared timestamp for all limits
+
+-- ============================================================================
+-- STEP 2: Calculate current token counts with refill
+-- ============================================================================
+-- For each limit, determine how many tokens are currently available by:
+-- 1. Reading the stored token count (or using full capacity for new limits)
+-- 2. Calculating how many tokens have refilled since the last update
+-- 3. Capping the refilled amount at the maximum capacity
+for i = 1, n do
+    -- Extract token count from MGET response (offset by 1 for timestamp)
+    local raw_tokens = raw[i + 1]
+
+    -- Initialize with stored value, or full capacity if this is a new limit
+    local t = raw_tokens and tonumber(raw_tokens) or caps[i]
+
+    -- Calculate token refill based on elapsed time
+    local delta = now_ms - last_ts -- Milliseconds since last update
+    if delta < 0 then
+        -- Clock skew protection: if timestamp is in the future, treat as no time passed
+        delta = 0
+    end
+
+    if refill_ms[i] > 0 and delta > 0 then
+        -- Calculate refill rate: tokens per millisecond
+        -- Example: 100 tokens / 60000ms = 0.00167 tokens per millisecond
+        local rate = caps[i] / refill_ms[i]
+
+        -- Add refilled tokens based on elapsed time, but cap at max capacity
+        -- Example: 0.00167 tokens/ms * 30000ms = 50 tokens refilled
+        t = math.min(caps[i], t + rate * delta)
+    end
+
+    -- Store the calculated current state
+    tokens[i] = t -- Current token count (may be fractional)
+end
+
+-- ============================================================================
+-- STEP 3: Check if all limits can satisfy the request
+-- ============================================================================
+-- ALL limits must have enough tokens for the request to succeed.
+-- If any limit fails, we track which one failed first (for debugging/reporting).
+local failed_index = 0
+for i = 1, n do
+    if tokens[i] < cost then
+        failed_index = i -- Store the 1-based index of the failing limit
+        break
+    end
+end
+
+-- ============================================================================
+-- STEP 4: Apply the decision (all-or-nothing)
+-- ============================================================================
+if failed_index == 0 then
+    -- ========================================================================
+    -- SUCCESS PATH: All limits passed - deduct tokens and persist state
+    -- ========================================================================
+
+    -- Deduct tokens from each limit
+    for i = 1, n do
+        tokens[i] = tokens[i] - cost
+    end
+
+    -- Set timestamp with expiration in a single call
+    -- Timestamp expires at the longest refill period across all limits
+    local max_refill = math.max(unpack(refill_ms))
+    if max_refill > 0 then
+        redis.call("SET", ts_key, tostring(now_ms), "PX", max_refill)
+    else
+        redis.call("SET", ts_key, tostring(now_ms))
+    end
+
+    -- Set each limit key with its value and expiration in a single call
+    -- When a bucket is full, it expires after its refill period
+    -- When not full, set TTL based on time to refill to capacity
+    for i = 1, n do
+        local ttl
+        if tokens[i] >= caps[i] then
+            -- Bucket is full - expire after full refill period
+            ttl = refill_ms[i]
+        else
+            -- Bucket not full - calculate time to refill to capacity
+            -- TTL = time needed to refill from current level to full capacity
+            local time_to_fill = (caps[i] - tokens[i]) * refill_ms[i] / caps[i]
+            ttl = math.ceil(time_to_fill)
+        end
+
+        -- Use SET with PX to set value and expiration atomically
+        redis.call("SET", KEYS[i + 1], tostring(tokens[i]), "PX", ttl)
+    end
+
+    -- Return success response: {1, remaining_tokens_1, remaining_tokens_2, ...}
+    local resp = { 1 }                -- 1 = allowed
+    for i = 1, n do
+        table.insert(resp, tokens[i]) -- Remaining after deduction
+    end
+    return resp
+else
+    -- ========================================================================
+    -- FAILURE PATH: At least one limit failed - reject without modifying state
+    -- ========================================================================
+
+    -- Return rejection response: {0, failed_index, current_tokens_1, current_tokens_2, ...}
+    local resp = { 0, failed_index }  -- 0 = denied, index = which limit failed
+    for i = 1, n do
+        table.insert(resp, tokens[i]) -- Current tokens (no deduction)
+    end
+    return resp
+end


### PR DESCRIPTION
## Summary

- We need a good general-purpose rate limiter that supports multiple rates. This can be used by the gateway, and ultimately the nodes are going to want their own distributed rate limiting as well
- Supports multiple limits (N per minute, Y per hour) with atomicity on checking the rates. All must pass to decrement balances
- Supports RetryAfter to give the client information on when their request should succeed
- All Redis fields expire as soon as they are no longer needed

## Alternatives considered

I spent a bit of time looking at what is out there in terms of Go/Redis rate limiters and couldn't find a good fit for our needs.

- There are a number of battle-tested Redis rate limiter libraries, but few of them support atomic checks against multiple limits ([go-redis/redis-rate](https://github.com/go-redis/redis_rate), [rate-limiter-go](https://github.com/riverset/rate-limiter-go?utm_source=chatgpt.com))
- The few that support multiple limits are very new/experimental or unmaintained (eg. https://github.com/ajiwo/ratelimit)

## TODO

- Add an in-memory alternative
- Integrate to gateway

<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->

### Introduce a Redis-backed rate limiter by adding `ratelimiter.RedisLimiter.Allow` in [redis_limiter.go](https://github.com/xmtp/xmtpd/pull/1249/files#diff-da826d2207d10e475aaf794dc89a319281ef32ed82bca01497883530ce9f5ad1) to perform atomic multi-limit token-bucket checks per subject using a Lua script in [script.lua](https://github.com/xmtp/xmtpd/pull/1249/files#diff-2ec2dff483c0d98fc1583fdc7ec0412bd055528ffdabefdccb83a7663f75f773)

This pull request adds a Redis-based rate limiting component with multi-limit token-bucket enforcement and structured results. It includes a Lua script for atomic operations, a Go `RateLimiter` interface and types, a Redis-backed implementation, error definitions, and tests.

- Add `ratelimiter.RedisLimiter` and `ratelimiter.RedisLimiter.Allow` with key/arg builders and result parsing in [redis_limiter.go](https://github.com/xmtp/xmtpd/pull/1249/files#diff-da826d2207d10e475aaf794dc89a319281ef32ed82bca01497883530ce9f5ad1)
- Add Redis Lua script for multi-limit token-bucket enforcement in [script.lua](https://github.com/xmtp/xmtpd/pull/1249/files#diff-2ec2dff483c0d98fc1583fdc7ec0412bd055528ffdabefdccb83a7663f75f773)
- Add `RateLimiter` interface and supporting types `Limit`, `LimitBalance`, and `Result` in [interface.go](https://github.com/xmtp/xmtpd/pull/1249/files#diff-ef86606dde1c77ec47f7095dea2243ab04c0c30b184e6d14d63c0d8b3fdd3e7c)
- Add exported error variables for validation and runtime cases in [errors.go](https://github.com/xmtp/xmtpd/pull/1249/files#diff-d6e1f0fd9e282b89c8dbe1b9cb2027a820e9725b3866d98b218fa95b3fea398e)
- Add tests covering limits, atomicity, balances, TTLs, refill, retry-after, constructor validation, and subject isolation in [redis_limiter_test.go](https://github.com/xmtp/xmtpd/pull/1249/files#diff-b7efa36410c0e0550e81d23694a24632b47ad23ad7851175785a739716ebf38e)
- Add documentation describing the Redis-backed token-bucket rate limiter in [README.md](https://github.com/xmtp/xmtpd/pull/1249/files#diff-b21f52a6163d810c848ddebad8f8a56eda5b56999bf65e4d6bc7025230a759ce)

#### 📍Where to Start

Start with the `ratelimiter.NewRedisLimiter` constructor and the `ratelimiter.RedisLimiter.Allow` method in [redis_limiter.go](https://github.com/xmtp/xmtpd/pull/1249/files#diff-da826d2207d10e475aaf794dc89a319281ef32ed82bca01497883530ce9f5ad1), then review the Lua flow in [script.lua](https://github.com/xmtp/xmtpd/pull/1249/files#diff-2ec2dff483c0d98fc1583fdc7ec0412bd055528ffdabefdccb83a7663f75f773).

---

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 Macroscope summarized ed06219. 3 files reviewed, 8 issues evaluated, 8 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues

<details>
<summary>pkg/ratelimiter/redis_limiter.go — 0 comments posted, 8 evaluated, 8 filtered</summary>

- [line 35](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L35): `NewRedisLimiter` does not validate that `client` is non-nil before storing it. If a nil `redis.UniversalClient` is passed, any future use of `l.client` will panic at runtime. Add a nil check and return a clear error (e.g., `errors.New("redis client is nil")`) to ensure a defined terminal state and avoid later nil dereferences. **[ Low confidence ]**
- [line 37](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L37): `NewRedisLimiter` constructs `l.script` with `redis.NewScript(luaScript)` even though the package-level `luaScript` variable is declared without initialization and thus is an empty string by default. Creating a Redis script from an empty source will cause subsequent `Script.Run` or `Script.Load` calls to fail at runtime (e.g., with `NOSCRIPT` or other Redis-side errors), breaking rate limiter behavior. This is a reachable runtime bug because the constructor wires in an invalid script object that will be used later. Initialize `luaScript` with the actual Lua source or validate and error if it is empty before constructing the script. **[ Low confidence ]**
- [line 69](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L69): `Allow` does not validate that `l.limits` is non-empty, even though `ErrNoLimitsProvided` exists. Running the Redis script with zero limits produces a keys array of length 1 and an args array that declares zero limits. Downstream, `transformResult` expects either an allowed tuple with balances or a rejected tuple including a failed index consistent with the number of limits. With zero limits, the script response contract is undefined and may lead to `ErrUnexpectedScriptResponse` or other mismatches. The code should explicitly reject empty `limits` up front and return `ErrNoLimitsProvided` before making any external calls. **[ Already posted ]**
- [line 98](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L98): `transformResult` performs unsafe type assertions on script output without validation: `arr[0].(int64)` and `arr[1].(int64)`. If the Redis script returns these values as other types (e.g., strings or floats), these assertions will panic. The code should use type checks or a conversion helper with error handling before relying on the values, and return `ErrUnexpectedScriptResponse` (or a more specific error) instead of panicking. **[ Low confidence ]**
- [line 114](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L114): `transformResult` computes `failedIndex := int(arr[1].(int64)) - 1` without validating the type of `arr[1]` first. This mirrors the earlier assertion risk and can panic on a type mismatch, and it also assumes the script’s indexing is 1-based. If the script returns 0-based indices or a different type, the calculation becomes incorrect or panics. The code should validate the type, bounds, and base (documented contract), and error out gracefully when mismatched. **[ Already posted ]**
- [line 157](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L157): `validateLimits` returns a generic `fmt.Errorf("invalid limit at index %d", i)` when a limit is invalid, despite the package declaring `ErrInvalidFailedLimit`. If callers rely on sentinel error comparison (e.g., `errors.Is(err, ErrInvalidFailedLimit)`), this breaks error handling parity and can cause incorrect runtime behavior (e.g., falling back to unexpected flows). Use the declared sentinel error (possibly wrapped) to preserve contract consistency, or remove the unused sentinel to avoid ambiguity. **[ Low confidence ]**
- [line 169](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L169): `toFloat` silently returns `0` for unknown types and ignores parse errors for string inputs (`strconv.ParseFloat` error is discarded). This can cause silent data loss and incorrect computations (e.g., `Remaining` tokens or `RetryAfter`) without any error surfaced. `toFloat` should return an error on type/parse failure so callers can fail fast with `ErrUnexpectedScriptResponse` rather than produce incorrect values. **[ Low confidence ]**
- [line 193](https://github.com/xmtp/xmtpd/blob/ed06219dd3d714dbd2190f8f995d5152cfa29b4e/pkg/ratelimiter/redis_limiter.go#L193): `calculateRetryAfter` does not validate `limit.Capacity` and `limit.RefillEvery`. If `Capacity` is `0`, `refillRate := float64(limit.RefillEvery.Nanoseconds()) / float64(limit.Capacity)` divides by zero, yielding `+Inf`. Casting `retryAfterNanos` to `time.Duration` can overflow and produce an invalid duration. If `RefillEvery` is negative, `refillRate` is negative, producing a negative `RetryAfter`. The function should enforce `Capacity > 0` and `RefillEvery > 0` (and probably non-negative remaining) and return an error or clamp appropriately before computing. **[ Low confidence ]**

</details>

</details>

\<!-- MACROSCOPE_FOOTER_END -->\<!-- Macroscope's pull request summary ends here -->