### PR TITLE
Fix Uint32Slice param array to accept empty strings

### DIFF
--- a/pkg/config/custom_types.go
+++ b/pkg/config/custom_types.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Uint32Slice parses a comma-separated list of uint32 values.
+//
+// It treats an empty string ("") or whitespace-only input as an empty slice,
+// which allows environment variables like XMTPD_PAYER_NODE_SELECTOR_PREFERRED_NODES=""
+// to be provided without causing a parse error.
+//
+// Examples:
+//
+//	""            -> nil
+//	"   "         -> nil
+//	"1,2,3"       -> []uint32{1,2,3}
+//	"1, 2, 3"     -> []uint32{1,2,3}
+//	"1,2,"        -> []uint32{1,2}
+//	",1,,2,3,"    -> []uint32{1,2,3}
+type Uint32Slice []uint32
+
+// UnmarshalFlag is used by github.com/jessevdk/go-flags to parse flag/env values.
+func (s *Uint32Slice) UnmarshalFlag(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		*s = nil
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	out := make([]uint32, 0, len(parts))
+
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		u, err := strconv.ParseUint(p, 10, 32)
+		if err != nil {
+			return err
+		}
+		out = append(out, uint32(u))
+	}
+
+	*s = out
+	return nil
+}
+
+func (s Uint32Slice) String() string {
+	if len(s) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(s))
+	for _, n := range s {
+		parts = append(parts, strconv.FormatUint(uint64(n), 10))
+	}
+	return strings.Join(parts, ",")
+}

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -87,7 +87,7 @@ type PayerOptions struct {
 	Enable     bool   `long:"enable"      env:"XMTPD_PAYER_ENABLE"      description:"Enable the payer API"`
 
 	NodeSelectorStrategy       string        `long:"node-selector-strategy"        env:"XMTPD_PAYER_NODE_SELECTOR_STRATEGY"        description:"Node selection strategy"           default:"stable"`
-	NodeSelectorPreferredNodes []uint32      `long:"node-selector-preferred-nodes" env:"XMTPD_PAYER_NODE_SELECTOR_PREFERRED_NODES" description:"Preferred node IDs"                                 env-delim:","`
+	NodeSelectorPreferredNodes Uint32Slice   `long:"node-selector-preferred-nodes" env:"XMTPD_PAYER_NODE_SELECTOR_PREFERRED_NODES" description:"Preferred node IDs"`
 	NodeSelectorCacheExpiry    time.Duration `long:"node-selector-cache-expiry"    env:"XMTPD_PAYER_NODE_SELECTOR_CACHE_EXPIRY"    description:"Cache expiry for closest strategy" default:"5m"`
 	NodeSelectorTimeout        time.Duration `long:"node-selector-connect-timeout" env:"XMTPD_PAYER_NODE_SELECTOR_CONNECT_TIMEOUT" description:"Connection timeout"                default:"2s"`
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Accept empty strings in flag/env parsing by adding `config.Uint32Slice` and using it for `config.PayerOptions.NodeSelectorPreferredNodes`
Add `config.Uint32Slice` with `UnmarshalFlag` and `String` for comma-separated `uint32` parsing, and switch `PayerOptions.NodeSelectorPreferredNodes` to this type in [options.go](https://github.com/xmtp/xmtpd/pull/1495/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c). Parsing trims spaces, skips empty tokens, treats empty input as nil, and errors on non-`uint32` tokens; `String` returns comma-separated values.

#### 📍Where to Start
Start with `config.Uint32Slice.UnmarshalFlag` in [custom_types.go](https://github.com/xmtp/xmtpd/pull/1495/files#diff-2a7eb7b420a5fe013717b94a56a671e291ca936a1f11e4b663f807793a11e10b), then review the field change in [options.go](https://github.com/xmtp/xmtpd/pull/1495/files#diff-6731fb6f709392ce3e37d3b0c42074cddbce566dad2bab86af24ba7585eeb57c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b39f6b0.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->