### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/pkg/blockchain/blockchain_publisher_test.go
+++ b/pkg/blockchain/blockchain_publisher_test.go
@@ -388,10 +388,7 @@ func TestPublishGroupMessageConcurrent(t *testing.T) {
 	errSet := sync.Map{}
 
 	for i := 0; i < parallelRuns; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			_, err := publisher.PublishGroupMessage(
 				context.Background(),
 				testutils.RandomGroupID(),
@@ -400,7 +397,7 @@ func TestPublishGroupMessageConcurrent(t *testing.T) {
 			if err != nil {
 				errSet.Store(err.Error(), struct{}{})
 			}
-		}()
+		})
 	}
 
 	// Wait for all goroutines to finish

--- a/pkg/blockchain/noncemanager/manager_test.go
+++ b/pkg/blockchain/noncemanager/manager_test.go
@@ -112,10 +112,7 @@ func TestConcurrentAllocation(t *testing.T) {
 			var errors []error
 
 			for i := 0; i < numGoroutines; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-
+				wg.Go(func() {
 					for j := 0; j < noncesPerGoroutine; j++ {
 						nonce, err := tm.manager.GetNonce(ctx)
 						if err != nil {
@@ -138,7 +135,7 @@ func TestConcurrentAllocation(t *testing.T) {
 							mu.Unlock()
 						}
 					}
-				}()
+				})
 			}
 
 			wg.Wait()

--- a/pkg/blockchain/noncemanager/sql/manager_test.go
+++ b/pkg/blockchain/noncemanager/sql/manager_test.go
@@ -164,9 +164,7 @@ func TestGetNonce_ConsumeManyConcurrent(t *testing.T) {
 	errCh := make(chan error, numClients)
 
 	for i := 0; i < numClients; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			nonce, err := nonceManager.GetNonce(ctx)
 			if err != nil {
 				errCh <- err
@@ -177,7 +175,7 @@ func TestGetNonce_ConsumeManyConcurrent(t *testing.T) {
 				errCh <- err
 				return
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/db/sequences_test.go
+++ b/pkg/db/sequences_test.go
@@ -99,16 +99,14 @@ func TestConcurrentReads(t *testing.T) {
 	results := make(chan int64, numClients)
 
 	for i := 0; i < numClients; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			seqID, err := getNextPayerSequence(t, ctx, db)
 			if err != nil {
 				t.Errorf("Error acquiring sequence: %v", err)
 			} else {
 				results <- seqID
 			}
-		}()
+		})
 	}
 
 	// Wait for all goroutines to complete
@@ -387,15 +385,13 @@ func TestAbandonConcurrently(t *testing.T) {
 	numDeletions := int64(0)
 
 	for i := 1; i <= numClients; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			numrows, err := querier.DeleteObsoleteNonces(ctx, int64(10*i))
 			if err != nil {
 				t.Errorf("Error deleting nonces: %v", err)
 			}
 			atomic.AddInt64(&numDeletions, numrows)
-		}()
+		})
 	}
 
 	// Wait for all goroutines to complete
@@ -433,15 +429,13 @@ func TestAbandonConcurrentlyWithOpenTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 1; i <= numClients; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			numrows, err := querier.DeleteObsoleteNonces(ctx, int64(10*i))
 			if err != nil {
 				t.Errorf("Error deleting nonces: %v", err)
 			}
 			atomic.AddInt64(&numDeletions, numrows)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/payerreport/store_test.go
+++ b/pkg/payerreport/store_test.go
@@ -1014,9 +1014,7 @@ func TestCreateAttestationConcurrency(t *testing.T) {
 	errCh := make(chan error, numWorkers)
 
 	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			attestation := &payerreport.PayerReportAttestation{
 				Report: &report,
 				NodeSignature: payerreport.NodeSignature{
@@ -1030,7 +1028,7 @@ func TestCreateAttestationConcurrency(t *testing.T) {
 			require.NoError(t, err)
 
 			errCh <- store.CreateAttestation(ctx, attestation, payerEnv)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/sync/originator_stream_test.go
+++ b/pkg/sync/originator_stream_test.go
@@ -164,11 +164,9 @@ func TestEnvelopeSinkShutdownViaClose(t *testing.T) {
 	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
 	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, t.Context())
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		dbStorerInstance.Start()
-	}()
+	})
 
 	close(writeQueue)
 	wg.Wait()
@@ -180,11 +178,9 @@ func TestEnvelopeSinkShutdownViaContext(t *testing.T) {
 	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
 	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, ctx)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		dbStorerInstance.Start()
-	}()
+	})
 
 	cancel()
 


### PR DESCRIPTION
use WaitGroup.Go to simplify code. 

More info: https://github.com/golang/go/issues/63796
