### PR TITLE
timeout waiting for publisher should be a warning

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -1031,12 +1031,10 @@ func (s *Service) waitForGatewayPublish(
 	for {
 		select {
 		case <-timeout:
-			if s.logger.Core().Enabled(zap.DebugLevel) {
-				logger.Debug(
-					"timeout waiting for publisher",
-					utils.LastProcessedField(s.publishWorker.lastProcessed.Load()),
-				)
-			}
+			logger.Warn(
+				"timeout waiting for publisher",
+				utils.LastProcessedField(s.publishWorker.lastProcessed.Load()),
+			)
 			return
 
 		case <-ctx.Done():


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Log a warn on publisher wait timeout in `message.Service.waitForGatewayPublish` to mark the timeout as a warning
Switch the timeout branch in `message.Service.waitForGatewayPublish` to emit an unconditional warn-level log; remove the debug-enabled guard in [service.go](https://github.com/xmtp/xmtpd/pull/1511/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2).

#### 📍Where to Start
Start in the timeout `select` case inside `message.Service.waitForGatewayPublish` in [service.go](https://github.com/xmtp/xmtpd/pull/1511/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e08898b.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->