### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -74,8 +74,8 @@ func ClientIPFromHeaderOrPeer(headers http.Header, peer string) string {
 
 	// There are potentially multiple comma separated IPs bundled in that first value.
 	// Return the first non-empty IP.
-	ips := strings.Split(xForwardedFor, ",")
-	for _, ip := range ips {
+	ips := strings.SplitSeq(xForwardedFor, ",")
+	for ip := range ips {
 		trimmed := strings.TrimSpace(ip)
 		if trimmed != "" {
 			return trimmed


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

More info: https://github.com/golang/go/issues/61901