### PR TITLE
Migrator: add option for migration start date

### DIFF
--- a/pkg/config/migrator.go
+++ b/pkg/config/migrator.go
@@ -14,6 +14,7 @@ type MigrationServerOptions struct {
 	BatchSize              int32         `long:"batch-size"               env:"XMTPD_MIGRATION_DB_BATCH_SIZE"               description:"Batch size for migration"                       default:"1000"`
 	PollInterval           time.Duration `long:"process-interval"         env:"XMTPD_MIGRATION_DB_PROCESS_INTERVAL"         description:"Interval for processing migration"              default:"10s"`
 	Namespace              string        `long:"namespace"                env:"XMTPD_MIGRATION_DB_NAMESPACE"                description:"Namespace for migration"                        default:""`
+	StartDate              time.Time     `long:"start-date"               env:"XMTPD_MIGRATION_START_DATE"                  description:"Start date for migration"                       default:"2025-10-01T00:00:00Z"`
 }
 
 type MigrationClientOptions struct {

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -179,11 +179,11 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 	}
 
 	readers := map[string]ISourceReader{
-		groupMessagesTableName:   NewGroupMessageReader(reader),
-		inboxLogTableName:        NewInboxLogReader(reader),
+		groupMessagesTableName:   NewGroupMessageReader(reader, cfg.options.StartDate.Unix()),
+		inboxLogTableName:        NewInboxLogReader(reader, cfg.options.StartDate.UnixNano()),
 		keyPackagesTableName:     NewKeyPackageReader(reader),
-		welcomeMessagesTableName: NewWelcomeMessageReader(reader),
-		commitMessagesTableName:  NewCommitMessageReader(reader),
+		welcomeMessagesTableName: NewWelcomeMessageReader(reader, cfg.options.StartDate.Unix()),
+		commitMessagesTableName:  NewCommitMessageReader(reader, cfg.options.StartDate.Unix()),
 	}
 
 	transformer := NewTransformer(payerPrivateKey, nodeSigningKey)

--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -70,6 +70,7 @@ func newMigratorTest(t *testing.T) *migratorTest {
 			WaitForDB:              5 * time.Second,
 			BatchSize:              1000,
 			PollInterval:           500 * time.Millisecond,
+			StartDate:              startDate,
 		}),
 		migrator.WithContractsOptions(chainConfig),
 	)

--- a/pkg/migrator/reader_test.go
+++ b/pkg/migrator/reader_test.go
@@ -2,11 +2,14 @@ package migrator_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/migrator"
 	"github.com/xmtp/xmtpd/pkg/migrator/testdata"
 )
+
+var startDate time.Time
 
 func TestGroupMessageReader(t *testing.T) {
 	ctx := t.Context()
@@ -14,7 +17,7 @@ func TestGroupMessageReader(t *testing.T) {
 	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
 	defer cleanup()
 
-	reader := migrator.NewGroupMessageReader(db)
+	reader := migrator.NewGroupMessageReader(db, startDate.Unix())
 
 	cases := []struct {
 		name      string
@@ -66,7 +69,7 @@ func TestInboxLogReader(t *testing.T) {
 	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
 	defer cleanup()
 
-	reader := migrator.NewInboxLogReader(db)
+	reader := migrator.NewInboxLogReader(db, startDate.UnixNano())
 
 	cases := []struct {
 		name      string
@@ -170,7 +173,7 @@ func TestCommitMessageReader(t *testing.T) {
 	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
 	defer cleanup()
 
-	reader := migrator.NewCommitMessageReader(db)
+	reader := migrator.NewCommitMessageReader(db, startDate.Unix())
 
 	cases := []struct {
 		name   string
@@ -217,7 +220,7 @@ func TestWelcomeMessageReader(t *testing.T) {
 	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
 	defer cleanup()
 
-	reader := migrator.NewWelcomeMessageReader(db)
+	reader := migrator.NewWelcomeMessageReader(db, startDate.Unix())
 
 	cases := []struct {
 		name      string

--- a/pkg/migrator/transformer_test.go
+++ b/pkg/migrator/transformer_test.go
@@ -64,7 +64,7 @@ func newTransformerTest(t *testing.T) *transformerTest {
 func TestTransformGroupMessage(t *testing.T) {
 	var (
 		test   = newTransformerTest(t)
-		reader = migrator.NewGroupMessageReader(test.db)
+		reader = migrator.NewGroupMessageReader(test.db, startDate.Unix())
 	)
 
 	defer test.cleanup()
@@ -131,7 +131,7 @@ func TestTransformGroupMessage(t *testing.T) {
 func TestTransformCommitMessage(t *testing.T) {
 	var (
 		test   = newTransformerTest(t)
-		reader = migrator.NewCommitMessageReader(test.db)
+		reader = migrator.NewCommitMessageReader(test.db, startDate.Unix())
 	)
 
 	defer test.cleanup()
@@ -198,7 +198,7 @@ func TestTransformCommitMessage(t *testing.T) {
 func TestTransformInboxLog(t *testing.T) {
 	var (
 		test   = newTransformerTest(t)
-		reader = migrator.NewInboxLogReader(test.db)
+		reader = migrator.NewInboxLogReader(test.db, startDate.UnixNano())
 	)
 
 	defer test.cleanup()
@@ -345,7 +345,7 @@ func TestTransformKeyPackage(t *testing.T) {
 func TestTransformWelcomeMessage(t *testing.T) {
 	var (
 		test   = newTransformerTest(t)
-		reader = migrator.NewWelcomeMessageReader(test.db)
+		reader = migrator.NewWelcomeMessageReader(test.db, startDate.Unix())
 	)
 
 	defer test.cleanup()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add migrator start date option and filter readers by `MigrationServerOptions.StartDate` across group, inbox_log, welcome, and commit tables
Introduce a `start-date` config on `MigrationServerOptions` and pass it into reader constructors to time-filter queries; update `DBReader` to accept an optional timestamp arg and conditionally append it to SQL; wire through seconds for created_at tables and nanoseconds for inbox_log. KeyPackageReader remains unfiltered.

#### 📍Where to Start
Start at `migrator.NewMigrationService` in [migrator.go](https://github.com/xmtp/xmtpd/pull/1442/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693) to see how `StartDate` flows into reader constructors, then review the SQL changes in [reader.go](https://github.com/xmtp/xmtpd/pull/1442/files#diff-5afb69a12b4d409ea45341dca6b796f48dc578ab56ad078142152b5628bf0828).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d4e7058. 3 files reviewed, 3 issues evaluated, 2 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/config/migrator.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 17](https://github.com/xmtp/xmtpd/blob/d4e70585796ca99237effae01e3a3e642d6bcecb/pkg/config/migrator.go#L17): The `default:"2025-10-01T00:00:00Z"` tag on the `StartDate` field of type `time.Time` may not be parsed correctly by the go-flags library. Many Go configuration libraries do not automatically handle string-to-`time.Time` conversion for default values, which could result in a zero `time.Time` value being used instead of the intended default, or a runtime panic during config parsing depending on the library implementation. <b>[ Low confidence ]</b>
</details>

<details>
<summary>pkg/migrator/migrator.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 182](https://github.com/xmtp/xmtpd/blob/d4e70585796ca99237effae01e3a3e642d6bcecb/pkg/migrator/migrator.go#L182): The change uses `cfg.options.StartDate` without any validation that it has been set. If `StartDate` is not configured (remains as zero value `time.Time{}`), calling `.Unix()` and `.UnixNano()` will return large negative values (-62135596800 and -62135596800000000000 respectively), which could cause the readers to behave unexpectedly or process all historical data unintentionally. A validation check for `cfg.options.StartDate` should be added similar to other required options. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->