### PR TITLE
Enhance payer report system logging

### DIFF
--- a/pkg/payerreport/store.go
+++ b/pkg/payerreport/store.go
@@ -216,6 +216,7 @@ func (s *Store) SetReportSettled(ctx context.Context, id ReportID) error {
 
 			s.logger.Info(
 				"cleared unsettled usage",
+				utils.OriginatorIDField(uint32(existingReport.OriginatorNodeID)),
 				zap.Int32("prev_report_end_minute_since_epoch", prevReportEndMinuteSinceEpoch),
 				zap.Int32(
 					"existing_report_end_minute_since_epoch",
@@ -233,6 +234,8 @@ func (s *Store) SetReportSettled(ctx context.Context, id ReportID) error {
 			); err != nil {
 				s.logger.Error(
 					"failed to set report submission status",
+					utils.OriginatorIDField(uint32(existingReport.OriginatorNodeID)),
+					utils.PayerReportIDField(id.String()),
 					zap.Error(err),
 				)
 				return err
@@ -358,7 +361,8 @@ func (s *Store) CreateAttestation(
 			if AttestationStatus(report.AttestationStatus) != AttestationPending {
 				s.logger.Debug(
 					"report already approved or rejected",
-					utils.PayerReportIDField(fmt.Sprintf("%x", reportID)),
+					utils.OriginatorIDField(uint32(report.OriginatorNodeID)),
+					utils.PayerReportIDField(attestation.Report.ID.String()),
 					zap.Int16("attestation_status", report.AttestationStatus),
 				)
 				return nil

--- a/pkg/payerreport/verifier.go
+++ b/pkg/payerreport/verifier.go
@@ -275,6 +275,7 @@ func (p *PayerReportVerifier) isAtMinuteEnd(
 	if !isAtMinuteEnd {
 		p.logger.Debug(
 			"sequence id is not the last message in the minute",
+			utils.OriginatorIDField(uint32(originatorID)),
 			utils.LastSequenceIDField(lastSequenceID),
 			zap.Int32("minute", minute),
 			zap.Int64("expected_sequence_id", expectedSequenceID),

--- a/pkg/payerreport/workers/attestation.go
+++ b/pkg/payerreport/workers/attestation.go
@@ -34,6 +34,8 @@ type AttestationWorker struct {
 	domainSeparator common.Hash
 }
 
+var _ stoppable = &AttestationWorker{}
+
 // NewAttestationWorker creates and starts a new attestation worker that will periodically
 // check for reports that need attestation.
 // It takes a context, logger, registrant for signing, store for accessing reports,

--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -36,6 +36,8 @@ type GeneratorWorker struct {
 	expiryOthersPeriod   time.Duration
 }
 
+var _ stoppable = &GeneratorWorker{}
+
 func NewGeneratorWorker(
 	ctx context.Context,
 	logger *zap.Logger,

--- a/pkg/payerreport/workers/settlement.go
+++ b/pkg/payerreport/workers/settlement.go
@@ -29,6 +29,8 @@ type SettlementWorker struct {
 	myNodeID         uint32
 }
 
+var _ stoppable = &SettlementWorker{}
+
 func NewSettlementWorker(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -38,6 +40,7 @@ func NewSettlementWorker(
 	myNodeID uint32,
 ) *SettlementWorker {
 	ctx, cancel := context.WithCancel(ctx)
+
 	return &SettlementWorker{
 		logger:           logger.Named(utils.PayerReportSettlementWorkerLoggerName),
 		ctx:              ctx,

--- a/pkg/payerreport/workers/submitter.go
+++ b/pkg/payerreport/workers/submitter.go
@@ -26,6 +26,8 @@ type SubmitterWorker struct {
 	myNodeID         uint32
 }
 
+var _ stoppable = &SubmitterWorker{}
+
 func NewSubmitterWorker(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -35,6 +37,7 @@ func NewSubmitterWorker(
 	myNodeID uint32,
 ) *SubmitterWorker {
 	ctx, cancel := context.WithCancel(ctx)
+
 	return &SubmitterWorker{
 		logger:           logger.Named(utils.PayerReportSubmitterWorkerLoggerName),
 		ctx:              ctx,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -326,7 +326,10 @@ func NewBaseServer(
 			sync.WithRegistrant(svc.registrant),
 			sync.WithDB(cfg.DB),
 			sync.WithFeeCalculator(cfg.FeeCalculator),
-			sync.WithPayerReportStore(payerreport.NewStore(cfg.DB, cfg.Logger)),
+			sync.WithPayerReportStore(
+				payerreport.NewStore(cfg.DB, cfg.Logger.Named(utils.PayerReportMainLoggerName).
+					With(utils.WorkerNodeIDField(svc.registrant.NodeID()))),
+			),
 			sync.WithPayerReportDomainSeparator(domainSeparator),
 		)
 		if err != nil {
@@ -384,7 +387,8 @@ func NewBaseServer(
 			return nil, err
 		}
 
-		payerReportBaseLogger := cfg.Logger.Named(utils.PayerReportMainLoggerName)
+		payerReportBaseLogger := cfg.Logger.Named(utils.PayerReportMainLoggerName).
+			With(utils.WorkerNodeIDField(svc.registrant.NodeID()))
 
 		workerConfig, err := workers.NewWorkerConfigBuilder().
 			WithLogger(payerReportBaseLogger).

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -309,3 +309,7 @@ func ToAddressField(toAddress string) zap.Field {
 func TopicField(topic string) zap.Field {
 	return zap.String("topic", topic)
 }
+
+func WorkerNodeIDField(nodeID uint32) zap.Field {
+	return zap.Uint32("worker_node_id", nodeID)
+}


### PR DESCRIPTION
`worker_node_id`
  - The current node running the worker (always present from base logger)
  - Filter logs by "which node am I debugging"

`originator_id`
  - The node that originated the report/attestation being acted upon
  - Filter logs by "which report originator am I investigating"

`report_id`
  - Unique identifier for the specific report
  - Trace a specific report through its lifecycle

Filtering examples in DD:

```
# All payer report logs from node 100
@worker_node_id:100 @caller:xmtpd.payer-report.*

# All reports originated by node 200, observed from any node
@originator_id:200

# Node 100 attesting reports from node 200
@worker_node_id:100 @originator_id:200 @caller:*attestation-worker*

# Trace a specific report across all nodes
@report_id:"abc123..."
# All payer report logs from node 100@worker_node_id:100 @caller:xmtpd.payer-report.*# All reports originated by node 200, observed from any node@originator_id:200# Node 100 attesting reports from node 200@worker_node_id:100 @originator_id:200 @caller:*attestation-worker*# Trace a specific report across all nodes@report_id:"abc123..."
```