### PR TITLE
Actually register migratorWriterBytesMigrated

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -124,6 +124,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		migratorWriterLatency,
 		migratorWriterRetryAttempts,
 		migratorWriterRowsMigrated,
+		migratorWriterBytesMigrated,
 		QueryDuration,
 		QueryErrors,
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Register `metrics.registerCollectors` to include `migratorWriterBytesMigrated` for runtime metrics exposure in [metrics.go](https://github.com/xmtp/xmtpd/pull/1448/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23)
Add `migratorWriterBytesMigrated` to the collectors slice registered by `metrics.registerCollectors` in [metrics.go](https://github.com/xmtp/xmtpd/pull/1448/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23).

#### 📍Where to Start
Start with the `metrics.registerCollectors` function in [metrics.go](https://github.com/xmtp/xmtpd/pull/1448/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 00005b4.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->