### PR TITLE
Add migrator target metric

### DIFF
--- a/doc/metrics_catalog.md
+++ b/doc/metrics_catalog.md
@@ -41,6 +41,7 @@ This document catalogs the [OpenMetrics](https://prometheus.io/docs/specs/om/ope
 | `xmtp_migrator_reader_fetch_duration_seconds` | `Histogram` | Time spent fetching records from source database | `pkg/metrics/migrator.go` |
 | `xmtp_migrator_reader_num_rows_found` | `Counter` | Number of rows fetched from source database | `pkg/metrics/migrator.go` |
 | `xmtp_migrator_source_last_sequence_id` | `Gauge` | Last sequence ID pulled from source DB | `pkg/metrics/migrator.go` |
+| `xmtp_migrator_target_last_sequence_id` | `Gauge` | Last sequence ID migrated to target from source DB | `pkg/metrics/migrator.go` |
 | `xmtp_migrator_transformer_errors_total` | `Counter` | Total number of transformation errors | `pkg/metrics/migrator.go` |
 | `xmtp_migrator_writer_bytes_migrated` | `Counter` | Total number of bytes successfully migrated | `pkg/metrics/migrator.go` |
 | `xmtp_migrator_writer_errors_total` | `Counter` | Total number of writer errors by destination and error type | `pkg/metrics/migrator.go` |

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -124,6 +124,7 @@ func registerCollectors(reg prometheus.Registerer) {
 		migratorWriterRetryAttempts,
 		migratorWriterRowsMigrated,
 		migratorWriterBytesMigrated,
+		migratorTargetLastSequenceID,
 		QueryDuration,
 		QueryErrors,
 	}

--- a/pkg/metrics/migrator.go
+++ b/pkg/metrics/migrator.go
@@ -96,6 +96,18 @@ func EmitMigratorSourceLastSequenceID(table string, sequenceID int64) {
 	migratorSourceLastSequenceID.With(prometheus.Labels{"table": table}).Set(float64(sequenceID))
 }
 
+var migratorTargetLastSequenceID = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xmtp_migrator_target_last_sequence_id",
+		Help: "Last sequence ID migrated to target from source DB",
+	},
+	[]string{"table"},
+)
+
+func EmitMigratorTargetLastSequenceID(table string, sequenceID int64) {
+	migratorTargetLastSequenceID.With(prometheus.Labels{"table": table}).Set(float64(sequenceID))
+}
+
 var migratorTransformerErrors = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "xmtp_migrator_transformer_errors_total",

--- a/pkg/migrator/writer.go
+++ b/pkg/migrator/writer.go
@@ -116,6 +116,8 @@ func (w *Worker) insertOriginatorEnvelopeDatabase(
 		return re.NewRecoverableError("database error", err)
 	}
 
+	metrics.EmitMigratorTargetLastSequenceID(w.tableName, int64(env.OriginatorSequenceID()))
+
 	return nil
 }
 
@@ -331,6 +333,8 @@ func (w *Worker) insertOriginatorEnvelopeBlockchainUnary(
 		)
 	}
 
+	metrics.EmitMigratorTargetLastSequenceID(w.tableName, int64(env.OriginatorSequenceID()))
+
 	return nil
 }
 
@@ -483,6 +487,8 @@ func (w *Worker) bootstrapIdentityUpdates(
 		utils.LengthField(batch.Len()),
 		utils.SequenceIDField(int64(batch.LastSequenceID())),
 	)
+
+	metrics.EmitMigratorTargetLastSequenceID(w.tableName, int64(batch.LastSequenceID()))
 
 	return nil
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add Prometheus gauge `xmtp_migrator_target_last_sequence_id` and update migrator workers to set it per table
Introduce `metrics.migratorTargetLastSequenceID` and `metrics.EmitMigratorTargetLastSequenceID`, register the collector, and set the gauge after successful DB insert, blockchain publish, and identity bootstrap in migrator worker paths. Docs add the metric to the catalog.

#### 📍Where to Start
Start in `metrics.EmitMigratorTargetLastSequenceID` in [migrator.go](https://github.com/xmtp/xmtpd/pull/1469/files#diff-94129ac032a24ee9c3f1a8c70772094f4d1e3d5979baeb72a86b511833303bcb), then see updates in worker methods in [writer.go](https://github.com/xmtp/xmtpd/pull/1469/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258), and confirm registration in [metrics.go](https://github.com/xmtp/xmtpd/pull/1469/files#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dc8168a. 3 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/migrator/writer.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 336](https://github.com/xmtp/xmtpd/blob/dc8168ab7baf47e81a3daec6b21c19dedd7cf98c/pkg/migrator/writer.go#L336): For valid originator IDs that are not `CommitMessageOriginatorID` or `InboxLogOriginatorID` (specifically `GroupMessageOriginatorID`, `WelcomeMessageOriginatorID`, and `KeyPackagesOriginatorID`), the function falls through the switch statement without processing, then emits `metrics.EmitMigratorTargetLastSequenceID` and returns `nil`. This silently skips these messages without publishing to blockchain or updating migration progress, while incorrectly reporting success via the metric. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->