### PR TITLE
Fix merkle comment typo

### DIFF
--- a/pkg/merkle/tree.go
+++ b/pkg/merkle/tree.go
@@ -13,10 +13,10 @@ type Leaf []byte
 
 // MerkleTree is a binary Merkle tree.
 //
-// tree has the collection of nodes, where:
-// - The tree is 1-indexed, so root is at index 1.
-// - The internal nodes are at index 1 to N-1.
-// - The leaves are at index N to 2N-1.
+// The tree is built as a balanced tree, where:
+// The root is at index 0, internal nodes are at index 1 to N-1, and the leaves are at index N to 2N-1.
+// Empty nodes and leaves are nil and not hashed, to save space.
+
 type MerkleTree struct {
 	tree   []Node
 	leaves []Leaf


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Correct MerkleTree doc comment in `pkg/merkle/tree.go` to state root at index 0 and note nil empty nodes and leaves
Updates the `MerkleTree` struct documentation to reflect 0-indexed root and clarifies that empty nodes and leaves are `nil` and not hashed in [tree.go](https://github.com/xmtp/xmtpd/pull/1393/files#diff-4a0ec8af27f891e4481136ec6a06b2eea6423d8992b8ea8c5c14d841b05b4d9a).

#### 📍Where to Start
Start with the `MerkleTree` struct doc comment in [tree.go](https://github.com/xmtp/xmtpd/pull/1393/files#diff-4a0ec8af27f891e4481136ec6a06b2eea6423d8992b8ea8c5c14d841b05b4d9a).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2a966ac.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->