### PR TITLE
Count message count for unsettled usage

### DIFF
--- a/pkg/migrator/writer.go
+++ b/pkg/migrator/writer.go
@@ -83,7 +83,8 @@ func (w *Worker) insertOriginatorEnvelopeDatabase(
 				MinutesSinceEpoch: utils.MinutesSinceEpoch(env.OriginatorTime()),
 				SpendPicodollars: int64(env.UnsignedOriginatorEnvelope.BaseFee()) +
 					int64(env.UnsignedOriginatorEnvelope.CongestionFee()),
-				SequenceID: int64(env.OriginatorSequenceID()),
+				SequenceID:   int64(env.OriginatorSequenceID()),
+				MessageCount: 1,
 			})
 			if err != nil {
 				logger.Error("increment unsettled usage failed", zap.Error(err))


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Count unsettled usage messages by setting `Worker.insertOriginatorEnvelopeDatabase` to call `querier.IncrementUnsettledUsage` with `MessageCount=1` in [writer.go](https://github.com/xmtp/xmtpd/pull/1462/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258)
Add a `MessageCount` argument set to 1 in the `querier.IncrementUnsettledUsage` call within `Worker.insertOriginatorEnvelopeDatabase` in [writer.go](https://github.com/xmtp/xmtpd/pull/1462/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258).

#### 📍Where to Start
Start at `Worker.insertOriginatorEnvelopeDatabase` in [writer.go](https://github.com/xmtp/xmtpd/pull/1462/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258) and review the `querier.IncrementUnsettledUsage` invocation.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized c9cc4ff.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->