### PR TITLE
Optimize filter by topic queries

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -374,7 +374,7 @@ func (s *Service) fetchEnvelopes(
 			return nil, status.Errorf(codes.Internal, "could not select envelopes: %v", err)
 		}
 
-		return rows, nil
+		return transformRows(rows), nil
 	}
 	if len(query.GetOriginatorNodeIds()) != 0 {
 		params := queries.SelectGatewayEnvelopesByOriginatorsParams{
@@ -798,4 +798,14 @@ func (s *Service) waitForGatewayPublish(
 			}
 		}
 	}
+}
+
+func transformRows(
+	rows []queries.SelectGatewayEnvelopesByTopicsRow,
+) []queries.GatewayEnvelopesView {
+	result := make([]queries.GatewayEnvelopesView, len(rows))
+	for i, row := range rows {
+		result[i] = queries.GatewayEnvelopesView(row)
+	}
+	return result
 }

--- a/pkg/db/sqlc/envelopes_v2.sql
+++ b/pkg/db/sqlc/envelopes_v2.sql
@@ -74,22 +74,56 @@ LIMIT NULLIF(@row_limit::INT, 0);
 -- name: SelectGatewayEnvelopesByTopics :many
 WITH cursors AS (
     SELECT x.node_id AS cursor_node_id, y.seq_id AS cursor_sequence_id
-    FROM unnest(@cursor_node_ids::INT[]) WITH ORDINALITY AS x(node_id, ord)
+    FROM unnest(@cursor_node_ids::INT[])   WITH ORDINALITY AS x(node_id, ord)
              JOIN unnest(@cursor_sequence_ids::BIGINT[]) WITH ORDINALITY AS y(seq_id, ord)
                   USING (ord)
-)
-SELECT v.originator_node_id,
-       v.originator_sequence_id,
-       v.gateway_time,
-       v.topic,
-       v.originator_envelope
-FROM gateway_envelopes_view v
-         LEFT JOIN cursors c
-                   ON v.originator_node_id = c.cursor_node_id
-WHERE v.topic = ANY(@topics::BYTEA[])
-  AND v.originator_sequence_id > COALESCE(c.cursor_sequence_id, 0)
-ORDER BY v.gateway_time, v.originator_node_id, v.originator_sequence_id
-LIMIT NULLIF(@row_limit::INT, 0);
+),
+     filtered AS (
+         -- A) topic + cursor
+         SELECT
+             m.originator_node_id,
+             m.originator_sequence_id,
+             m.gateway_time,
+             m.topic
+         FROM gateway_envelopes_meta AS m
+                  JOIN cursors AS c
+                       ON m.originator_node_id     = c.cursor_node_id
+                           AND m.originator_sequence_id > c.cursor_sequence_id
+         WHERE m.topic = ANY(@topics::BYTEA[])
+
+         UNION ALL
+
+         -- B) topic + no-cursor
+         SELECT
+             m.originator_node_id,
+             m.originator_sequence_id,
+             m.gateway_time,
+             m.topic
+         FROM gateway_envelopes_meta AS m
+         WHERE m.topic = ANY(@topics::BYTEA[])
+           AND m.originator_sequence_id > 0
+           AND NOT EXISTS (
+             SELECT 1
+             FROM cursors AS c
+             WHERE c.cursor_node_id = m.originator_node_id
+         )
+
+         -- Do the ordering/limit on meta rows before touching blobs
+         ORDER BY gateway_time, originator_node_id, originator_sequence_id
+         LIMIT NULLIF(@row_limit::INT, 0)
+     )
+SELECT
+    f.originator_node_id,
+    f.originator_sequence_id,
+    f.gateway_time,
+    f.topic,
+    b.originator_envelope
+FROM filtered AS f
+         JOIN gateway_envelope_blobs AS b
+              ON b.originator_node_id     = f.originator_node_id
+                  AND b.originator_sequence_id = f.originator_sequence_id
+ORDER BY f.gateway_time, f.originator_node_id, f.originator_sequence_id;
+
 
 -- name: SelectGatewayEnvelopesUnfiltered :many
 WITH cursors AS (SELECT x.node_id AS cursor_node_id, y.seq_id AS cursor_sequence_id

--- a/pkg/indexer/app_chain/contracts/identity_update_storer_test.go
+++ b/pkg/indexer/app_chain/contracts/identity_update_storer_test.go
@@ -119,7 +119,7 @@ func TestStoreSequential(t *testing.T) {
 	numCalls := 0
 	validationService.EXPECT().
 		GetAssociationStateFromEnvelopes(mock.Anything, mock.Anything, mock.Anything).
-		RunAndReturn(func(ctx context.Context, prevEnvs []queries.GatewayEnvelopesView, newUpdate *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error) {
+		RunAndReturn(func(ctx context.Context, prevEnvs []queries.SelectGatewayEnvelopesByTopicsRow, newUpdate *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error) {
 			numCalls++
 			if numCalls > 1 {
 				require.Len(t, prevEnvs, 1)

--- a/pkg/mlsvalidate/interface.go
+++ b/pkg/mlsvalidate/interface.go
@@ -42,7 +42,7 @@ type MLSValidationService interface {
 	) (*AssociationStateResult, error)
 	GetAssociationStateFromEnvelopes(
 		ctx context.Context,
-		oldUpdates []queries.GatewayEnvelopesView,
+		oldUpdates []queries.SelectGatewayEnvelopesByTopicsRow,
 		newIdentityUpdate *associations.IdentityUpdate,
 	) (*AssociationStateResult, error)
 }

--- a/pkg/mlsvalidate/service.go
+++ b/pkg/mlsvalidate/service.go
@@ -85,7 +85,7 @@ func (s *MLSValidationServiceImpl) GetAssociationState(
 
 func (s *MLSValidationServiceImpl) GetAssociationStateFromEnvelopes(
 	ctx context.Context,
-	oldUpdateEnvelopes []queries.GatewayEnvelopesView,
+	oldUpdateEnvelopes []queries.SelectGatewayEnvelopesByTopicsRow,
 	newUpdate *associations.IdentityUpdate,
 ) (*AssociationStateResult, error) {
 	oldUpdates := make([]*associations.IdentityUpdate, len(oldUpdateEnvelopes))

--- a/pkg/mocks/mlsvalidate/mock_MLSValidationService.go
+++ b/pkg/mocks/mlsvalidate/mock_MLSValidationService.go
@@ -89,7 +89,7 @@ func (_c *MockMLSValidationService_GetAssociationState_Call) RunAndReturn(run fu
 }
 
 // GetAssociationStateFromEnvelopes provides a mock function with given fields: ctx, oldUpdates, newIdentityUpdate
-func (_m *MockMLSValidationService) GetAssociationStateFromEnvelopes(ctx context.Context, oldUpdates []queries.GatewayEnvelopesView, newIdentityUpdate *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error) {
+func (_m *MockMLSValidationService) GetAssociationStateFromEnvelopes(ctx context.Context, oldUpdates []queries.SelectGatewayEnvelopesByTopicsRow, newIdentityUpdate *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error) {
 	ret := _m.Called(ctx, oldUpdates, newIdentityUpdate)
 
 	if len(ret) == 0 {
@@ -98,10 +98,10 @@ func (_m *MockMLSValidationService) GetAssociationStateFromEnvelopes(ctx context
 
 	var r0 *mlsvalidate.AssociationStateResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []queries.GatewayEnvelopesView, *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []queries.SelectGatewayEnvelopesByTopicsRow, *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error)); ok {
 		return rf(ctx, oldUpdates, newIdentityUpdate)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []queries.GatewayEnvelopesView, *associations.IdentityUpdate) *mlsvalidate.AssociationStateResult); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []queries.SelectGatewayEnvelopesByTopicsRow, *associations.IdentityUpdate) *mlsvalidate.AssociationStateResult); ok {
 		r0 = rf(ctx, oldUpdates, newIdentityUpdate)
 	} else {
 		if ret.Get(0) != nil {
@@ -109,7 +109,7 @@ func (_m *MockMLSValidationService) GetAssociationStateFromEnvelopes(ctx context
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []queries.GatewayEnvelopesView, *associations.IdentityUpdate) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []queries.SelectGatewayEnvelopesByTopicsRow, *associations.IdentityUpdate) error); ok {
 		r1 = rf(ctx, oldUpdates, newIdentityUpdate)
 	} else {
 		r1 = ret.Error(1)
@@ -125,15 +125,15 @@ type MockMLSValidationService_GetAssociationStateFromEnvelopes_Call struct {
 
 // GetAssociationStateFromEnvelopes is a helper method to define mock.On call
 //   - ctx context.Context
-//   - oldUpdates []queries.GatewayEnvelopesView
+//   - oldUpdates []queries.SelectGatewayEnvelopesByTopicsRow
 //   - newIdentityUpdate *associations.IdentityUpdate
 func (_e *MockMLSValidationService_Expecter) GetAssociationStateFromEnvelopes(ctx interface{}, oldUpdates interface{}, newIdentityUpdate interface{}) *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call {
 	return &MockMLSValidationService_GetAssociationStateFromEnvelopes_Call{Call: _e.mock.On("GetAssociationStateFromEnvelopes", ctx, oldUpdates, newIdentityUpdate)}
 }
 
-func (_c *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call) Run(run func(ctx context.Context, oldUpdates []queries.GatewayEnvelopesView, newIdentityUpdate *associations.IdentityUpdate)) *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call {
+func (_c *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call) Run(run func(ctx context.Context, oldUpdates []queries.SelectGatewayEnvelopesByTopicsRow, newIdentityUpdate *associations.IdentityUpdate)) *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]queries.GatewayEnvelopesView), args[2].(*associations.IdentityUpdate))
+		run(args[0].(context.Context), args[1].([]queries.SelectGatewayEnvelopesByTopicsRow), args[2].(*associations.IdentityUpdate))
 	})
 	return _c
 }
@@ -143,7 +143,7 @@ func (_c *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call) Return
 	return _c
 }
 
-func (_c *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call) RunAndReturn(run func(context.Context, []queries.GatewayEnvelopesView, *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error)) *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call {
+func (_c *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call) RunAndReturn(run func(context.Context, []queries.SelectGatewayEnvelopesByTopicsRow, *associations.IdentityUpdate) (*mlsvalidate.AssociationStateResult, error)) *MockMLSValidationService_GetAssociationStateFromEnvelopes_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Restructure topic filter query to order and limit meta rows before blob join and update `message.Service.fetchEnvelopes` to return `[]queries.GatewayEnvelopesView` via internal conversion
Update the topic-based query to select and limit meta rows prior to joining blobs, introduce `queries.SelectGatewayEnvelopesByTopicsRow` as the return type for `SelectGatewayEnvelopesByTopics`, and add a `message.transformRows` helper to convert rows to `[]queries.GatewayEnvelopesView` for `message.Service.fetchEnvelopes`. Adjust parameter order to `$1/$2` for cursor arrays, `$3` for `row_limit`, and `$4` for `topics`, and propagate the new row type through validation interfaces, implementations, tests, and mocks.

#### 📍Where to Start
Start with the SQL definition for `SelectGatewayEnvelopesByTopics` in [envelopes_v2.sql](https://github.com/xmtp/xmtpd/pull/1297/files#diff-26ca3ff0889ad4b2aa77e6edc7cafa970393fe952969c76c781fb136df2c07e3), then review the Go bindings in [envelopes_v2.sql.go](https://github.com/xmtp/xmtpd/pull/1297/files#diff-cc069856ce1d1eb7751ecc6dc978d79f101acdfb499d3f4ad4f101453b088dd3), followed by the `message.Service.fetchEnvelopes` changes in [service.go](https://github.com/xmtp/xmtpd/pull/1297/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f6453c3. 5 files reviewed, 6 issues evaluated, 5 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/api/message/service.go — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 387](https://github.com/xmtp/xmtpd/blob/f6453c31a60f683551a0bef8cd1446878abf9e76/pkg/api/message/service.go#L387): Potential integer truncation: in the `originators` path, `OriginatorNodeIds` are converted with `int32(o)`. If `query.GetOriginatorNodeIds()` contains values outside the `int32` range, this will silently truncate and yield incorrect IDs, causing wrong DB filtering or data leakage. Validate the range before casting or change the parameter type to accommodate larger IDs. <b>[ Out of scope ]</b>
- [line 401](https://github.com/xmtp/xmtpd/blob/f6453c31a60f683551a0bef8cd1446878abf9e76/pkg/api/message/service.go#L401): Missing validation for `rowLimit`: the code passes `rowLimit` directly to query params without guarding against negative values. If a negative `rowLimit` is provided, DB query behavior may be undefined or error-prone (e.g., database rejecting the limit, returning no rows, or causing an internal error). Add validation to ensure `rowLimit` is non-negative and handle zero appropriately (e.g., treat zero as no results or as a default limit). <b>[ Out of scope ]</b>
</details>

<details>
<summary>pkg/db/queries/envelopes_v2.sql.go — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 146](https://github.com/xmtp/xmtpd/blob/f6453c31a60f683551a0bef8cd1446878abf9e76/pkg/db/queries/envelopes_v2.sql.go#L146): The SQL parameter order was changed compared to the previous query, but the constant retained the same name `SelectGatewayEnvelopesByTopics`. The new query now expects `$1::INT[]` (node IDs) and `$2::BIGINT[]` (sequence IDs) to build the `cursors` CTE, `$3::INT` for the `LIMIT`, and `$4::BYTEA[]` for `topic` filtering. Previously, the query expected `$1::BYTEA[]` (topics), `$2::INT` (limit), `$3::INT[]` (node IDs), and `$4::BIGINT[]` (sequence IDs). If the generated Go method signature and its callers were not updated to match this new parameter ordering, runtime execution will fail with PostgreSQL type errors (e.g., attempting to `unnest($1::INT[])` when `$1` is actually a `BYTEA[]` of topics), or worse, produce incorrect results if some casts were accepted. This is a breaking contract change for the query name and is a runtime bug unless all call sites were updated to pass parameters in the new order. <b>[ Low confidence ]</b>
- [line 180](https://github.com/xmtp/xmtpd/blob/f6453c31a60f683551a0bef8cd1446878abf9e76/pkg/db/queries/envelopes_v2.sql.go#L180): The query applies `ORDER BY ... LIMIT NULLIF($3::INT, 0)` within the `filtered` CTE, before performing the `JOIN gateway_envelope_blobs AS b` to fetch `originator_envelope`. If there exist meta rows without a corresponding blob row (e.g., due to transient inconsistency, delayed blob insertion, or partial replication), the inner join will drop those rows after the limit has already been applied. This can yield fewer than the requested limit of returned envelopes, and worse, it can permanently skip eligible later meta rows that do have blobs because they were excluded by the early limit. The previous implementation selected from `gateway_envelopes_view` (which likely joins meta and blobs) and applied `LIMIT` at the final step, ensuring the limit applies to actual joined rows. This change risks under-delivery and starvation under realistic data inconsistencies. <b>[ Low confidence ]</b>
</details>

<details>
<summary>pkg/mlsvalidate/service.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 110](https://github.com/xmtp/xmtpd/blob/f6453c31a60f683551a0bef8cd1446878abf9e76/pkg/mlsvalidate/service.go#L110): `GetAssociationStateFromEnvelopes` does not validate `newUpdate` before passing it to `GetAssociationState`. If `newUpdate` is `nil` (which is reachable given callers like `identity_update_storer.validateIdentityUpdate` that do not check `identityUpdate.IdentityUpdate` for nil), the request will contain a slice with a `nil` element (`[]*associations.IdentityUpdate{nil}`). This can result in a malformed gRPC/protobuf request at marshal time or a server-side validation error. At minimum, this violates the implicit contract that `NewUpdates` contains valid messages. The function should explicitly check `newUpdate != nil` and return a clear error before making the RPC. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->