### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/pkg/blockchain/app_chain_admin_test.go
+++ b/pkg/blockchain/app_chain_admin_test.go
@@ -76,7 +76,6 @@ func TestBootstrapperAddress(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name+"/roundtrip", func(t *testing.T) {
 			var err error
 			want := common.HexToAddress("0x000000000000000000000000000000000000BEEF")
@@ -180,7 +179,6 @@ func TestPauseFlags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
 				var err error
@@ -280,7 +278,6 @@ func TestPayloadSizeParams_ReadDefault_WriteThenRead(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run(tc.name+"/read_default", func(t *testing.T) {
 				t.Skip(

--- a/pkg/blockchain/blockchain_publisher_test.go
+++ b/pkg/blockchain/blockchain_publisher_test.go
@@ -164,7 +164,6 @@ func TestPublishIdentityUpdate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logMessage, err := publisher.PublishIdentityUpdate(
@@ -292,7 +291,6 @@ func TestPublishGroupMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logMessage, err := publisher.PublishGroupMessage(tt.ctx, tt.groupID, tt.message)

--- a/pkg/blockchain/settlement_chain_admin_test.go
+++ b/pkg/blockchain/settlement_chain_admin_test.go
@@ -87,7 +87,6 @@ func TestPauseFlagsSettlement(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run(tc.name+"/toggle_true_false", func(t *testing.T) {
 				var err error
@@ -284,7 +283,6 @@ func TestPayerRegistry_Uint32Params_ReadDefault_WriteThenRead(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run(tc.name+"/read_default", func(t *testing.T) {
 				t.Skip(
@@ -359,7 +357,6 @@ func TestPayerRegistry_Uint96Params_ReadDefault_WriteThenRead(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run(tc.name+"/read_default", func(t *testing.T) {
 				t.Skip(


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore