### PR TITLE
Turn prints into logs

### DIFF
--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -33,16 +33,6 @@ func main() {
 		}
 	}
 
-	err = config.ParseJSONConfig(&options.Contracts)
-	if err != nil {
-		fatal("could not parse JSON contracts config: %s", err)
-	}
-
-	err = config.ValidatePruneOptions(options)
-	if err != nil {
-		fatal("could not validate options: %s", err)
-	}
-
 	logger, _, err := utils.BuildLogger(options.Log)
 	if err != nil {
 		fatal("could not build logger: %s", err)
@@ -50,6 +40,18 @@ func main() {
 	logger = logger.Named(utils.PrunerLoggerName)
 
 	logger.Info(fmt.Sprintf("version: %s", Version))
+
+	validator := config.NewOptionsValidator(logger)
+
+	err = validator.ParseJSONConfig(&options.Contracts)
+	if err != nil {
+		fatal("could not parse JSON contracts config: %s", err)
+	}
+
+	err = validator.ValidatePruneOptions(options)
+	if err != nil {
+		fatal("could not validate options: %s", err)
+	}
 
 	ctx := context.Background()
 

--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -75,7 +75,8 @@ func main() {
 		options.API.Enable = true
 	}
 
-	err = config.ValidateServerOptions(&options)
+	validator := config.NewOptionsValidator(logger)
+	err = validator.ValidateServerOptions(&options)
 	if err != nil {
 		fatal("could not validate options: %s", err)
 	}

--- a/dev/run-reporting
+++ b/dev/run-reporting
@@ -4,10 +4,7 @@ set -eu
 
 . dev/local.env
 
-export XMTPD_REFLECTION_ENABLE=true
 export XMTPD_PAYER_REPORT_RUN_WORKERS=true
-export XMTPD_METRICS_ENABLE=true
-export XMTPD_METRICS_METRICS_ADDRESS=0.0.0.0
 export XMTPD_CONTRACTS_ENVIRONMENT=anvil
 
 go run -ldflags="-X main.Version=$(git describe HEAD --tags --long)" cmd/replication/main.go "$@"

--- a/pkg/gateway/helpers.go
+++ b/pkg/gateway/helpers.go
@@ -59,7 +59,13 @@ func LoadConfigFromEnv() (*config.GatewayConfig, error) {
 		return nil, err
 	}
 
-	if err = config.ParseJSONConfig(&cfg.Contracts); err != nil {
+	logger, _, err := utils.BuildLogger(cfg.Log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build logger: %v", err)
+	}
+
+	validator := config.NewOptionsValidator(logger)
+	if err = validator.ParseJSONConfig(&cfg.Contracts); err != nil {
 		return nil, fmt.Errorf("could not parse contracts JSON config: %s", err)
 	}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Replace prints with structured logging and validate options via `config.OptionsValidator` in CLI entrypoints and gateway config loading
Introduce `config.OptionsValidator` bound to a zap logger; switch config parsing and validation to instance methods; initialize and name the logger before option parsing in CLI; update gateway config loading to build a logger and parse contracts config with the validator; remove unused env exports from the reporting script.

#### 📍Where to Start
Start at `main` in [cmd/prune/main.go](https://github.com/xmtp/xmtpd/pull/1340/files#diff-4039fdc6d104f56ad8d0fb6dbbbabe36a2b635478cc1def051fadd4a868aa524) to see logger initialization and validator wiring, then review the `config.OptionsValidator` implementation in [pkg/config/validation.go](https://github.com/xmtp/xmtpd/pull/1340/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e278669.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->