### PR TITLE
Migrator now pays fees

### DIFF
--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/migrator"
 	"github.com/xmtp/xmtpd/pkg/migrator/testdata"
 	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/testutils/fees"
 	"github.com/xmtp/xmtpd/pkg/utils"
 )
 
@@ -53,6 +54,7 @@ func newMigratorTest(t *testing.T) *migratorTest {
 		_, dsn, cleanup = testdata.NewMigratorTestDB(t, ctx)
 		chainConfig     = testdata.NewMigratorBlockchain(t)
 		nodePrivateKey  = testutils.RandomPrivateKey(t)
+		feeCalculator   = fees.NewTestFeeCalculator()
 	)
 
 	payerPrivateKey, err := crypto.HexToECDSA(testdata.PayerPrivateKeyString)
@@ -74,6 +76,7 @@ func newMigratorTest(t *testing.T) *migratorTest {
 			StartDate:              startDate,
 		}),
 		migrator.WithContractsOptions(chainConfig),
+		migrator.WithFeeCalculator(feeCalculator),
 	)
 	require.NoError(t, err)
 

--- a/pkg/migrator/transformer_test.go
+++ b/pkg/migrator/transformer_test.go
@@ -18,6 +18,7 @@ import (
 	mlsv1 "github.com/xmtp/xmtpd/pkg/proto/mls/api/v1"
 	proto "github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/testutils"
+	"github.com/xmtp/xmtpd/pkg/testutils/fees"
 	"github.com/xmtp/xmtpd/pkg/topic"
 	"github.com/xmtp/xmtpd/pkg/utils"
 	protobuf "google.golang.org/protobuf/proto"
@@ -45,6 +46,7 @@ func newTransformerTest(t *testing.T) *transformerTest {
 	)
 
 	transformer := migrator.NewTransformer(
+		fees.NewTestFeeCalculator(),
 		payerPrivateKey,
 		nodePrivateKey,
 	)
@@ -116,7 +118,9 @@ func TestTransformGroupMessage(t *testing.T) {
 	)
 
 	// Originator node checks: fees.
-	require.Equal(t, uint64(0), envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars)
+	// Base fee is calculated based on message size and retention days.
+	require.Greater(t, envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars, uint64(0))
+	// Migrator does not pay congestion fees.
 	require.Equal(
 		t,
 		uint64(0),
@@ -183,7 +187,9 @@ func TestTransformCommitMessage(t *testing.T) {
 	)
 
 	// Originator node checks: fees.
+	// Blockchain-bound messages (commits) don't have fees calculated.
 	require.Equal(t, uint64(0), envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars)
+	// Migrator does not pay congestion fees.
 	require.Equal(
 		t,
 		uint64(0),
@@ -261,7 +267,9 @@ func TestTransformInboxLog(t *testing.T) {
 	)
 
 	// Originator node checks: fees.
+	// Blockchain-bound messages (inbox logs) don't have fees calculated.
 	require.Equal(t, uint64(0), envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars)
+	// Migrator does not pay congestion fees.
 	require.Equal(
 		t,
 		uint64(0),
@@ -330,7 +338,9 @@ func TestTransformKeyPackage(t *testing.T) {
 	)
 
 	// Originator node checks: fees.
-	require.Equal(t, uint64(0), envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars)
+	// Base fee is calculated based on message size and retention days.
+	require.Greater(t, envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars, uint64(0))
+	// Migrator does not pay congestion fees.
 	require.Equal(
 		t,
 		uint64(0),
@@ -407,7 +417,9 @@ func TestTransformWelcomeMessage(t *testing.T) {
 	)
 
 	// Originator node checks: fees.
-	require.Equal(t, uint64(0), envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars)
+	// Base fee is calculated based on message size and retention days.
+	require.Greater(t, envelope.UnsignedOriginatorEnvelope.Proto().BaseFeePicodollars, uint64(0))
+	// Migrator does not pay congestion fees.
 	require.Equal(
 		t,
 		uint64(0),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -290,6 +290,7 @@ func NewBaseServer(
 			migrator.WithDestinationDB(cfg.DB),
 			migrator.WithMigratorConfig(&cfg.Options.MigrationServer),
 			migrator.WithContractsOptions(&cfg.Options.Contracts),
+			migrator.WithFeeCalculator(cfg.FeeCalculator),
 		)
 		if err != nil {
 			cfg.Logger.Error("failed to initialize migrator", zap.Error(err))


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Require a fee calculator and set base fees for database-destined envelopes in `migrator.NewMigrationService` and `Transformer.buildAndSignOriginatorEnvelope`
Inject a `fees.IFeeCalculator` into migrator and transformer, validate it in `migrator.NewMigrationService`, and compute `BaseFeePicodollars` for database targets in `Transformer.buildAndSignOriginatorEnvelope`; wire the dependency from server setup in [server.go](https://github.com/xmtp/xmtpd/pull/1470/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996).

#### 📍Where to Start
Start with the constructor validation and wiring in [migrator.go](https://github.com/xmtp/xmtpd/pull/1470/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693), then review fee application in `Transformer.buildAndSignOriginatorEnvelope` in [transformer.go](https://github.com/xmtp/xmtpd/pull/1470/files#diff-c76d70079716ba42e22c5b5031c1960504cccbca874aadb118385ca67341cf62).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized df1503b.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->