### PR TITLE
Limit blockchain payload size

### DIFF
--- a/pkg/api/payer/publish_test.go
+++ b/pkg/api/payer/publish_test.go
@@ -88,6 +88,7 @@ func buildPayerService(
 		privKey,
 		mockMessagePublisher,
 		nil,
+		0,
 	)
 	require.NoError(t, err)
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -33,6 +33,7 @@ type AppChainOptions struct {
 	GatewayAddress                   string        `long:"gateway-address"                     env:"XMTPD_APP_CHAIN_GATEWAY_ADDRESS"                   description:"App Chain Gateway contract address"`
 	ParameterRegistryAddress         string        `long:"parameter-registry-address"          env:"XMTPD_APP_CHAIN_PARAMETER_REGISTRY_ADDRESS"        description:"Parameter Registry contract address"`
 	DeploymentBlock                  uint64        `long:"deployment-block"                    env:"XMTPD_APP_CHAIN_DEPLOYMENT_BLOCK"                  description:"Deployment block for the application chain"                   default:"0"`
+	MaxBlockchainPayloadSize         uint64        `long:"max-blockchain-payload-size"         env:"XMTPD_APP_CHAIN_MAX_BLOCKCHAIN_PAYLOAD_SIZE"       description:"Max payload size for the App Chain in bytes"                  default:"200000"`
 }
 
 type SettlementChainOptions struct {

--- a/pkg/gateway/builder.go
+++ b/pkg/gateway/builder.go
@@ -245,6 +245,7 @@ func (b *GatewayServiceBuilder) buildGatewayService(
 			gatewayPrivateKey,
 			b.blockchainPublisher,
 			clientMetrics,
+			b.config.Contracts.AppChain.MaxBlockchainPayloadSize,
 		)
 		if err != nil {
 			return err

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -153,6 +153,7 @@ func NewTestAPIServer(t *testing.T) (*api.APIServer, *sql.DB, APIServerMocks) {
 			privKey,
 			mockMessagePublisher,
 			nil,
+			0,
 		)
 		require.NoError(t, err)
 		payer_api.RegisterPayerApiServer(grpcServer, payerService)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Enforce a 200000-byte blockchain payload limit by adding `payer.Service.maxPayerMessageSize` and validating in `payer.Service.PublishClientEnvelopes`
Add a configurable max payload size for blockchain-bound messages and validate message bytes in `payer.Service.PublishClientEnvelopes`, wiring the limit from config and updating constructors and tests to pass the new parameter.

#### 📍Where to Start
Start with the validation in `payer.Service.PublishClientEnvelopes` in [service.go](https://github.com/xmtp/xmtpd/pull/1282/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280), then review the new config option in [options.go](https://github.com/xmtp/xmtpd/pull/1282/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c) and the constructor changes in [builder.go](https://github.com/xmtp/xmtpd/pull/1282/files#diff-27a239accb0576c3da95c1fea41bd81227bc4355f38be11a66d7b15135ea8e61).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d827b28. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->