### PR TITLE
GetPayerByAddress fetches EIP-55 formatted addresses

### DIFF
--- a/pkg/api/metadata/payer_info.go
+++ b/pkg/api/metadata/payer_info.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/metadata_api"
@@ -67,5 +68,5 @@ func (f *PayerInfoFetcher) GetPayerInfo(
 
 // GetPayerByAddress looks up a payer ID by address
 func (f *PayerInfoFetcher) GetPayerByAddress(ctx context.Context, address string) (int32, error) {
-	return f.db.ReadQuery().GetPayerByAddress(ctx, address)
+	return f.db.ReadQuery().GetPayerByAddress(ctx, common.HexToAddress(address).Hex())
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Normalize payer address lookups in `metadata.PayerInfoFetcher.GetPayerByAddress` to EIP-55 using go-ethereum for DB queries
Convert input addresses to `common.Address` and use the canonical 0x-prefixed hex string for the DB lookup in [`pkg/api/metadata/payer_info.go`](https://github.com/xmtp/xmtpd/pull/1476/files#diff-183842a0929bc137c21b11b4758dae074226d55f791c47181d59830c8b02242a).

#### 📍Where to Start
Start with `metadata.PayerInfoFetcher.GetPayerByAddress` in [`pkg/api/metadata/payer_info.go`](https://github.com/xmtp/xmtpd/pull/1476/files#diff-183842a0929bc137c21b11b4758dae074226d55f791c47181d59830c8b02242a).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2896686.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->