### PR TITLE
Reduce subscribe worker batch size

### DIFF
--- a/pkg/api/message/subscribe_worker.go
+++ b/pkg/api/message/subscribe_worker.go
@@ -18,7 +18,9 @@ import (
 const (
 	subscriptionBufferSize  = 1024
 	SubscribeWorkerPollTime = 100 * time.Millisecond
-	subscribeWorkerPollRows = 10000
+	// based on measurements in testnet using PG, we can poll at most 1000 elements in a large DB
+	// this gives us sufficient throughput if being run continually
+	subscribeWorkerPollRows = 1000
 )
 
 type listener struct {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Reduce subscribe worker database poll batch size from 10000 to 1000 to support the motivation to reduce subscribe worker batch size in `message.subscribe_worker`
Update the constant that controls the subscribe worker poll size in `message.subscribe_worker` and add comments documenting measurement context.

- Set `subscribeWorkerPollRows` to `1000` in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1270/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab)
- Add comments explaining PostgreSQL-based measurement and continuous throughput in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1270/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab)

#### 📍Where to Start
Start with the `subscribeWorkerPollRows` constant definition and related comments in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1270/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6379f07. 1 files reviewed, 1 issues evaluated, 1 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/api/message/subscribe_worker.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 23](https://github.com/xmtp/xmtpd/blob/6379f07a4c8f5da470fdecac55f0a41458c7a074/pkg/api/message/subscribe_worker.go#L23): The `subscribeWorkerPollRows` constant change (from `10000` to `1000`) has no effect because the `pollableQuery` function ignores its `numRows` parameter. In `startSubscribeWorker`, `db.NewDBSubscription` is given `PollingOptions{ NumRows: subscribeWorkerPollRows }`, and it calls the provided `pollableQuery(ctx, lastSeen, numRows)`. However, `pollableQuery` does not use `numRows` and calls `q.SelectGatewayEnvelopes(ctx, ...)` without passing or enforcing any row limit. This silently defeats the intended throughput/row cap and contradicts the newly added comments about limiting to 1000 rows. Depending on the database size, this can cause the worker to fetch arbitrarily large batches, increasing latency, memory usage, and potentially delaying vector clock advancement. The externally visible contract of limiting polled rows per interval is not honored on this execution path. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->