### PR TITLE
PayerReports-1: Knuth distribution intervals

### DIFF
--- a/pkg/payerreport/workers/timers.go
+++ b/pkg/payerreport/workers/timers.go
@@ -4,23 +4,37 @@ import (
 	"time"
 )
 
+var (
+	// Spread nodes across N minutes (0 .. 59).
+	distributionSpreadMinutes uint32 = 60
+
+	// Run every M minutes.
+	repeatIntervalMinutes uint32 = 60
+)
+
 // Distributes the minute of the hour that each node will run operations on.
 // This is to avoid having many nodes do identical work at the same time, and potentially leading to
 // duplicate reports or submissions.
+//
+// TODO: Make distributionInterval and distributionRange configurable via blockchain parameters.
 func findNextRunTime(myNodeID uint32, workerID uint32) time.Time {
 	// Use a hash function to distribute node IDs evenly across minutes
 	// regardless of their numerical distribution
 	// Uses a Knuth multiplicative hash function
-	minuteOffset := int((((myNodeID + workerID) * 2654435761) >> 16) % 60)
+	minuteOffset := int((((myNodeID + workerID) * 2654435761) >> 16) % distributionSpreadMinutes)
 
 	now := time.Now().UTC()
+
 	// Next run is at the „minuteOffset" of the current hour unless that
 	// time has already passed.
 	nextRun := time.Date(
 		now.Year(), now.Month(), now.Day(), now.Hour(), minuteOffset, 0, 0, time.UTC,
 	)
-	if !nextRun.After(now) {
-		nextRun = nextRun.Add(time.Hour)
+
+	// Advance next run.
+	// The for loop cover corner cases where the next run is in the past.
+	for !nextRun.After(now) {
+		nextRun = nextRun.Add(time.Duration(repeatIntervalMinutes) * time.Minute)
 	}
 
 	return nextRun


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Make `workers.findNextRunTime` use configurable Knuth minute spread and repeat interval for PayerReports scheduling
Introduce package vars `distributionSpreadMinutes` (default 60) and `repeatIntervalMinutes` (default 60), apply `distributionSpreadMinutes` to the Knuth hash modulo, and advance `nextRun` in `repeatIntervalMinutes` steps until it exceeds `now` in [timers.go](https://github.com/xmtp/xmtpd/pull/1336/files#diff-65e7dcb5fd88def8a05b9462d52288762c3d934c0f0aa90de82d4d2a0fc7eb87).

#### 📍Where to Start
Start with the `findNextRunTime` logic in [timers.go](https://github.com/xmtp/xmtpd/pull/1336/files#diff-65e7dcb5fd88def8a05b9462d52288762c3d934c0f0aa90de82d4d2a0fc7eb87).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 863e42a.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->