### PR TITLE
Close DB connections on shutdown

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -162,6 +162,7 @@ type BaseServer struct {
 	nodeRegistry registry.NodeRegistry
 
 	// Dependencies.
+	db                  *db.Handler
 	cursorUpdater       metadata.CursorUpdater
 	blockchainPublisher *blockchain.BlockchainPublisher
 	reportWorkers       *workers.WorkerWrapper
@@ -225,6 +226,7 @@ func NewBaseServer(
 		logger:       cfg.Logger,
 		nodeRegistry: cfg.NodeRegistry,
 		metrics:      metricsServer,
+		db:           cfg.DB,
 	}
 
 	svc.ctx, svc.cancel = context.WithCancel(cfg.Ctx)
@@ -606,6 +608,12 @@ func (s *BaseServer) Shutdown(timeout time.Duration) {
 	if s.migrator != nil {
 		if err := s.migrator.Stop(); err != nil {
 			s.logger.Error("failed to stop migator", zap.Error(err))
+		}
+	}
+
+	if s.db != nil {
+		if err := s.db.Close(); err != nil {
+			s.logger.Error("failed to close database connections", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Close database connections during `server.BaseServer.Shutdown` in [server.go](https://github.com/xmtp/xmtpd/pull/1526/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996) to ensure shutdown completes cleanly
Add a `db` handler to `server.BaseServer`, wire it in `server.NewBaseServer`, and invoke conditional `db.Close()` with error logging in `server.BaseServer.Shutdown` in [server.go](https://github.com/xmtp/xmtpd/pull/1526/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996)

#### 📍Where to Start
Start with `server.BaseServer.Shutdown` in [server.go](https://github.com/xmtp/xmtpd/pull/1526/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8d7f316. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/server/server.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 332](https://github.com/xmtp/xmtpd/blob/8d7f316c9b8fcc6f797f6fb0919c7fc5714c4d2d/pkg/server/server.go#L332): At line 332, `log.Error` is called using the `github.com/DataDog/datadog-agent/pkg/trace/log` package instead of `cfg.Logger.Error` which is used consistently elsewhere in this function. This will log to a different logging system (Datadog trace logger) instead of the configured zap logger, causing inconsistent logging behavior and potentially missing logs in the expected output. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->