### PR TITLE
Return CodeCanceled properly

### DIFF
--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -164,6 +164,13 @@ func (s *Service) PublishClientEnvelopes(
 
 		originatorEnvelopes, err := s.publishToNodeWithRetry(ctx, originatorID, payloadsWithIndex)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, connect.NewError(
+					connect.CodeCanceled,
+					errors.New("request canceled by client"),
+				)
+			}
+
 			return nil, connect.NewError(
 				connect.CodeInternal,
 				fmt.Errorf("error publishing payer envelopes: %w", err),
@@ -279,7 +286,7 @@ func (s *Service) publishToNodeWithRetry(
 
 		// Don't retry or ban nodes if context was cancelled.
 		if ctx.Err() != nil {
-			s.logger.Debug("request cancelled by client", zap.Error(err))
+			s.logger.Debug("request canceled by client", zap.Error(err))
 			return nil, err
 		}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Return `CodeCanceled` with message 'request canceled by client' from `payer.Service.PublishClientEnvelopes` when the request context is canceled during `publishToNodeWithRetry`
Update `payer.Service.PublishClientEnvelopes` to map canceled contexts to `CodeCanceled` and adjust a debug log string in `publishToNodeWithRetry` in [service.go](https://github.com/xmtp/xmtpd/pull/1417/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280).

#### 📍Where to Start
Start with the `PublishClientEnvelopes` handler in [service.go](https://github.com/xmtp/xmtpd/pull/1417/files#diff-68452fc27f6bc31d33c1a89c833c0f4d3f76632124587b98e44b5e241629f280).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0c7c18f. 1 file reviewed, 4 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/api/payer/service.go — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 137](https://github.com/xmtp/xmtpd/blob/0c7c18fc1526d8b26a52692cdabbac86025294a7/pkg/api/payer/service.go#L137): On error from `env.payload.Bytes()` the function returns the raw `err` (`return nil, err`) rather than a Connect error. This is inconsistent with other errors in the method (which use `connect.NewError`) and can cause the client to receive an unmapped/unknown status instead of `InvalidArgument`. Wrap the error using `connect.NewError(connect.CodeInvalidArgument, err)` or a specific code. <b>[ Low confidence ]</b>
- [line 140](https://github.com/xmtp/xmtpd/blob/0c7c18fc1526d8b26a52692cdabbac86025294a7/pkg/api/payer/service.go#L140): The size check returns `status.Errorf(codes.InvalidArgument, ...)` (gRPC status) inside a Connect service. Other errors use `connect.NewError`. Mixing error types can result in incorrect wire status for Connect clients. Use `connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("message at index %d too large", env.originalIndex))` for consistency. <b>[ Out of scope ]</b>
- [line 195](https://github.com/xmtp/xmtpd/blob/0c7c18fc1526d8b26a52692cdabbac86025294a7/pkg/api/payer/service.go#L195): Cancellation is mapped to `CodeCanceled` for node publishing errors but not for blockchain publishing errors. If `ctx` is canceled and `s.publishToBlockchain` returns an error due to cancellation, the method returns `connect.CodeInternal` instead of `connect.CodeCanceled`. Add a `ctx.Err()` check before wrapping the blockchain publish error to consistently return `CodeCanceled`. <b>[ Low confidence ]</b>
- [line 276](https://github.com/xmtp/xmtpd/blob/0c7c18fc1526d8b26a52692cdabbac86025294a7/pkg/api/payer/service.go#L276): `indexedEnvelopes[0]` is accessed without validating that `indexedEnvelopes` is non-empty. If the caller passes an empty slice (e.g., due to a grouping anomaly), this will panic. Add a length check before indexing and return a clear error if empty. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->