### PR TITLE
Add topic log field to errors in IU handling

### DIFF
--- a/pkg/indexer/app_chain/contracts/identity_update_storer.go
+++ b/pkg/indexer/app_chain/contracts/identity_update_storer.go
@@ -129,7 +129,11 @@ func (s *IdentityUpdateStorer) StoreLog(
 
 			clientEnvelope, err := envelopes.NewClientEnvelopeFromBytes(msgSent.Update)
 			if err != nil {
-				s.logger.Error(ErrParseClientEnvelope, zap.Error(err))
+				s.logger.Error(
+					ErrParseClientEnvelope,
+					utils.TopicField(messageTopic.String()),
+					zap.Error(err),
+				)
 				return re.NewNonRecoverableError(ErrParseClientEnvelope, err)
 			}
 
@@ -140,7 +144,11 @@ func (s *IdentityUpdateStorer) StoreLog(
 				clientEnvelope,
 			)
 			if err != nil {
-				s.logger.Error(ErrValidateIdentityUpdate, zap.Error(err))
+				s.logger.Error(
+					ErrValidateIdentityUpdate,
+					utils.TopicField(messageTopic.String()),
+					zap.Error(err),
+				)
 				return re.NewNonRecoverableError(ErrValidateIdentityUpdate, err)
 			}
 
@@ -169,6 +177,7 @@ func (s *IdentityUpdateStorer) StoreLog(
 							utils.AddressField(address.EthereumAddress),
 							utils.InboxIDField(inboxID),
 							utils.SequenceIDField(int64(msgSent.SequenceId)),
+							utils.TopicField(messageTopic.String()),
 						)
 					}
 				}
@@ -199,6 +208,7 @@ func (s *IdentityUpdateStorer) StoreLog(
 							"could not find address log entry to revoke",
 							utils.AddressField(address.EthereumAddress),
 							utils.InboxIDField(inboxID),
+							utils.TopicField(messageTopic.String()),
 						)
 					}
 				}
@@ -210,7 +220,11 @@ func (s *IdentityUpdateStorer) StoreLog(
 				msgSent.Update,
 			)
 			if err != nil {
-				s.logger.Error(ErrBuildOriginatorEnvelope, zap.Error(err))
+				s.logger.Error(
+					ErrBuildOriginatorEnvelope,
+					utils.TopicField(messageTopic.String()),
+					zap.Error(err),
+				)
 				return re.NewNonRecoverableError(ErrBuildOriginatorEnvelope, err)
 			}
 
@@ -219,13 +233,21 @@ func (s *IdentityUpdateStorer) StoreLog(
 				event.TxHash,
 			)
 			if err != nil {
-				s.logger.Error(ErrBuildSignedOriginatorEnvelope, zap.Error(err))
+				s.logger.Error(
+					ErrBuildSignedOriginatorEnvelope,
+					utils.TopicField(messageTopic.String()),
+					zap.Error(err),
+				)
 				return re.NewNonRecoverableError(ErrBuildSignedOriginatorEnvelope, err)
 			}
 
 			originatorEnvelopeBytes, err := proto.Marshal(signedOriginatorEnvelope)
 			if err != nil {
-				s.logger.Error(ErrMarshallOriginatorEnvelope, zap.Error(err))
+				s.logger.Error(
+					ErrMarshallOriginatorEnvelope,
+					utils.TopicField(messageTopic.String()),
+					zap.Error(err),
+				)
 				return re.NewNonRecoverableError(ErrMarshallOriginatorEnvelope, err)
 			}
 
@@ -241,7 +263,11 @@ func (s *IdentityUpdateStorer) StoreLog(
 				},
 			)
 			if err != nil {
-				s.logger.Error(ErrInsertEnvelopeFromSmartContract, zap.Error(err))
+				s.logger.Error(
+					ErrInsertEnvelopeFromSmartContract,
+					utils.TopicField(messageTopic.String()),
+					zap.Error(err),
+				)
 				return re.NewRecoverableError(ErrInsertEnvelopeFromSmartContract, err)
 			}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `utils.TopicField` to error and warning logs in `contracts.IdentityUpdateStorer.StoreLog` to include message topic for IU handling
Add structured `utils.TopicField(messageTopic.String())` to logger calls within `contracts.IdentityUpdateStorer.StoreLog` in [identity_update_storer.go](https://github.com/xmtp/xmtpd/pull/1507/files#diff-719fcd3f6b2a547b6c6f299d70464725ddf9c1161c104099b3c3cab140cb2354).

#### 📍Where to Start
Start in `contracts.IdentityUpdateStorer.StoreLog` in [identity_update_storer.go](https://github.com/xmtp/xmtpd/pull/1507/files#diff-719fcd3f6b2a547b6c6f299d70464725ddf9c1161c104099b3c3cab140cb2354).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 8670938.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->