### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/pkg/api/message/subscribe_worker.go
+++ b/pkg/api/message/subscribe_worker.go
@@ -84,7 +84,7 @@ func (ls *listenerSet) removeListener(l *listener) {
 
 func (ls *listenerSet) isEmpty() bool {
 	empty := true
-	ls.Range(func(_, _ interface{}) bool {
+	ls.Range(func(_, _ any) bool {
 		empty = false
 		return false // stop iteration
 	})

--- a/pkg/authn/signing_method.go
+++ b/pkg/authn/signing_method.go
@@ -27,7 +27,7 @@ var (
 // but updated to work with the latest serverVersion of jwt-go.
 type SigningMethodSecp256k1 struct{}
 
-func (sm *SigningMethodSecp256k1) Verify(signingString string, sig []byte, key interface{}) error {
+func (sm *SigningMethodSecp256k1) Verify(signingString string, sig []byte, key any) error {
 	pub, ok := key.(*ecdsa.PublicKey)
 	if !ok {
 		return ErrWrongKeyFormat
@@ -49,7 +49,7 @@ func (sm *SigningMethodSecp256k1) Verify(signingString string, sig []byte, key i
 	return nil
 }
 
-func (sm *SigningMethodSecp256k1) Sign(signingString string, key interface{}) ([]byte, error) {
+func (sm *SigningMethodSecp256k1) Sign(signingString string, key any) ([]byte, error) {
 	priv, ok := key.(*ecdsa.PrivateKey)
 	if !ok {
 		return nil, ErrWrongKeyFormat

--- a/pkg/authn/signing_method_test.go
+++ b/pkg/authn/signing_method_test.go
@@ -65,7 +65,7 @@ func TestFullJWT(t *testing.T) {
 	tokenString, err := token.SignedString(privateKey)
 	require.NoError(t, err)
 
-	parsedToken, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	parsedToken, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		return privateKey.Public(), nil
 	})
 	require.NoError(t, err)

--- a/pkg/authn/verifier.go
+++ b/pkg/authn/verifier.go
@@ -74,7 +74,7 @@ func (v *RegistryVerifier) Verify(tokenString string) (uint32, CloseFunc, error)
 	return nodeID, closer, nil
 }
 
-func (v *RegistryVerifier) getMatchingPublicKey(token *jwt.Token) (interface{}, error) {
+func (v *RegistryVerifier) getMatchingPublicKey(token *jwt.Token) (any, error) {
 	if _, ok := token.Method.(*SigningMethodSecp256k1); !ok {
 		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 	}

--- a/pkg/blockchain/app_chain_admin.go
+++ b/pkg/blockchain/app_chain_admin.go
@@ -122,10 +122,10 @@ func (a appChainAdmin) UpdateIdentityUpdateBootstrapper(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.identityUpdateBroadcaster.UpdatePayloadBootstrapper(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.identityUpdateBroadcaster.ParsePayloadBootstrapperUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			parameterSet, ok := event.(*iu.IdentityUpdateBroadcasterPayloadBootstrapperUpdated)
 			if !ok {
 				a.logger.Error(
@@ -166,10 +166,10 @@ func (a appChainAdmin) UpdateGroupMessageBootstrapper(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.groupMessageBroadcaster.UpdatePayloadBootstrapper(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.groupMessageBroadcaster.ParsePayloadBootstrapperUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			parameterSet, ok := event.(*gm.GroupMessageBroadcasterPayloadBootstrapperUpdated)
 			if !ok {
 				a.logger.Error(
@@ -208,10 +208,10 @@ func (a appChainAdmin) UpdateGroupMessagePauseStatus(ctx context.Context) error 
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.groupMessageBroadcaster.UpdatePauseStatus(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.groupMessageBroadcaster.ParsePauseStatusUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			parameterSet, ok := event.(*gm.GroupMessageBroadcasterPauseStatusUpdated)
 			if !ok {
 				a.logger.Error(
@@ -249,10 +249,10 @@ func (a appChainAdmin) UpdateIdentityUpdatePauseStatus(ctx context.Context) erro
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.identityUpdateBroadcaster.UpdatePauseStatus(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.identityUpdateBroadcaster.ParsePauseStatusUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*iu.IdentityUpdateBroadcasterPauseStatusUpdated)
 			if !ok {
 				a.logger.Error(
@@ -288,10 +288,10 @@ func (a appChainAdmin) UpdateAppChainGatewayPauseStatus(ctx context.Context) err
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.appChainGateway.UpdatePauseStatus(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.appChainGateway.ParsePauseStatusUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*acg.AppChainGatewayPauseStatusUpdated)
 			if !ok {
 				a.logger.Error(
@@ -325,10 +325,10 @@ func (a appChainAdmin) UpdateGroupMessageMaxPayloadSize(ctx context.Context) err
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.groupMessageBroadcaster.UpdateMaxPayloadSize(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.groupMessageBroadcaster.ParseMaxPayloadSizeUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*gm.GroupMessageBroadcasterMaxPayloadSizeUpdated)
 			if !ok {
 				a.logger.Error(
@@ -363,10 +363,10 @@ func (a appChainAdmin) UpdateGroupMessageMinPayloadSize(ctx context.Context) err
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.groupMessageBroadcaster.UpdateMinPayloadSize(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.groupMessageBroadcaster.ParseMinPayloadSizeUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*gm.GroupMessageBroadcasterMinPayloadSizeUpdated)
 			if !ok {
 				a.logger.Error(
@@ -401,10 +401,10 @@ func (a appChainAdmin) UpdateIdentityUpdateMaxPayloadSize(ctx context.Context) e
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.identityUpdateBroadcaster.UpdateMaxPayloadSize(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.identityUpdateBroadcaster.ParseMaxPayloadSizeUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*iu.IdentityUpdateBroadcasterMaxPayloadSizeUpdated)
 			if !ok {
 				a.logger.Error(
@@ -439,10 +439,10 @@ func (a appChainAdmin) UpdateIdentityUpdateMinPayloadSize(ctx context.Context) e
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return a.identityUpdateBroadcaster.UpdateMinPayloadSize(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return a.identityUpdateBroadcaster.ParseMinPayloadSizeUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*iu.IdentityUpdateBroadcasterMinPayloadSizeUpdated)
 			if !ok {
 				a.logger.Error(

--- a/pkg/blockchain/blockchain_publisher_test.go
+++ b/pkg/blockchain/blockchain_publisher_test.go
@@ -22,11 +22,11 @@ func (h *Int64Heap) Len() int           { return len(*h) }
 func (h *Int64Heap) Less(i, j int) bool { return (*h)[i] < (*h)[j] }
 func (h *Int64Heap) Swap(i, j int)      { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
 
-func (h *Int64Heap) Push(x interface{}) {
+func (h *Int64Heap) Push(x any) {
 	*h = append(*h, x.(int64))
 }
 
-func (h *Int64Heap) Pop() interface{} {
+func (h *Int64Heap) Pop() any {
 	old := *h
 	n := len(old)
 	x := old[0] // Get the smallest element
@@ -405,7 +405,7 @@ func TestPublishGroupMessageConcurrent(t *testing.T) {
 
 	// Collect and print unique errors
 	var uniqueErrors []string
-	errSet.Range(func(key, value interface{}) bool {
+	errSet.Range(func(key, value any) bool {
 		uniqueErrors = append(uniqueErrors, key.(string))
 		return true
 	})

--- a/pkg/blockchain/client.go
+++ b/pkg/blockchain/client.go
@@ -97,8 +97,8 @@ func ExecuteTransaction(
 	logger *zap.Logger,
 	client *ethclient.Client,
 	txFunc func(*bind.TransactOpts) (*types.Transaction, error),
-	eventParser func(*types.Log) (interface{}, error),
-	logHandler func(interface{}),
+	eventParser func(*types.Log) (any, error),
+	logHandler func(any),
 ) ProtocolError {
 	if signer == nil {
 		return NewBlockchainError(fmt.Errorf("no signer provided"))

--- a/pkg/blockchain/funds_admin.go
+++ b/pkg/blockchain/funds_admin.go
@@ -195,10 +195,10 @@ func (f *fundsAdmin) MintMockUSDC(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return f.mockUnderlyingFeeToken.Mint(opts, addr, amount)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return f.mockUnderlyingFeeToken.ParseTransfer(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			transfer, ok := event.(*mft.MockUnderlyingFeeTokenTransfer)
 			if !ok {
 				f.logger.Error("unexpected event type, not MockUnderlyingFeeTokenTransfer")
@@ -266,10 +266,10 @@ func (f *fundsAdmin) Deposit(
 				gasPrice,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return f.settlementGateway.ParseDeposit(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			deposit, ok := event.(*scg.SettlementChainGatewayDeposit)
 			if !ok {
 				f.logger.Error("node added event is not of type SettlementChainGatewayDeposit")
@@ -323,10 +323,10 @@ func (f *fundsAdmin) Withdraw(
 				from,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return f.appGateway.ParseWithdrawal(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			withdrawal, ok := event.(*acg.AppChainGatewayWithdrawal)
 			if !ok {
 				f.logger.Error("node added event is not of type AppChainGatewayWithdrawal")
@@ -364,10 +364,10 @@ func (f *fundsAdmin) ReceiveWithdrawal(
 				from,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return f.settlementGateway.ParseWithdrawalReceived(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			withdrawal, ok := event.(*scg.SettlementChainGatewayWithdrawalReceived)
 			if !ok {
 				f.logger.Error(

--- a/pkg/blockchain/node_registry_admin.go
+++ b/pkg/blockchain/node_registry_admin.go
@@ -91,10 +91,10 @@ func (n *nodeRegistryAdmin) AddNode(
 				httpAddress,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return n.nodeContract.ParseNodeAdded(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			nodeAdded, ok := event.(*noderegistry.NodeRegistryNodeAdded)
 			if !ok {
 				n.logger.Error("node added event is not of type NodesNodeAdded")
@@ -131,10 +131,10 @@ func (n *nodeRegistryAdmin) AddToNetwork(
 				nodeID,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return n.nodeContract.ParseNodeAddedToCanonicalNetwork(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			nodeAdded, ok := event.(*noderegistry.NodeRegistryNodeAddedToCanonicalNetwork)
 			if !ok {
 				n.logger.Error(
@@ -164,10 +164,10 @@ func (n *nodeRegistryAdmin) RemoveFromNetwork(
 				nodeID,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return n.nodeContract.ParseNodeRemovedFromCanonicalNetwork(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			nodeRemoved, ok := event.(*noderegistry.NodeRegistryNodeRemovedFromCanonicalNetwork)
 			if !ok {
 				n.logger.Error(
@@ -199,10 +199,10 @@ func (n *nodeRegistryAdmin) SetHTTPAddress(
 				httpAddress,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return n.nodeContract.ParseHttpAddressUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			httpAddressUpdated, ok := event.(*noderegistry.NodeRegistryHttpAddressUpdated)
 			if !ok {
 				n.logger.Error(
@@ -237,10 +237,10 @@ func (n *nodeRegistryAdmin) SetMaxCanonical(
 				opts,
 			)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return n.nodeContract.ParseMaxCanonicalNodesUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			maxCanonicalUpdated, ok := event.(*noderegistry.NodeRegistryMaxCanonicalNodesUpdated)
 			if !ok {
 				n.logger.Error(

--- a/pkg/blockchain/noncemanager/sql/manager_test.go
+++ b/pkg/blockchain/noncemanager/sql/manager_test.go
@@ -20,11 +20,11 @@ func (h *Int64Heap) Len() int           { return len(*h) }
 func (h *Int64Heap) Less(i, j int) bool { return (*h)[i] < (*h)[j] }
 func (h *Int64Heap) Swap(i, j int)      { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
 
-func (h *Int64Heap) Push(x interface{}) {
+func (h *Int64Heap) Push(x any) {
 	*h = append(*h, x.(int64))
 }
 
-func (h *Int64Heap) Pop() interface{} {
+func (h *Int64Heap) Pop() any {
 	old := *h
 	n := len(old)
 	x := old[0] // Get the smallest element

--- a/pkg/blockchain/parameter_registry_admin.go
+++ b/pkg/blockchain/parameter_registry_admin.go
@@ -460,14 +460,14 @@ func (n *ParameterAdmin) setParameterBytes32(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return n.registry.Set(opts, paramName, value)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			key, v, err := n.registry.ParseParameterSet(*log)
 			if err != nil {
 				return nil, err
 			}
 			return parameterSetEvent{Key: key, Value: v}, nil
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(parameterSetEvent)
 			if !ok {
 				n.logger.Error("unexpected event type, not ParameterSet tuple")
@@ -493,14 +493,14 @@ func (n *ParameterAdmin) setParametersBytes32Many(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return n.registry.SetMany(opts, keys, values)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			key, v, err := n.registry.ParseParameterSet(*log)
 			if err != nil {
 				return nil, err
 			}
 			return parameterSetEvent{Key: key, Value: v}, nil
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(parameterSetEvent)
 			if !ok {
 				n.logger.Error("unexpected event type, not ParameterSet tuple")

--- a/pkg/blockchain/rate_registry_admin.go
+++ b/pkg/blockchain/rate_registry_admin.go
@@ -95,10 +95,10 @@ func (r *RatesAdmin) AddRates(ctx context.Context, rates fees.Rates) ProtocolErr
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return r.ratesContract.UpdateRates(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return r.ratesContract.ParseRatesUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			e, ok := event.(*rateregistry.RateRegistryRatesUpdated)
 			if !ok {
 				r.logger.Error("unexpected event type, not of type RateRegistryRatesUpdated")

--- a/pkg/blockchain/settlement_chain_admin.go
+++ b/pkg/blockchain/settlement_chain_admin.go
@@ -167,10 +167,10 @@ func (s settlementChainAdmin) UpdateSettlementChainGatewayPauseStatus(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.settlementChainGateway.UpdatePauseStatus(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.settlementChainGateway.ParsePauseStatusUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*scg.SettlementChainGatewayPauseStatusUpdated)
 			if !ok {
 				s.logger.Error(
@@ -207,10 +207,10 @@ func (s settlementChainAdmin) UpdatePayerRegistryPauseStatus(ctx context.Context
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.payerRegistry.UpdatePauseStatus(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.payerRegistry.ParsePauseStatusUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*pr.PayerRegistryPauseStatusUpdated)
 			if !ok {
 				s.logger.Error(
@@ -249,10 +249,10 @@ func (s settlementChainAdmin) UpdateDistributionManagerPauseStatus(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.distributionManager.UpdatePauseStatus(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.distributionManager.ParsePauseStatusUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*dm.DistributionManagerPauseStatusUpdated)
 			if !ok {
 				s.logger.Error(
@@ -292,10 +292,10 @@ func (s settlementChainAdmin) UpdateDistributionManagerProtocolFeesRecipient(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.distributionManager.UpdateProtocolFeesRecipient(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.distributionManager.ParseProtocolFeesRecipientUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*dm.DistributionManagerProtocolFeesRecipientUpdated)
 			if !ok {
 				s.logger.Error(
@@ -331,10 +331,10 @@ func (s settlementChainAdmin) UpdatePayerRegistryMinimumDeposit(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.payerRegistry.UpdateMinimumDeposit(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.payerRegistry.ParseMinimumDepositUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*pr.PayerRegistryMinimumDepositUpdated)
 			if !ok {
 				s.logger.Error("unexpected event type, not PayerRegistryMinimumDepositUpdated")
@@ -369,10 +369,10 @@ func (s settlementChainAdmin) UpdatePayerRegistryWithdrawLockPeriod(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.payerRegistry.UpdateWithdrawLockPeriod(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.payerRegistry.ParseWithdrawLockPeriodUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*pr.PayerRegistryWithdrawLockPeriodUpdated)
 			if !ok {
 				s.logger.Error("unexpected event type, not PayerRegistryWithdrawLockPeriodUpdated")
@@ -407,10 +407,10 @@ func (s settlementChainAdmin) UpdatePayerReportManagerProtocolFeeRate(
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.payerReportManager.UpdateProtocolFeeRate(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.payerReportManager.ParseProtocolFeeRateUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*prm.PayerReportManagerProtocolFeeRateUpdated)
 			if !ok {
 				s.logger.Error(
@@ -443,10 +443,10 @@ func (s settlementChainAdmin) UpdateNodeRegistryAdmin(ctx context.Context) error
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return s.nodeRegistry.UpdateAdmin(opts)
 		},
-		func(log *types.Log) (interface{}, error) {
+		func(log *types.Log) (any, error) {
 			return s.nodeRegistry.ParseAdminUpdated(*log)
 		},
-		func(event interface{}) {
+		func(event any) {
 			ev, ok := event.(*nr.NodeRegistryAdminUpdated)
 			if !ok {
 				s.logger.Error(
@@ -511,10 +511,10 @@ func (s settlementChainAdmin) BridgeParameters(ctx context.Context, keys []strin
 				amountToSend,
 			)
 		},
-		func(l *types.Log) (interface{}, error) {
+		func(l *types.Log) (any, error) {
 			return s.settlementChainGateway.ParseParametersSent(*l)
 		},
-		func(ev interface{}) {
+		func(ev any) {
 			e, ok := ev.(*scg.SettlementChainGatewayParametersSent)
 			if ok {
 				s.logger.Info("parameters sent",

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -511,7 +511,7 @@ func validateSettlementChainConfig(
 }
 
 // validateField checks if a field meets the validation requirements and adds appropriate errors.
-func validateField(value interface{}, fieldName string, set map[string]struct{}) {
+func validateField(value any, fieldName string, set map[string]struct{}) {
 	switch v := value.(type) {
 	case string:
 		if v == "" {

--- a/pkg/envelopes/client.go
+++ b/pkg/envelopes/client.go
@@ -57,7 +57,7 @@ func (c *ClientEnvelope) TargetTopic() topic.Topic {
 	return c.targetTopic
 }
 
-func (c *ClientEnvelope) Payload() interface{} {
+func (c *ClientEnvelope) Payload() any {
 	return c.proto.Payload
 }
 

--- a/pkg/gateway/examples/jwt/main.go
+++ b/pkg/gateway/examples/jwt/main.go
@@ -34,7 +34,7 @@ func jwtIdentityFn(publicKey []byte) gateway.IdentityFn {
 		token, err := jwt.ParseWithClaims(
 			authHeader,
 			&jwt.RegisteredClaims{},
-			func(token *jwt.Token) (interface{}, error) {
+			func(token *jwt.Token) (any, error) {
 				// Verify signing method
 				if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
 					return nil, gateway.NewPermissionDeniedError(

--- a/pkg/interceptors/client/auth.go
+++ b/pkg/interceptors/client/auth.go
@@ -76,8 +76,8 @@ func (i *ClientAuthInterceptor) Unary() grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
-		req interface{},
-		reply interface{},
+		req any,
+		reply any,
 		cc *grpc.ClientConn,
 		invoker grpc.UnaryInvoker,
 		opts ...grpc.CallOption,

--- a/pkg/ratelimiter/redis_limiter.go
+++ b/pkg/ratelimiter/redis_limiter.go
@@ -53,7 +53,7 @@ func (l *RedisLimiter) buildKeys(subject string) []string {
 }
 
 func (l *RedisLimiter) buildArgs(requestTime time.Time, cost uint64) []any {
-	args := make([]interface{}, 0, 3+len(l.limits)*2)
+	args := make([]any, 0, 3+len(l.limits)*2)
 	args = append(args, requestTime.UnixMilli(), len(l.limits), cost)
 	for _, lim := range l.limits {
 		args = append(args, lim.Capacity, lim.RefillEvery.Milliseconds())

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -150,7 +150,7 @@ func BlockNumberField(blockNumber uint64) zap.Field {
 
 // BodyField uses reflection to log the body of the request or response.
 // Do not use in hot paths unless guarded with "if logger.Core().Enabled(zap.DebugLevel) { ... }"
-func BodyField(body interface{}) zap.Field {
+func BodyField(body any) zap.Field {
 	return zap.Any("body", body)
 }
 

--- a/pkg/utils/unimplemented.go
+++ b/pkg/utils/unimplemented.go
@@ -1,12 +1,12 @@
 package utils
 
 // Unimplemented panics with a message indicating that the function is not implemented.
-func Unimplemented(message string, unusedVariables ...interface{}) {
+func Unimplemented(message string, unusedVariables ...any) {
 	panic("unimplemented: " + message)
 }
 
 // Unused is a no-op function that takes any number of arguments and does nothing with them.
 // Useful for temporarily silencing "unused variable" warnings in development.
-func Unused(unusedVariables ...interface{}) {
+func Unused(unusedVariables ...any) {
 	// Do nothing
 }


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.