### PR TITLE
PayerReports-2: Log string ID on fetch report

### DIFF
--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -254,7 +254,12 @@ func (w *GeneratorWorker) generateReport(nodeID uint32, lastReportEndSequenceID 
 		return err
 	}
 
-	w.logger.Info("generated report", utils.PayerReportIDField(reportID.String()))
+	w.logger.Info("generated report",
+		utils.PayerReportIDField(reportID.String()),
+		utils.StartSequenceIDField(int64(report.StartSequenceID)),
+		utils.LastSequenceIDField(int64(report.EndSequenceID)),
+		utils.OriginatorIDField(report.OriginatorNodeID),
+	)
 
 	return nil
 }


### PR DESCRIPTION
Currently it's logged via `zap.Any` which yields a bytes array, whereas on other part ID is logged as string. This makes debugging difficult.