### PR TITLE
Expand verifier error messages

### DIFF
--- a/pkg/authn/verifier.go
+++ b/pkg/authn/verifier.go
@@ -81,12 +81,12 @@ func (v *RegistryVerifier) getMatchingPublicKey(token *jwt.Token) (any, error) {
 
 	subjectNodeID, err := getSubjectNodeID(token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get subject node ID: %w", err)
 	}
 
 	node, err := v.registry.GetNode(subjectNodeID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get node %d from registry: %w", subjectNodeID, err)
 	}
 
 	return node.SigningKey, nil


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Expand error context in `authn.RegistryVerifier.getMatchingPublicKey` to improve failure messaging for subject node ID extraction and registry lookups in [verifier.go](https://github.com/xmtp/xmtpd/pull/1512/files#diff-2e5b543bb414576ed2de54e263e89919092854a130c63e566f21b48f8eac115d)
Wrap underlying errors with `fmt.Errorf` in `authn.RegistryVerifier.getMatchingPublicKey`, adding messages for subject node ID retrieval and registry node fetch failures in [verifier.go](https://github.com/xmtp/xmtpd/pull/1512/files#diff-2e5b543bb414576ed2de54e263e89919092854a130c63e566f21b48f8eac115d).

#### 📍Where to Start
Start with `authn.RegistryVerifier.getMatchingPublicKey` in [verifier.go](https://github.com/xmtp/xmtpd/pull/1512/files#diff-2e5b543bb414576ed2de54e263e89919092854a130c63e566f21b48f8eac115d).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 08c46ff.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->