### PR TITLE
Label indexer log processing time with address

### DIFF
--- a/pkg/indexer/common/log_handler.go
+++ b/pkg/indexer/common/log_handler.go
@@ -79,7 +79,7 @@ func IndexLogs(
 				contract.Logger().Error("error updating block tracker", zap.Error(trackerErr))
 			}
 
-			metrics.EmitIndexerLogProcessingTime(time.Since(now))
+			metrics.EmitIndexerLogProcessingTime(contract.Address().Hex(), time.Since(now))
 		}
 	}
 }

--- a/pkg/metrics/indexer.go
+++ b/pkg/metrics/indexer.go
@@ -64,11 +64,12 @@ var indexerGetLogsRequests = prometheus.NewCounterVec(
 	[]string{"contract_address", "success"},
 )
 
-var indexerLogProcessingTime = prometheus.NewHistogram(
+var indexerLogProcessingTime = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name: "xmtp_indexer_log_processing_time_seconds",
 		Help: "Time to process a blockchain log",
 	},
+	[]string{"contract_address"},
 )
 
 func EmitIndexerNumLogsFound(contractAddress string, numLogs int) {
@@ -112,6 +113,7 @@ func MeasureGetLogs[Return any](contractAddress string, fn func() (Return, error
 	return ret, err
 }
 
-func EmitIndexerLogProcessingTime(duration time.Duration) {
-	indexerLogProcessingTime.Observe(duration.Seconds())
+func EmitIndexerLogProcessingTime(contractAddress string, duration time.Duration) {
+	indexerLogProcessingTime.With(prometheus.Labels{"contract_address": contractAddress}).
+		Observe(duration.Seconds())
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Label indexer log processing time by contract address and update `pkg/indexer/common.log_handler.IndexLogs` to pass `contract.Address().Hex()` to `pkg/metrics.EmitIndexerLogProcessingTime`
Convert `xmtp_indexer_log_processing_time_seconds` to a `prometheus.NewHistogramVec` with `contract_address` and update metric emission to include the address in [indexer.go](https://github.com/xmtp/xmtpd/pull/1508/files#diff-153d06a8c477ef1f7a09d063a8c951c64e3cc720f06f9341697abd147bb42679) and [log_handler.go](https://github.com/xmtp/xmtpd/pull/1508/files#diff-a31c080b060abb8bd9dfa4d6092255d7f851497acd426d985f03ee9c70389d3c).

#### 📍Where to Start
Start with the `EmitIndexerLogProcessingTime` changes in [indexer.go](https://github.com/xmtp/xmtpd/pull/1508/files#diff-153d06a8c477ef1f7a09d063a8c951c64e3cc720f06f9341697abd147bb42679), then review the call site in `IndexLogs` in [log_handler.go](https://github.com/xmtp/xmtpd/pull/1508/files#diff-a31c080b060abb8bd9dfa4d6092255d7f851497acd426d985f03ee9c70389d3c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized fe8a6d3.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->