### PR TITLE
Track latest local sequence ID

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/xmtp/xmtpd/pkg/metrics"
 	"github.com/xmtp/xmtpd/pkg/utils/retryerrors"
 
 	"connectrpc.com/connect"
@@ -631,6 +632,11 @@ func (s *Service) PublishPayerEnvelopes(
 
 	s.publishWorker.notifyStagedPublish()
 	s.waitForGatewayPublish(ctx, latestStaged, logger)
+
+	metrics.EmitSyncLastSeenOriginatorSequenceID(
+		s.registrant.NodeID(),
+		uint64(latestStaged.ID),
+	)
 
 	return connect.NewResponse(&message_api.PublishPayerEnvelopesResponse{
 		OriginatorEnvelopes: results,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Emit latest local originator sequence ID metrics from `Service.PublishPayerEnvelopes` in [service.go](https://github.com/xmtp/xmtpd/pull/1358/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) to track the latest local sequence ID
Add `metrics.EmitSyncLastSeenOriginatorSequenceID(s.registrant.NodeID(), uint64(latestStaged.ID))` after gateway publish in `Service.PublishPayerEnvelopes`, and import `github.com/xmtp/xmtpd/pkg/metrics` in [service.go](https://github.com/xmtp/xmtpd/pull/1358/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2).

#### 📍Where to Start
Start at the `Service.PublishPayerEnvelopes` handler in [service.go](https://github.com/xmtp/xmtpd/pull/1358/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2), focusing on the post-publish metrics emission call.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized fde025e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->