### PR TITLE
Fix default payer report config

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -124,8 +124,8 @@ type PayerReportOptions struct {
 	AttestationWorkerPollInterval time.Duration `long:"attestation-worker-poll-interval" env:"XMTPD_PAYER_REPORT_ATTESTATION_WORKER_POLL_INTERVAL" description:"Interval between checks for new reports to attest to"                            default:"1m"`
 	GenerateReportSelfPeriod      time.Duration `long:"generate-report-self-period"      env:"XMTPD_PAYER_REPORT_GENERATE_REPORT_SELF_PERIOD"      description:"Period of time we should use to generate payer reports about self"               default:"6h"`
 	GenerateReportOthersPeriod    time.Duration `long:"generate-report-others-period"    env:"XMTPD_PAYER_REPORT_GENERATE_REPORT_OTHERS_PERIOD"    description:"Period of time we should use to generate backup payer reports about other nodes" default:"12h"`
-	ExpirySelfPeriod              time.Duration `long:"expiry-self-period"               env:"XMTPD_PAYER_REPORT_EXPIRY_SELF_PERIOD"               description:"Period of time we should use to expire payer reports about self"                 default:"6h"`
-	ExpiryOthersPeriod            time.Duration `long:"expiry-others-period"             env:"XMTPD_PAYER_REPORT_EXPIRY_OTHERS_PERIOD"             description:"Period of time we should use to expire backup payer reports about other nodes"   default:"12h"`
+	ExpirySelfPeriod              time.Duration `long:"expiry-self-period"               env:"XMTPD_PAYER_REPORT_EXPIRY_SELF_PERIOD"               description:"Period of time we should use to expire payer reports about self"                 default:"9h"`
+	ExpiryOthersPeriod            time.Duration `long:"expiry-others-period"             env:"XMTPD_PAYER_REPORT_EXPIRY_OTHERS_PERIOD"             description:"Period of time we should use to expire backup payer reports about other nodes"   default:"18h"`
 }
 
 type ServerOptions struct {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update `pkg/config.PayerReportOptions` defaults to set `ExpirySelfPeriod` to 9h and `ExpiryOthersPeriod` to 18h to fix default payer report config
Adjust struct tag defaults in [options.go](https://github.com/xmtp/xmtpd/pull/1320/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c) for `PayerReportOptions` to 9h and 18h.

#### 📍Where to Start
Start with the `PayerReportOptions` struct in [options.go](https://github.com/xmtp/xmtpd/pull/1320/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2527352.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->