### PR TITLE
Instrument logger with nodeId/SeqId

### DIFF
--- a/pkg/migrator/writer.go
+++ b/pkg/migrator/writer.go
@@ -29,6 +29,12 @@ func (w *Worker) insertOriginatorEnvelopeDatabase(
 	logger *zap.Logger,
 	env *envelopes.OriginatorEnvelope,
 ) re.RetryableError {
+	// instrument the logger for easier debugging
+	logger = logger.With(
+		utils.SequenceIDField(int64(env.OriginatorSequenceID())),
+		utils.OriginatorIDField(env.OriginatorNodeID()),
+	)
+
 	if env == nil {
 		return re.NewNonRecoverableError("", errors.New("envelope is nil"))
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Bind `SequenceID` and `OriginatorID` to the logger in `migrator.Worker.insertOriginatorEnvelopeDatabase` to instrument logs with nodeId/seqId
Rebind the method-local logger with `SequenceID` from `env.OriginatorSequenceID()` and `OriginatorID` from `env.OriginatorNodeID()` at the start of `migrator.Worker.insertOriginatorEnvelopeDatabase` in [writer.go](https://github.com/xmtp/xmtpd/pull/1461/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258).

#### 📍Where to Start
Begin at `migrator.Worker.insertOriginatorEnvelopeDatabase` in [writer.go](https://github.com/xmtp/xmtpd/pull/1461/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258) to review the logger rebinding and added fields.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a8f5491.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->