### PR TITLE
Extend retryable pg errors

### DIFF
--- a/pkg/db/subscription.go
+++ b/pkg/db/subscription.go
@@ -93,7 +93,7 @@ func (s *DBSubscription[ValueType, CursorType]) poll() {
 		} else if err != nil {
 			// Log is extremely noisy during test teardown
 			s.logger.Error(
-				"",
+				"error querying for database subscription",
 				zap.Error(err),
 				utils.NumRowsField(s.options.NumRows),
 			)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Extend retryable PostgreSQL error handling by updating `retryerrors.IsRetryableSQLError` to include 40003, 08001, and 08007
Expand retryable SQL detection in `retryerrors.IsRetryableSQLError` and adjust an error log message in `db.DBSubscription.poll` in [pkg/utils/retryerrors/sql_errors.go](https://github.com/xmtp/xmtpd/pull/1423/files#diff-46303fb4daac88053851c5441bbc781272ae9dac93d97e0106bb4c1d71a4475d) and [pkg/db/subscription.go](https://github.com/xmtp/xmtpd/pull/1423/files#diff-2af031639fabe8db927ae2b9d80ab346ea90e66ed03d407148a8c7c6fcb25a9a).

#### 📍Where to Start
Start with `retryerrors.IsRetryableSQLError` in [pkg/utils/retryerrors/sql_errors.go](https://github.com/xmtp/xmtpd/pull/1423/files#diff-46303fb4daac88053851c5441bbc781272ae9dac93d97e0106bb4c1d71a4475d), then review the logging change in `db.DBSubscription.poll` in [pkg/db/subscription.go](https://github.com/xmtp/xmtpd/pull/1423/files#diff-2af031639fabe8db927ae2b9d80ab346ea90e66ed03d407148a8c7c6fcb25a9a).

<!-- Macroscope's changelog starts here -->
#### Changes since #1423 opened

- Updated error logging in `DBSubscription.poll` method to include descriptive message when query errors occur [17aa032]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 87bc502.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->