### PR TITLE
XMTPD Goreleaser for Darwin and Linux

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,16 +38,19 @@ archives:
     ids: [ xmtpd ]
     formats: [ "zip" ]
     name_template: '{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
 
   - id: xmtpd-tars
     ids: [ xmtpd ]
     formats: [ "tar.gz" ]
     name_template: '{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
 
   - id: zips
     ids: [xmtpd-cli]
     formats: ["zip"]
     name_template: '{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
     files:
       - LICENSE*
       - src: build/completions/xmtpd-cli.bash
@@ -61,6 +64,7 @@ archives:
     ids: [xmtpd-cli]
     formats: ["tar.gz"]
     name_template: '{{ .Binary }}_{{ replace .Version "/" "-" }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
     files:
       - LICENSE*
       - src: build/completions/xmtpd-cli.bash


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add Goreleaser build for `xmtpd` to produce Darwin and Linux amd64/arm64 archives with CGO disabled and version ldflags
Add a new `xmtpd` build in [.goreleaser.yaml](https://github.com/xmtp/xmtpd/pull/1413/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826) targeting linux/darwin on amd64/arm64 with `CGO_ENABLED=0`, inject `Version` and `ShortCommit` via ldflags, create zip and tar.gz archives for `xmtpd` with directory wrapping, and enable directory wrapping for existing CLI archives.

#### 📍Where to Start
Start with the `builds` and `archives` sections in [.goreleaser.yaml](https://github.com/xmtp/xmtpd/pull/1413/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 911523c.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->