### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -103,7 +103,7 @@ func SpanResource(span Span, resource string) {
 	span.SetTag(ext.ResourceName, resource)
 }
 
-func SpanTag(span Span, key string, value interface{}) {
+func SpanTag(span Span, key string, value any) {
 	span.SetTag(key, value)
 }
 


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.