### PR TITLE
Add logging to diagnose startup issues

### DIFF
--- a/pkg/api/message/publish_worker.go
+++ b/pkg/api/message/publish_worker.go
@@ -83,6 +83,8 @@ func startPublishWorker(
 	}
 	go worker.start()
 
+	logger.Debug("started")
+
 	return worker, nil
 }
 

--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -80,11 +80,13 @@ func NewReplicationAPIService(
 
 	publishWorker, err := startPublishWorker(ctx, logger, registrant, store, feeCalculator)
 	if err != nil {
+		logger.Error("could not start publish worker", zap.Error(err))
 		return nil, err
 	}
 
 	subscribeWorker, err := startSubscribeWorker(ctx, logger, store)
 	if err != nil {
+		logger.Error("could not start subscribe worker", zap.Error(err))
 		return nil, err
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -201,6 +201,7 @@ func NewReplicationServer(
 			cfg.ServerVersion,
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize registrant", zap.Error(err))
 			return nil, err
 		}
 	}
@@ -213,6 +214,7 @@ func NewReplicationServer(
 			clientMetrics,
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize mls validation service", zap.Error(err))
 			return nil, err
 		}
 	}
@@ -246,11 +248,13 @@ func NewReplicationServer(
 			migrator.WithContractsOptions(&cfg.Options.Contracts),
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize migrator", zap.Error(err))
 			return nil, err
 		}
 
 		err = s.migratorServer.Start()
 		if err != nil {
+			cfg.Logger.Error("failed to start migrator", zap.Error(err))
 			return nil, err
 		}
 
@@ -268,6 +272,7 @@ func NewReplicationServer(
 			promReg,
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to start api server", zap.Error(err))
 			return nil, err
 		}
 
@@ -291,6 +296,7 @@ func NewReplicationServer(
 			sync.WithPayerReportDomainSeparator(domainSeparator),
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize sync server", zap.Error(err))
 			return nil, err
 		}
 
@@ -312,6 +318,7 @@ func NewReplicationServer(
 			cfg.Options.Contracts.SettlementChain.ChainID,
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize signer for payer report workers", zap.Error(err))
 			return nil, err
 		}
 
@@ -320,6 +327,10 @@ func NewReplicationServer(
 			cfg.Options.Contracts.SettlementChain.RPCURL,
 		)
 		if err != nil {
+			cfg.Logger.Error(
+				"failed to initialize settlement chain client for payer report workers",
+				zap.Error(err),
+			)
 			return nil, err
 		}
 
@@ -330,6 +341,10 @@ func NewReplicationServer(
 			cfg.Options.Contracts.SettlementChain,
 		)
 		if err != nil {
+			cfg.Logger.Error(
+				"failed to initialize reports manager for payer report workers",
+				zap.Error(err),
+			)
 			return nil, err
 		}
 
@@ -381,6 +396,7 @@ func startAPIServer(
 			isMigrationEnabled,
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize replication api service", zap.Error(err))
 			return err
 		}
 		message_api.RegisterReplicationApiServer(grpcServer, replicationService)
@@ -395,6 +411,7 @@ func startAPIServer(
 			metadata.NewPayerInfoFetcher(cfg.DB),
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize metadata api service", zap.Error(err))
 			return err
 		}
 		metadata_api.RegisterMetadataApiServer(grpcServer, metadataService)
@@ -414,6 +431,7 @@ func startAPIServer(
 			cfg.ServerVersion,
 		)
 		if err != nil {
+			cfg.Logger.Error("failed to initialize jwt verifier", zap.Error(err))
 			return err
 		}
 	}
@@ -438,6 +456,7 @@ func startAPIServer(
 
 	s.apiServer, err = api.NewAPIServer(apiOpts...)
 	if err != nil {
+		cfg.Logger.Error("failed to initialize api server", zap.Error(err))
 		return err
 	}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add startup diagnostics by logging failures and worker starts in `pkg/server/server.go`, `pkg/api/message/service.go`, `pkg/api/message/publish_worker.go`, and `pkg/api/message/subscribe_worker.go`
Add targeted logs across server and message workers to diagnose startup issues, and adjust vector clock handling in subscription bootstrap.

- Add error logs before returns in `NewReplicationServer` and `startAPIServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996)
- Add error logs before returns in `NewReplicationAPIService` in [service.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2)
- Add debug logs after starting `startPublishWorker` and `startSubscribeWorker` goroutines in [publish_worker.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-a985e2d18aa8bb7ea586f77e5bc52dad0a4c4989e5a220806f737fb1c9c50415) and [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab)
- Change `pollableQuery` to return an empty `VectorClock` on `SelectGatewayEnvelopes` error and update per-node advancement only when the new sequence ID is greater than the current value in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab)

#### 📍Where to Start
Start with `startSubscribeWorker` and the `pollableQuery` logic in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab), then review error logging additions in `NewReplicationServer` and `startAPIServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1271/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 34bc29e. 4 files reviewed, 12 issues evaluated, 10 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/server/server.go — 0 comments posted, 10 evaluated, 10 filtered</summary>

- [line 174](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L174): Resources started earlier in `NewReplicationServer` are not cleaned up when a later initialization step fails, causing background processes to keep running even though the constructor returns an error. Examples: when metrics are enabled, `metrics.NewMetricsServer` likely starts an HTTP server and is never stopped if a later block returns an error; `StartIndexer()` starts the indexer and will remain running if subsequent initialization (e.g., API, Sync, or payer report) fails; `migratorServer.Start()` starts migration workers and will keep running on later failures; after `startAPIServer` successfully starts the API server, any failure in subsequent blocks returns without shutting down the API server. This violates single paired cleanup and no-leak invariants. <b>[ Previously rejected ]</b>
- [line 211](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L211): Inconsistent lifecycle control: several components are initialized with `cfg.Ctx` instead of the server-owned `s.ctx` created by `context.WithCancel(cfg.Ctx)`. Specifically, `mlsvalidate.NewMlsValidationService` (line 211), `indexer.WithContext(cfg.Ctx)` (line 226), and `migrator.WithContext(cfg.Ctx)` (line 244) receive `cfg.Ctx`, while other components (e.g., Sync server, payer report workers) use `s.ctx`. This prevents coordinated shutdown via `s.cancel`, leading to components that do not stop when the server’s context is canceled and causing potential leaks or split lifecycles. <b>[ Low confidence ]</b>
- [line 234](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L234): The indexer is started (`StartIndexer`) and on any later failure in the constructor a `return nil, err` occurs without stopping the indexer, leaving it running in the background. This violates single paired cleanup and can lead to duplicate indexers if the caller retries or tests create multiple servers. <b>[ Previously rejected ]</b>
- [line 255](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L255): The migrator service is started (`migratorServer.Start`) and any later error in initialization (API, Sync, payer report workers) returns without stopping the migrator, leaving it running. This breaks the all-or-nothing initialization expectation and leaks resources. <b>[ Previously rejected ]</b>
- [line 268](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L268): After successfully starting the API server via `startAPIServer`, any subsequent failure (e.g., during Sync server initialization at line 299 or payer report workers setup) returns an error without shutting down the API server, leaving it running. This constitutes a leak and violates the all-or-nothing initialization contract for `NewReplicationServer`. <b>[ Previously rejected ]</b>
- [line 382](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L382): The function does not validate that `cfg` is non-nil before dereferencing it. `cfg` is used immediately at `line 382` (`cfg.Options...`) and subsequently on many lines (`cfg.Logger`, `cfg.DB`, `cfg.FeeCalculator`, `cfg.GRPCListener`, `cfg.Options.Reflection.Enable`, `cfg.ServerVersion`). If a caller passes a nil `*ReplicationServerConfig`, the function will panic due to a nil pointer dereference. There is no guard or constructor guarantee in this code that `cfg` cannot be nil. <b>[ Low confidence ]</b>
- [line 385](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L385): The function mutates shared state `s.cursorUpdater` inside `serviceRegistrationFunc` at `line 385` before validating that later service initialization succeeds. If `message.NewReplicationAPIService` or `metadata.NewMetadataAPIService` fails, `startAPIServer` returns an error but leaves `s.cursorUpdater` set. This introduces partial mutation without rollback, which can lead to inconsistent state if other parts of the server read or act on `s.cursorUpdater` assuming the API server initialization succeeded. There is no cleanup or restoration of the prior value on error paths. <b>[ Previously rejected ]</b>
- [line 385](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L385): The function does not validate that `s` is non-nil before dereferencing its fields. `s` is dereferenced at `line 385` (`s.ctx` to construct `metadata.NewCursorUpdater`), and repeatedly (`s.registrant`, `s.validationService`, `s.nodeRegistry`, `s.ctx` again). If a caller passes a nil `*ReplicationServer`, the function will panic due to a nil pointer dereference. <b>[ Low confidence ]</b>
- [line 399](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L399): The function calls methods on `cfg.Logger` without ensuring it is non-nil. For example, at `line 399`, `cfg.Logger.Error(...)` is called, and similar calls occur at lines 414, 434, 459, 404, 419. If `cfg.Logger` is nil, invoking methods on it will panic (zap `Logger` methods have pointer receivers and do not support a nil receiver). There is no guard that prevents a nil `Logger`. <b>[ Low confidence ]</b>
- [line 426](https://github.com/xmtp/xmtpd/blob/34bc29e11e18312e58809ba9f59f1b1b8b113054/pkg/server/server.go#L426): The function conditionally builds JWT auth interceptors only when both `s.nodeRegistry` and `s.registrant` are non-nil (`line 426`). However, `s.registrant` is passed (unconditionally) into `message.NewReplicationAPIService` at `line 387`. If `s.registrant` is nil, the replication API service may dereference it internally, leading to a runtime panic or undefined behavior. This mismatch between conditional use for auth and unconditional passing to service initialization is a defensive coding gap. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->