### PR TITLE
Do not allow pruner to delete unsettled envelopes

### DIFF
--- a/pkg/db/queries/prune.sql.go
+++ b/pkg/db/queries/prune.sql.go
@@ -10,10 +10,19 @@ import (
 )
 
 const countExpiredEnvelopes = `-- name: CountExpiredEnvelopes :one
+WITH max_prunable AS (SELECT originator_node_id,
+                             COALESCE(MAX(end_sequence_id), 0) AS max_end_sequence_id
+                      FROM payer_reports
+                      WHERE submission_status = 1 -- SUBMITTED
+                         OR submission_status = 2 -- SETTLED
+                      GROUP BY originator_node_id)
 SELECT COUNT(*)::bigint AS expired_count
-FROM gateway_envelopes_meta
-WHERE expiry IS NOT NULL
-  AND expiry < EXTRACT(EPOCH FROM now())::bigint
+FROM gateway_envelopes_meta ge
+         LEFT JOIN max_prunable mp
+                   ON ge.originator_node_id = mp.originator_node_id
+WHERE ge.expiry IS NOT NULL
+  AND ge.expiry < EXTRACT(EPOCH FROM now())::bigint
+  AND ge.originator_sequence_id <= COALESCE(mp.max_end_sequence_id, 0)
 `
 
 func (q *Queries) CountExpiredEnvelopes(ctx context.Context) (int64, error) {
@@ -24,16 +33,24 @@ func (q *Queries) CountExpiredEnvelopes(ctx context.Context) (int64, error) {
 }
 
 const deleteExpiredEnvelopesBatch = `-- name: DeleteExpiredEnvelopesBatch :many
-WITH to_delete AS (
-    SELECT originator_node_id, originator_sequence_id
-    FROM gateway_envelopes_meta
-    WHERE expiry IS NOT NULL
-      AND expiry < EXTRACT(EPOCH FROM now())::bigint
-    ORDER BY expiry, originator_node_id, originator_sequence_id
-    LIMIT $1
-        FOR UPDATE SKIP LOCKED
-)
-DELETE FROM gateway_envelopes_meta ge
+WITH max_prunable AS (SELECT originator_node_id,
+                             COALESCE(MAX(end_sequence_id), 0) AS max_end_sequence_id
+                      FROM payer_reports
+                      WHERE submission_status = 1 -- SUBMITTED
+                         OR submission_status = 2 -- SETTLED
+                      GROUP BY originator_node_id),
+     to_delete AS (SELECT ge.originator_node_id,
+                          ge.originator_sequence_id
+                   FROM gateway_envelopes_meta ge
+                            LEFT JOIN max_prunable mp
+                                      ON ge.originator_node_id = mp.originator_node_id
+                   WHERE ge.expiry IS NOT NULL
+                     AND ge.expiry < EXTRACT(EPOCH FROM now())::bigint
+                     AND ge.originator_sequence_id <= COALESCE(mp.max_end_sequence_id, 0)
+                   ORDER BY ge.expiry, ge.originator_node_id, ge.originator_sequence_id
+                   LIMIT $1 FOR UPDATE SKIP LOCKED)
+DELETE
+FROM gateway_envelopes_meta ge
     USING to_delete td
 WHERE ge.originator_node_id = td.originator_node_id
   AND ge.originator_sequence_id = td.originator_sequence_id

--- a/pkg/db/sqlc/prune.sql
+++ b/pkg/db/sqlc/prune.sql
@@ -1,20 +1,37 @@
 -- name: CountExpiredEnvelopes :one
+WITH max_prunable AS (SELECT originator_node_id,
+                             COALESCE(MAX(end_sequence_id), 0) AS max_end_sequence_id
+                      FROM payer_reports
+                      WHERE submission_status = 1 -- SUBMITTED
+                         OR submission_status = 2 -- SETTLED
+                      GROUP BY originator_node_id)
 SELECT COUNT(*)::bigint AS expired_count
-FROM gateway_envelopes_meta
-WHERE expiry IS NOT NULL
-  AND expiry < EXTRACT(EPOCH FROM now())::bigint;
+FROM gateway_envelopes_meta ge
+         LEFT JOIN max_prunable mp
+                   ON ge.originator_node_id = mp.originator_node_id
+WHERE ge.expiry IS NOT NULL
+  AND ge.expiry < EXTRACT(EPOCH FROM now())::bigint
+  AND ge.originator_sequence_id <= COALESCE(mp.max_end_sequence_id, 0);
 
 -- name: DeleteExpiredEnvelopesBatch :many
-WITH to_delete AS (
-    SELECT originator_node_id, originator_sequence_id
-    FROM gateway_envelopes_meta
-    WHERE expiry IS NOT NULL
-      AND expiry < EXTRACT(EPOCH FROM now())::bigint
-    ORDER BY expiry, originator_node_id, originator_sequence_id
-    LIMIT @batch_size
-        FOR UPDATE SKIP LOCKED
-)
-DELETE FROM gateway_envelopes_meta ge
+WITH max_prunable AS (SELECT originator_node_id,
+                             COALESCE(MAX(end_sequence_id), 0) AS max_end_sequence_id
+                      FROM payer_reports
+                      WHERE submission_status = 1 -- SUBMITTED
+                         OR submission_status = 2 -- SETTLED
+                      GROUP BY originator_node_id),
+     to_delete AS (SELECT ge.originator_node_id,
+                          ge.originator_sequence_id
+                   FROM gateway_envelopes_meta ge
+                            LEFT JOIN max_prunable mp
+                                      ON ge.originator_node_id = mp.originator_node_id
+                   WHERE ge.expiry IS NOT NULL
+                     AND ge.expiry < EXTRACT(EPOCH FROM now())::bigint
+                     AND ge.originator_sequence_id <= COALESCE(mp.max_end_sequence_id, 0)
+                   ORDER BY ge.expiry, ge.originator_node_id, ge.originator_sequence_id
+                   LIMIT @batch_size FOR UPDATE SKIP LOCKED)
+DELETE
+FROM gateway_envelopes_meta ge
     USING to_delete td
 WHERE ge.originator_node_id = td.originator_node_id
   AND ge.originator_sequence_id = td.originator_sequence_id

--- a/pkg/migrations/00010_store-payer-reports.up.sql
+++ b/pkg/migrations/00010_store-payer-reports.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE payer_reports (
     end_minute_since_epoch INT NOT NULL,
     payers_merkle_root BYTEA NOT NULL,
     active_node_ids INT [] NOT NULL,
-    -- 0 = pending, 1 = submitted, 2 = settled
+    -- 0 = pending, 1 = submitted, 2 = settled, 3 = rejected
     submission_status SMALLINT NOT NULL DEFAULT 0,
     -- 0 = pending, 1 = approved, 2 = rejected
     attestation_status SMALLINT NOT NULL DEFAULT 0,

--- a/pkg/prune/prune_test.go
+++ b/pkg/prune/prune_test.go
@@ -3,8 +3,11 @@ package prune_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/xmtp/xmtpd/pkg/payerreport"
 
 	"go.uber.org/zap/zapcore"
 
@@ -18,16 +21,25 @@ import (
 )
 
 const (
-	DEFAULT_EXPIRED_CNT = 10
-	DEFAULT_VALID_CNT   = 5
+	DefaultOriginatorID = 100
+	DefaultExpiredCnt   = 10
+	DefaultValidCnt     = 5
+	DefaultSubmittedCnt = 10000
 )
 
-func setupTestData(t *testing.T, db *sql.DB, expired int, valid int) {
+func setupTestData(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	expired int,
+	valid int,
+	submitted int,
+) {
 	// Insert expired envelopes
 	for i := 0; i < expired; i++ {
 		testutils.InsertGatewayEnvelopes(t, db, []queries.InsertGatewayEnvelopeParams{{
-			OriginatorNodeID:     100,
-			OriginatorSequenceID: int64(i),
+			OriginatorNodeID:     DefaultOriginatorID,
+			OriginatorSequenceID: int64(i + 1),
 			Topic:                []byte("topic"),
 			OriginatorEnvelope:   []byte("payload"),
 			GatewayTime:          time.Now(),
@@ -38,14 +50,16 @@ func setupTestData(t *testing.T, db *sql.DB, expired int, valid int) {
 	// Insert non-expired envelopes
 	for i := 0; i < valid; i++ {
 		testutils.InsertGatewayEnvelopes(t, db, []queries.InsertGatewayEnvelopeParams{{
-			OriginatorNodeID:     100,
-			OriginatorSequenceID: int64(i + expired),
+			OriginatorNodeID:     DefaultOriginatorID,
+			OriginatorSequenceID: int64(i + expired + 1),
 			Topic:                []byte("topic"),
 			OriginatorEnvelope:   []byte("payload"),
 			GatewayTime:          time.Now(),
 			Expiry:               time.Now().Add(1 * time.Hour).Unix(),
 		}})
 	}
+
+	createPrunableReport(t, ctx, db, submitted)
 }
 
 func makeTestExecutor(
@@ -64,21 +78,50 @@ func makeTestExecutor(
 	)
 }
 
+func createPrunableReport(t *testing.T, ctx context.Context, db *sql.DB, endSequence int) {
+	if endSequence == 0 {
+		return
+	}
+
+	q := queries.New(db)
+
+	reportID := testutils.RandomReportID()
+
+	_, err := q.InsertOrIgnorePayerReport(ctx, queries.InsertOrIgnorePayerReportParams{
+		ID:                  reportID,
+		OriginatorNodeID:    DefaultOriginatorID,
+		StartSequenceID:     0,
+		EndSequenceID:       int64(endSequence),
+		EndMinuteSinceEpoch: 0,
+		PayersMerkleRoot:    make([]byte, 0),
+		ActiveNodeIds:       []int32{DefaultOriginatorID},
+	})
+	require.NoError(t, err)
+	err = q.SetReportSubmitted(ctx, queries.SetReportSubmittedParams{
+		ReportID:             reportID,
+		NewStatus:            payerreport.SubmissionSubmitted,
+		PrevStatus:           []int16{int16(payerreport.SubmissionPending)},
+		SubmittedReportIndex: 0,
+	})
+	require.NoError(t, err)
+}
+
 func TestExecutor_PrunesExpired(t *testing.T) {
 	ctx := context.Background()
 	dbs := testutils.NewDBs(t, ctx, 1)
 	db := dbs[0]
+	q := queries.New(db)
 
-	setupTestData(t, db, DEFAULT_EXPIRED_CNT, DEFAULT_VALID_CNT)
+	setupTestData(t, ctx, db, DefaultExpiredCnt, DefaultValidCnt, DefaultSubmittedCnt)
 
 	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
 		DryRun:    false,
 		MaxCycles: 5,
 	})
+
 	err := exec.Run()
 	assert.NoError(t, err)
 
-	q := queries.New(db)
 	cnt, err := q.CountExpiredEnvelopes(ctx)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, cnt, "All expired envelopes should be deleted")
@@ -88,7 +131,7 @@ func TestExecutor_PrunesExpired(t *testing.T) {
 	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_envelopes_meta`)
 	err = row.Scan(&total)
 	assert.NoError(t, err)
-	assert.EqualValues(t, DEFAULT_VALID_CNT, total, "Only non-expired envelopes should remain")
+	assert.EqualValues(t, DefaultValidCnt, total, "Only non-expired envelopes should remain")
 }
 
 func TestExecutor_DryRun_NoPrune(t *testing.T) {
@@ -96,7 +139,7 @@ func TestExecutor_DryRun_NoPrune(t *testing.T) {
 	dbs := testutils.NewDBs(t, ctx, 1)
 	db := dbs[0]
 
-	setupTestData(t, db, DEFAULT_EXPIRED_CNT, DEFAULT_VALID_CNT)
+	setupTestData(t, ctx, db, DefaultExpiredCnt, DefaultValidCnt, DefaultSubmittedCnt)
 
 	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
 		DryRun:    true,
@@ -112,7 +155,7 @@ func TestExecutor_DryRun_NoPrune(t *testing.T) {
 
 	assert.EqualValues(
 		t,
-		DEFAULT_VALID_CNT+DEFAULT_EXPIRED_CNT,
+		DefaultValidCnt+DefaultExpiredCnt,
 		total,
 		"All envelopes should still be present",
 	)
@@ -138,7 +181,7 @@ func TestExecutor_PrunesExpired_WithConcurrentLock(t *testing.T) {
 	db := dbs[0]
 	q := queries.New(db)
 
-	setupTestData(t, db, DEFAULT_EXPIRED_CNT, 0)
+	setupTestData(t, ctx, db, DefaultExpiredCnt, 0, DefaultSubmittedCnt)
 
 	tx := openAndHoldLock(t, ctx, db)
 
@@ -188,10 +231,11 @@ func TestExecutor_PrunesExpired_LargePayload(t *testing.T) {
 	ctx := context.Background()
 	dbs := testutils.NewDBs(t, ctx, 1)
 	db := dbs[0]
+	q := queries.New(db)
 
-	const KEEP_THIS_MANY = 10
+	const KeepThisMany = 10
 
-	setupTestData(t, db, 1000+KEEP_THIS_MANY, 0)
+	setupTestData(t, ctx, db, 1000+KeepThisMany, 0, DefaultSubmittedCnt)
 
 	// only allow for 1 cycle, which deletes at most 1000 envelopes
 	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
@@ -201,10 +245,9 @@ func TestExecutor_PrunesExpired_LargePayload(t *testing.T) {
 	err := exec.Run()
 	assert.NoError(t, err)
 
-	q := queries.New(db)
 	cnt, err := q.CountExpiredEnvelopes(ctx)
 	assert.NoError(t, err)
-	assert.EqualValues(t, KEEP_THIS_MANY, cnt)
+	assert.EqualValues(t, KeepThisMany, cnt)
 
 	// 2nd cycle should finish off
 	err = exec.Run()
@@ -219,7 +262,7 @@ func TestExecutor_PruneCountWorks(t *testing.T) {
 	dbs := testutils.NewDBs(t, ctx, 1)
 	db := dbs[0]
 
-	setupTestData(t, db, DEFAULT_EXPIRED_CNT, DEFAULT_VALID_CNT)
+	setupTestData(t, ctx, db, DefaultExpiredCnt, DefaultValidCnt, DefaultSubmittedCnt)
 
 	logger := testutils.NewCapturingLogger(zapcore.DebugLevel)
 
@@ -238,5 +281,152 @@ func TestExecutor_PruneCountWorks(t *testing.T) {
 
 	if !logger.Contains("count of envelopes eligible for pruning") {
 		t.Errorf("expected log message not found, got: %s", logger.Logs())
+	}
+}
+
+func TestExecutor_CantPruneWithoutReport(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+
+	setupTestData(t, ctx, db, DefaultExpiredCnt, DefaultValidCnt, 0)
+
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    false,
+		MaxCycles: 5,
+	})
+
+	err := exec.Run()
+	assert.NoError(t, err)
+
+	q := queries.New(db)
+	cnt, err := q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, cnt, "All expired envelopes should be deleted")
+
+	// Ensure all remain
+	var total int64
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_envelopes_meta`)
+	err = row.Scan(&total)
+	assert.NoError(t, err)
+	assert.EqualValues(
+		t,
+		DefaultValidCnt+DefaultExpiredCnt,
+		total,
+		"All envelopes should remain",
+	)
+}
+
+func TestExecutor_MultipleOverlappingReportsOK(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+
+	setupTestData(t, ctx, db, DefaultExpiredCnt, DefaultValidCnt, 0)
+
+	createPrunableReport(t, ctx, db, 10)
+	createPrunableReport(t, ctx, db, 50)
+	createPrunableReport(t, ctx, db, 100)
+
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    false,
+		MaxCycles: 5,
+	})
+
+	err := exec.Run()
+	assert.NoError(t, err)
+
+	q := queries.New(db)
+	cnt, err := q.CountExpiredEnvelopes(ctx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, cnt, "All expired envelopes should be deleted")
+
+	var total int64
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_envelopes_meta`)
+	err = row.Scan(&total)
+	assert.NoError(t, err)
+	assert.EqualValues(t, DefaultValidCnt, total, "Valid envelopes should remain")
+}
+
+func TestExecutor_ReportStatusVariants(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name   string
+		status int16
+		pruned int
+	}{
+		{
+			name:   "pending",
+			status: int16(payerreport.SubmissionPending),
+			pruned: 0,
+		},
+		{
+			name:   "rejected",
+			status: int16(payerreport.SubmissionRejected),
+			pruned: 0,
+		},
+		{
+			name:   "submitted",
+			status: int16(payerreport.SubmissionSubmitted),
+			pruned: DefaultExpiredCnt,
+		},
+		{
+			name:   "settled",
+			status: int16(payerreport.SubmissionSettled),
+			pruned: DefaultExpiredCnt,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("report-status-state-%s", tt.name), func(t *testing.T) {
+			dbs := testutils.NewDBs(t, ctx, 1)
+			db := dbs[0]
+
+			setupTestData(t, ctx, db, DefaultExpiredCnt, DefaultValidCnt, 0)
+
+			q := queries.New(db)
+			reportID := testutils.RandomReportID()
+			_, err := q.InsertOrIgnorePayerReport(ctx, queries.InsertOrIgnorePayerReportParams{
+				ID:                  reportID,
+				OriginatorNodeID:    DefaultOriginatorID,
+				StartSequenceID:     0,
+				EndSequenceID:       DefaultSubmittedCnt,
+				EndMinuteSinceEpoch: 0,
+				PayersMerkleRoot:    make([]byte, 0),
+				ActiveNodeIds:       []int32{DefaultOriginatorID},
+			})
+			require.NoError(t, err)
+
+			t.Logf("Setting report to state %d", tt.status)
+
+			err = q.SetReportSubmissionStatus(ctx, queries.SetReportSubmissionStatusParams{
+				ReportID:   reportID,
+				NewStatus:  tt.status,
+				PrevStatus: []int16{int16(payerreport.SubmissionPending)},
+			})
+			require.NoError(t, err)
+
+			cnt, err := q.CountExpiredEnvelopes(ctx)
+			assert.NoError(t, err)
+			assert.EqualValues(t, tt.pruned, cnt)
+
+			exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+				DryRun:    false,
+				MaxCycles: 5,
+			})
+
+			err = exec.Run()
+			assert.NoError(t, err)
+
+			var total int64
+			row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_envelopes_meta`)
+			err = row.Scan(&total)
+			assert.NoError(t, err)
+			assert.EqualValues(
+				t,
+				DefaultValidCnt+DefaultExpiredCnt-tt.pruned,
+				total,
+				"All envelopes should remain",
+			)
+		})
 	}
 }

--- a/pkg/testutils/random.go
+++ b/pkg/testutils/random.go
@@ -46,6 +46,10 @@ func RandomInboxIDBytes() [32]byte {
 	return inboxID
 }
 
+func RandomReportID() []byte {
+	return RandomBytes(32)
+}
+
 func RandomAddress() common.Address {
 	bytes := RandomBytes(20)
 	return common.BytesToAddress(bytes)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Restrict pruning to submitted/settled sequences by modifying `CountExpiredEnvelopes` and `DeleteExpiredEnvelopesBatch` to only act on `gateway_envelopes_meta` rows with `originator_sequence_id` <= COALESCE(MAX(`payer_reports.end_sequence_id`), 0) per `originator_node_id`
Introduce a `WITH max_prunable` CTE and join it to `gateway_envelopes_meta` in both queries to block deletion/counting of envelopes beyond reported sequence ranges; add tests covering report status variants and the absence/presence of prunable reports; update submission status comment to include `3 = rejected`.

#### 📍Where to Start
Start with the SQL changes in [pkg/db/sqlc/prune.sql](https://github.com/xmtp/xmtpd/pull/1332/files#diff-540405f1eed4e78df7e9d1fa7ae0de149323598c155ddad1f02f2b13dca8b621), then verify the corresponding generated code in [pkg/db/queries/prune.sql.go](https://github.com/xmtp/xmtpd/pull/1332/files#diff-9a959d77372eb085090720480556db88da7a707311780213d137648bbe61e0a8) and the new test coverage in [pkg/prune/prune_test.go](https://github.com/xmtp/xmtpd/pull/1332/files#diff-4017c4c995dfb20aa0d7f3e4f7714a2b1c542d31dddf2555425e840c9105a4fb).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 113095b.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->