### PR TITLE
Serialize deploys on main using concurrency to prevent race conditions

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: build-and-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   push_to_registry:
     strategy:
@@ -87,9 +91,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: push_to_registry
     if: github.ref == 'refs/heads/main'
-    concurrency:
-      group: deploy-testnet-staging-main
-      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Serialize main branch deploys by grouping GitHub Actions runs with concurrency group 'build-and-deploy-${{ github.ref }}' and setting 'cancel-in-progress: false' in [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1435/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9)
Add a top-level `concurrency` block to [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1435/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9) that groups runs by `github.ref` and queues subsequent runs for the same ref without canceling in-progress runs.

#### 📍Where to Start
Start at the top-level `concurrency` configuration in [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1435/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e45d511.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->