### PR TITLE
Add client metrics in node to node sync

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -319,6 +319,7 @@ func NewBaseServer(
 			log.Error("failed to get domain separator", zap.Error(err))
 			return nil, err
 		}
+
 		svc.sync, err = sync.NewSyncServer(
 			sync.WithContext(svc.ctx),
 			sync.WithLogger(cfg.Logger),
@@ -328,6 +329,7 @@ func NewBaseServer(
 			sync.WithFeeCalculator(cfg.FeeCalculator),
 			sync.WithPayerReportStore(payerreport.NewStore(cfg.DB, cfg.Logger)),
 			sync.WithPayerReportDomainSeparator(domainSeparator),
+			sync.WithClientMetrics(clientMetrics),
 		)
 		if err != nil {
 			cfg.Logger.Error("failed to initialize sync server", zap.Error(err))


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Require and pass Prometheus `ClientMetrics` into sync server to add client metrics to node-to-node sync
Add `ClientMetrics` to `SyncServerConfig`, require it in `NewSyncServer`, pass it from `NewBaseServer`, and attach unary and stream client interceptors in `syncWorker.connectToNode` after auth. See [server.go](https://github.com/xmtp/xmtpd/pull/1404/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996), [server.go](https://github.com/xmtp/xmtpd/pull/1404/files#diff-a6653905697dd73c403bb9463230cc7376fd81e63495c52de100ffc0b2394231), and [sync_worker.go](https://github.com/xmtp/xmtpd/pull/1404/files#diff-566958c8832792b443513b0e677f3bdb0b96ffbd906d68b1cccc257aae31c852).

#### 📍Where to Start
Start with `NewSyncServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1404/files#diff-a6653905697dd73c403bb9463230cc7376fd81e63495c52de100ffc0b2394231) to review the new `ClientMetrics` requirement, then follow initialization from `NewBaseServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1404/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996) and interceptor wiring in `syncWorker.connectToNode` in [sync_worker.go](https://github.com/xmtp/xmtpd/pull/1404/files#diff-566958c8832792b443513b0e677f3bdb0b96ffbd906d68b1cccc257aae31c852).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 05f27c1.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->