### PR TITLE
Add a partially covering index to speed up API queries

### DIFF
--- a/pkg/migrations/00019_add_gateway_index.down.sql
+++ b/pkg/migrations/00019_add_gateway_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_gw_by_originator_cover;

--- a/pkg/migrations/00019_add_gateway_index.up.sql
+++ b/pkg/migrations/00019_add_gateway_index.up.sql
@@ -1,0 +1,6 @@
+-- Run without timeout, needed as the table can contain up to millions of rows
+SET statement_timeout = 0;
+
+CREATE INDEX IF NOT EXISTS idx_gw_by_originator_cover
+    ON gateway_envelopes (originator_node_id, originator_sequence_id, gateway_time)
+    INCLUDE (topic);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Create a partially covering index `idx_gw_by_originator_cover` on `gateway_envelopes` to speed up API queries
Add migrations that create and drop a covering index on `gateway_envelopes`.

- Create `idx_gw_by_originator_cover` on `(originator_node_id, originator_sequence_id, gateway_time)` including `topic` with `statement_timeout` set to `0` in [00019_add_gateway_index.up.sql](https://github.com/xmtp/xmtpd/pull/1268/files#diff-db7d0ba028272f14e79a086ba3c0b194856ae2bf82a452925140bfd661eabc77)
- Drop `idx_gw_by_originator_cover` if it exists in [00019_add_gateway_index.down.sql](https://github.com/xmtp/xmtpd/pull/1268/files#diff-f197d281301e9cf55e2dfbc35e72ef8b6c3290993858c3d46493157edb83e1d8)

#### 📍Where to Start
Start with the migration definition in [00019_add_gateway_index.up.sql](https://github.com/xmtp/xmtpd/pull/1268/files#diff-db7d0ba028272f14e79a086ba3c0b194856ae2bf82a452925140bfd661eabc77).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 608885e. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->