### PR TITLE
make GetSecondNewestMinute total using LEFT JOIN

### DIFF
--- a/pkg/db/queries/payer_reports.sql.go
+++ b/pkg/db/queries/payer_reports.sql.go
@@ -489,11 +489,12 @@ WITH second_newest_minute AS (
 	ORDER BY unsettled_usage.minutes_since_epoch DESC
 	LIMIT 1 OFFSET 1
 )
-SELECT coalesce(max(last_sequence_id), 0)::BIGINT AS max_sequence_id,
-	coalesce(max(unsettled_usage.minutes_since_epoch), 0)::INT AS minutes_since_epoch
-FROM unsettled_usage
-	JOIN second_newest_minute ON second_newest_minute.minutes_since_epoch = unsettled_usage.minutes_since_epoch
-WHERE unsettled_usage.originator_id = $1
+SELECT coalesce(max(u.last_sequence_id), 0)::BIGINT AS max_sequence_id,
+	coalesce(max(u.minutes_since_epoch), 0)::INT AS minutes_since_epoch
+FROM second_newest_minute snm
+LEFT JOIN unsettled_usage u
+    ON u.originator_id = $1
+AND u.minutes_since_epoch = snm.minutes_since_epoch
 `
 
 type GetSecondNewestMinuteParams struct {

--- a/pkg/db/sqlc/payer_reports.sql
+++ b/pkg/db/sqlc/payer_reports.sql
@@ -90,11 +90,12 @@ WITH second_newest_minute AS (
 	ORDER BY unsettled_usage.minutes_since_epoch DESC
 	LIMIT 1 OFFSET 1
 )
-SELECT coalesce(max(last_sequence_id), 0)::BIGINT AS max_sequence_id,
-	coalesce(max(unsettled_usage.minutes_since_epoch), 0)::INT AS minutes_since_epoch
-FROM unsettled_usage
-	JOIN second_newest_minute ON second_newest_minute.minutes_since_epoch = unsettled_usage.minutes_since_epoch
-WHERE unsettled_usage.originator_id = @originator_id;
+SELECT coalesce(max(u.last_sequence_id), 0)::BIGINT AS max_sequence_id,
+	coalesce(max(u.minutes_since_epoch), 0)::INT AS minutes_since_epoch
+FROM second_newest_minute snm
+LEFT JOIN unsettled_usage u
+    ON u.originator_id = @originator_id
+AND u.minutes_since_epoch = snm.minutes_since_epoch;
 
 -- name: GetLastSequenceIDForOriginatorMinute :one
 SELECT COALESCE(MAX(last_sequence_id), 0)::BIGINT AS last_sequence_id


### PR DESCRIPTION
The GetSecondNewestMinute query could return zero rows when no
“second newest” minute exists (e.g. fewer than two distinct minutes).
With a :one sqlc binding, this surfaced as `sql: no rows in result set`.

Rewrite the query to LEFT JOIN from a guaranteed single-row anchor,
ensuring the aggregate always has an input row. Missing data now
correctly yields (0, 0) via COALESCE instead of ErrNoRows.

This makes the query total and aligns its behavior with callers that
expect a result even when insufficient history exists.