### PR TITLE
Remove protocol error SettleUsageFailed

### DIFF
--- a/pkg/blockchain/errors.go
+++ b/pkg/blockchain/errors.go
@@ -100,7 +100,6 @@ var (
 		"PayerReportNotSettled(uint32,uint256)",
 	)
 	ErrPendingWithdrawalExists = fmt.Errorf("PendingWithdrawalExists()")
-	ErrSettleUsageFailed       = fmt.Errorf("SettleUsageFailed(bytes)")
 	ErrTransferFailed          = fmt.Errorf("TransferFailed()")
 	ErrTransferFromFailed      = fmt.Errorf("TransferFromFailed()")
 	ErrUnorderedNodeIDs        = fmt.Errorf("UnorderedNodeIds()")
@@ -198,7 +197,6 @@ var (
 		"0xc3e0931f": ErrPayerReportIndexOutOfBounds,
 		"0x7fddb8df": ErrPayerReportNotSettled,
 		"0x75c41473": ErrPendingWithdrawalExists,
-		"0xcaa2acb9": ErrSettleUsageFailed,
 		"0x90b8ec18": ErrTransferFailed,
 		"0x7939f424": ErrTransferFromFailed,
 		"0x99a67242": ErrUnorderedNodeIDs,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove protocol error `ErrSettleUsageFailed` and delete selector `0xcaa2acb9` mapping in [errors.go](https://github.com/xmtp/xmtpd/pull/1390/files#diff-ab170895982dd4ada75b480013cd68a3cffbb7b1d8178f2bc1151756b425dcca)
Delete the exported `ErrSettleUsageFailed` variable and remove its entry from the protocol error selector map for `0xcaa2acb9` in [errors.go](https://github.com/xmtp/xmtpd/pull/1390/files#diff-ab170895982dd4ada75b480013cd68a3cffbb7b1d8178f2bc1151756b425dcca).

#### 📍Where to Start
Start with the protocol error map and the declaration of `ErrSettleUsageFailed` in [errors.go](https://github.com/xmtp/xmtpd/pull/1390/files#diff-ab170895982dd4ada75b480013cd68a3cffbb7b1d8178f2bc1151756b425dcca).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f92b416.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->