### PR TITLE
Some logging level changes

### DIFF
--- a/pkg/indexer/app_chain/contracts/group_message_storer.go
+++ b/pkg/indexer/app_chain/contracts/group_message_storer.go
@@ -98,10 +98,12 @@ func (s *GroupMessageStorer) StoreLog(
 		return re.NewNonRecoverableError(ErrMarshallOriginatorEnvelope, err)
 	}
 
-	s.logger.Debug(
-		"inserting message from contract",
-		utils.TopicField(topicStruct.String()),
-	)
+	if s.logger.Core().Enabled(zap.DebugLevel) {
+		s.logger.Debug(
+			"inserting message from contract",
+			utils.TopicField(topicStruct.String()),
+		)
+	}
 
 	_, err = db.InsertGatewayEnvelopeWithChecksStandalone(
 		ctx,

--- a/pkg/indexer/app_chain/contracts/identity_update_storer.go
+++ b/pkg/indexer/app_chain/contracts/identity_update_storer.go
@@ -122,10 +122,12 @@ func (s *IdentityUpdateStorer) StoreLog(
 
 			messageTopic := topic.NewTopic(topic.TopicKindIdentityUpdatesV1, msgSent.InboxId[:])
 
-			s.logger.Debug(
-				"inserting identity update from contract",
-				utils.TopicField(messageTopic.String()),
-			)
+			if s.logger.Core().Enabled(zap.DebugLevel) {
+				s.logger.Debug(
+					"inserting identity update from contract",
+					utils.TopicField(messageTopic.String()),
+				)
+			}
 
 			clientEnvelope, err := envelopes.NewClientEnvelopeFromBytes(msgSent.Update)
 			if err != nil {

--- a/pkg/indexer/common/log_handler.go
+++ b/pkg/indexer/common/log_handler.go
@@ -21,16 +21,23 @@ func IndexLogs(
 	eventChannel <-chan types.Log,
 	contract IContract,
 ) {
+	lastProgressLogTime := time.Now()
+
 	for {
 		select {
 		case <-ctx.Done():
-			contract.Logger().Debug("indexLogs context cancelled, exiting log handler")
+			contract.Logger().Info("indexLogs context cancelled, exiting log handler")
 			return
 
 		case event, open := <-eventChannel:
 			if !open {
-				contract.Logger().Debug("indexLogs event channel closed, exiting log handler")
+				contract.Logger().Info("indexLogs event channel closed, exiting log handler")
 				return
+			}
+			if time.Since(lastProgressLogTime) > 5*time.Minute {
+				contract.Logger().
+					Info("Reached block number", utils.BlockNumberField(event.BlockNumber))
+				lastProgressLogTime = time.Now()
 			}
 
 			if IsUpdateProgressEvent(event) {

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -191,7 +191,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 		for {
 			select {
 			case <-r.ctx.Done():
-				logger.Error("context cancelled, stopping watcher")
+				logger.Info("context cancelled, stopping watcher")
 				return
 
 			case err := <-sub.Err():
@@ -199,7 +199,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 					continue
 				}
 
-				logger.Error("subscription error, rebuilding", zap.Error(err))
+				logger.Warn("subscription error, rebuilding", zap.Error(err))
 				sub, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
 				if err != nil {
 					logger.Fatal("failed rebuilding subscription after max disconnect time", zap.Error(err), zap.String("max_disconnect_time", cfg.MaxDisconnectTime.String()))
@@ -223,7 +223,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 							cfg.eventChannel <- c.NewUpdateProgressLog(backfillFromBlockNumber, backfillFromBlockHash)
 						}
 
-						logger.Debug("backfill complete, switching to subscription")
+						logger.Info("backfill complete, switching to subscription")
 						break backfillLoop
 
 					case ErrReorg:
@@ -284,7 +284,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 		for {
 			select {
 			case <-r.ctx.Done():
-				logger.Error("context cancelled, stopping watcher")
+				logger.Info("context cancelled, stopping watcher")
 				return
 
 			case err := <-sub.Err():
@@ -292,7 +292,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 					continue
 				}
 
-				logger.Error("subscription error, rebuilding", zap.Error(err))
+				logger.Warn("subscription error, rebuilding", zap.Error(err))
 				sub, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
 				if err != nil {
 					logger.Fatal("failed rebuilding subscription after max disconnect time", zap.Error(err), zap.String("max_disconnect_time", cfg.MaxDisconnectTime.String()))
@@ -303,7 +303,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 
 			case log, open := <-innerSubCh:
 				if !open {
-					logger.Error("subscription channel closed, closing watcher")
+					logger.Info("subscription channel closed, closing watcher")
 					return
 				}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Adjust logging levels in `contracts.GroupMessageStorer.StoreLog`, `contracts.IdentityUpdateStorer.StoreLog`, `common.IndexLogs`, and `rpc_streamer.RPCLogStreamer.watchContract`, adding 5-minute Info progress logs and moving termination logs to Info
Raises operational log levels to Info/Warn, adds periodic 5-minute Info progress logs for the latest block, and guards Debug logs behind a `zap.DebugLevel` check.

#### 📍Where to Start
Start with `common.IndexLogs` in [log_handler.go](https://github.com/xmtp/xmtpd/pull/1521/files#diff-a31c080b060abb8bd9dfa4d6092255d7f851497acd426d985f03ee9c70389d3c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 5402e97.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->