### PR TITLE
Log orig id of generated report

### DIFF
--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -254,7 +254,11 @@ func (w *GeneratorWorker) generateReport(nodeID uint32, lastReportEndSequenceID 
 		return err
 	}
 
-	w.logger.Info("generated report", utils.PayerReportIDField(reportID.String()))
+	w.logger.Info(
+		"generated report",
+		utils.PayerReportIDField(reportID.String()),
+		utils.OriginatorIDField(nodeID),
+	)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Log originator ID in `GeneratorWorker.generateReport` Info log after payer report creation in [generator.go](https://github.com/xmtp/xmtpd/pull/1330/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e)
Add `utils.OriginatorIDField(nodeID)` to the final Info log in `GeneratorWorker.generateReport`, alongside `utils.PayerReportIDField(reportID.String())`, and reformat the call to multi-line in [generator.go](https://github.com/xmtp/xmtpd/pull/1330/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e).

#### 📍Where to Start
Start with the `GeneratorWorker.generateReport` method in [generator.go](https://github.com/xmtp/xmtpd/pull/1330/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 8d00d90.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->