### PR TITLE
Fix typos

### DIFF
--- a/pkg/indexer/settlement_chain/contracts/payer_registry.go
+++ b/pkg/indexer/settlement_chain/contracts/payer_registry.go
@@ -66,7 +66,7 @@ func NewPayerRegistry(
 		return nil, err
 	}
 
-	logger = logger.Named(utils.PayerReportContractLoggerName).
+	logger = logger.Named(utils.PayerRegistryContractLoggerName).
 		With(utils.ContractAddressField(address.Hex()))
 
 	payerRegistryStorer, err := NewPayerRegistryStorer(

--- a/pkg/payerreport/generator.go
+++ b/pkg/payerreport/generator.go
@@ -2,7 +2,7 @@ package payerreport
 
 import (
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/xmtp/xmtpd/pkg/currency"
@@ -154,7 +154,7 @@ func extractActiveNodeIDs(nodes []registry.Node) []uint32 {
 		activeNodeIDs[i] = node.NodeID
 	}
 
-	sort.Slice(activeNodeIDs, func(i, j int) bool { return activeNodeIDs[i] < activeNodeIDs[j] })
+	slices.Sort(activeNodeIDs)
 
 	return activeNodeIDs
 }

--- a/pkg/sync/sync_worker.go
+++ b/pkg/sync/sync_worker.go
@@ -381,10 +381,10 @@ func (s *syncWorker) setupStream(
 		)
 	}
 
-	lastSequenceId := uint64(0)
+	lastSequenceID := uint64(0)
 	for _, row := range result {
 		if slices.Contains(originatorNodeIDs, uint32(row.OriginatorNodeID)) {
-			lastSequenceId = uint64(row.OriginatorSequenceID)
+			lastSequenceID = uint64(row.OriginatorSequenceID)
 		}
 	}
 
@@ -392,7 +392,7 @@ func (s *syncWorker) setupStream(
 		s.ctx,
 		s.logger,
 		&node,
-		lastSequenceId,
+		lastSequenceID,
 		stream,
 		writeQueue,
 	), nil

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -50,7 +50,7 @@ const (
 	AppChainIndexerLoggerName            = "app-chain"
 	GroupMessageBroadcasterLoggerName    = "group-message-broadcaster"
 	IdentityUpdateBroadcasterLoggerName  = "identity-update-broadcaster"
-	PayerReportContractLoggerName        = "payer-report"
+	PayerRegistryContractLoggerName      = "payer-registry"
 	PayerReportManagerContractLoggerName = "payer-report-manager"
 	RPCLogStreamerLoggerName             = "rpc-log-streamer"
 	StorerLoggerName                     = "storer"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Rename logger to `utils.PayerRegistryContractLoggerName` and update `contracts.NewPayerRegistry` to use `payer-registry`
Updates logger naming from `payer-report` to `payer-registry` and applies the new constant in `contracts.NewPayerRegistry`. Also switches `payerreport.extractActiveNodeIDs` sorting to `slices.Sort` and standardizes `lastSequenceID` naming in `syncWorker.setupStream`.

#### 📍Where to Start
Start with `contracts.NewPayerRegistry` in [payer_registry.go](https://github.com/xmtp/xmtpd/pull/1382/files#diff-1bf2fe0a2cfb5086289b10bb02cf6523e12eb52a91ff6f0667f508e467db0439).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized cf10744.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->