### PR TITLE
Remove BlockUntilDesiredCursorReached clutch from payer

### DIFF
--- a/pkg/gateway/builder.go
+++ b/pkg/gateway/builder.go
@@ -244,7 +244,6 @@ func (b *GatewayServiceBuilder) buildGatewayService(
 			b.nodeRegistry,
 			gatewayPrivateKey,
 			b.blockchainPublisher,
-			nil,
 			clientMetrics,
 		)
 		if err != nil {

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -153,7 +153,6 @@ func NewTestAPIServer(t *testing.T) (*api.APIServer, *sql.DB, APIServerMocks) {
 			privKey,
 			mockMessagePublisher,
 			nil,
-			nil,
 		)
 		require.NoError(t, err)
 		payer_api.RegisterPayerApiServer(grpcServer, payerService)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove blocking cursor wait from `payer.Service.publishToBlockchain` to eliminate the BlockUntilDesiredCursorReached clutch in the payer API
Refactor the payer service to drop node cursor tracking and metadata client wiring, changing `payer.NewPayerAPIService` to exclude the metadata client and updating `payer.Service.publishToBlockchain` to return immediately after publishing without waiting on a node cursor. Tests and builders update to the new constructor signature.

#### 📍Where to Start
Start with `payer.NewPayerAPIService` and the removal of cursor tracking in [service.go](https://github.com/xmtp/xmtpd/pull/1281/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280), then review the callsite updates in [builder.go](https://github.com/xmtp/xmtpd/pull/1281/files#diff-27a239accb0576c3da95c1fea41bd81227bc4355f38be11a66d7b15135ea8e61) and test changes in [publish_test.go](https://github.com/xmtp/xmtpd/pull/1281/files#diff-90f55a60181ca91b3410cc4004a28e01102f7ba16ea52bc465062fc3dfe9fe43).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 5c31aa6.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->