### PR TITLE
Avoid log overflow

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -240,7 +240,7 @@ func (s *Service) catchUpFromCursor(
 		}
 
 		if s.logger.Core().Enabled(zap.DebugLevel) {
-			logger.Debug("fetched envelopes", utils.BodyField(rows))
+			logger.Debug("fetched envelopes", utils.CountField(int64(len(rows))))
 		}
 
 		envs := make([]*envelopes.OriginatorEnvelope, 0, len(rows))


### PR DESCRIPTION
This log line can carry more than the allowed max size in Datadog. When that happens, DD splits the log line into multiple logs with `partial_id`, `partial_ordinal`, `partial_message` and `partial_last`.

This is not a major problem for us, so just show the count here.