### PR TITLE
Attest only on last sequence ID seen

### DIFF
--- a/pkg/mocks/payerreport/mock_IPayerReportStore.go
+++ b/pkg/mocks/payerreport/mock_IPayerReportStore.go
@@ -315,6 +315,63 @@ func (_c *MockIPayerReportStore_GetAdvisoryLocker_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// GetLatestSequenceID provides a mock function with given fields: ctx, originatorNodeID
+func (_m *MockIPayerReportStore) GetLatestSequenceID(ctx context.Context, originatorNodeID int32) (int64, error) {
+	ret := _m.Called(ctx, originatorNodeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestSequenceID")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int32) (int64, error)); ok {
+		return rf(ctx, originatorNodeID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int32) int64); ok {
+		r0 = rf(ctx, originatorNodeID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int32) error); ok {
+		r1 = rf(ctx, originatorNodeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockIPayerReportStore_GetLatestSequenceID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestSequenceID'
+type MockIPayerReportStore_GetLatestSequenceID_Call struct {
+	*mock.Call
+}
+
+// GetLatestSequenceID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - originatorNodeID int32
+func (_e *MockIPayerReportStore_Expecter) GetLatestSequenceID(ctx interface{}, originatorNodeID interface{}) *MockIPayerReportStore_GetLatestSequenceID_Call {
+	return &MockIPayerReportStore_GetLatestSequenceID_Call{Call: _e.mock.On("GetLatestSequenceID", ctx, originatorNodeID)}
+}
+
+func (_c *MockIPayerReportStore_GetLatestSequenceID_Call) Run(run func(ctx context.Context, originatorNodeID int32)) *MockIPayerReportStore_GetLatestSequenceID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int32))
+	})
+	return _c
+}
+
+func (_c *MockIPayerReportStore_GetLatestSequenceID_Call) Return(_a0 int64, _a1 error) *MockIPayerReportStore_GetLatestSequenceID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockIPayerReportStore_GetLatestSequenceID_Call) RunAndReturn(run func(context.Context, int32) (int64, error)) *MockIPayerReportStore_GetLatestSequenceID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Queries provides a mock function with no fields
 func (_m *MockIPayerReportStore) Queries() *queries.Queries {
 	ret := _m.Called()

--- a/pkg/payerreport/interface.go
+++ b/pkg/payerreport/interface.go
@@ -80,4 +80,5 @@ type IPayerReportStore interface {
 	GetAdvisoryLocker(
 		ctx context.Context,
 	) (db.ITransactionScopedAdvisoryLocker, error)
+	GetLatestSequenceID(ctx context.Context, originatorNodeID int32) (int64, error)
 }

--- a/pkg/payerreport/store.go
+++ b/pkg/payerreport/store.go
@@ -52,6 +52,10 @@ func (s *Store) GetAdvisoryLocker(
 	return db.NewTransactionScopedAdvisoryLocker(ctx, s.db, &sql.TxOptions{})
 }
 
+func (s *Store) GetLatestSequenceID(ctx context.Context, originatorNodeID int32) (int64, error) {
+	return s.queries.GetLatestSequenceId(ctx, originatorNodeID)
+}
+
 // StoreReport stores a report in the database. No validations have been performed, and no originator envelope is stored.
 func (s *Store) StoreReport(ctx context.Context, report *PayerReport) (int64, error) {
 	params, err := prepareStoreReportParams(report)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Filter attestation candidates in `payerreport.workers.AttestationWorker.findReportsNeedingAttestation` to attest only when `EndSequenceID` ≤ the latest sequence ID seen for the originator node
Add `GetLatestSequenceID` to `payerreport.IPayerReportStore` and `payerreport.Store`, update attestation worker to skip reports when the store’s latest sequence ID is less than a report’s `EndSequenceID`, and extend mocks and tests to cover the new filter. Key changes touch [interface.go](https://github.com/xmtp/xmtpd/pull/1313/files#diff-eefb5f451bfbb5d7123a5f5c08f36927dcba84c43d9578cef4d7191bdf89c112), [store.go](https://github.com/xmtp/xmtpd/pull/1313/files#diff-1557531d1361293f11123bbcc86167d7a99f261d62a4a71af45f898ac3b5c770), [attestation.go](https://github.com/xmtp/xmtpd/pull/1313/files#diff-e878e7214f8d54fd2250fb682976303e3753543783c7e7b141e6b0eab479a537), and related tests.

#### 📍Where to Start
Start in the filtering logic within `findReportsNeedingAttestation` in [attestation.go](https://github.com/xmtp/xmtpd/pull/1313/files#diff-e878e7214f8d54fd2250fb682976303e3753543783c7e7b141e6b0eab479a537), then review the interface addition in [interface.go](https://github.com/xmtp/xmtpd/pull/1313/files#diff-eefb5f451bfbb5d7123a5f5c08f36927dcba84c43d9578cef4d7191bdf89c112) and its store implementation in [store.go](https://github.com/xmtp/xmtpd/pull/1313/files#diff-1557531d1361293f11123bbcc86167d7a99f261d62a4a71af45f898ac3b5c770).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized c602ff2.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->