### PR TITLE
Increase wait periods for a few flaky tests

### DIFF
--- a/pkg/payerreport/workers/integration_test.go
+++ b/pkg/payerreport/workers/integration_test.go
@@ -429,9 +429,11 @@ func TestValidSignature(t *testing.T) {
 }
 
 func TestCanGenerateReport(t *testing.T) {
-	scaffold := setupMultiNodeTest(t)
-	groupID := testutils.RandomGroupID()
-	messageTopic := topic.NewTopic(topic.TopicKindGroupMessagesV1, groupID[:]).Bytes()
+	var (
+		scaffold     = setupMultiNodeTest(t)
+		groupID      = testutils.RandomGroupID()
+		messageTopic = topic.NewTopic(topic.TopicKindGroupMessagesV1, groupID[:]).Bytes()
+	)
 
 	scaffold.publishRandomMessage(t, messageTopic, 0, 0)
 	scaffold.publishRandomMessage(t, messageTopic, 1, 1)
@@ -441,7 +443,7 @@ func TestCanGenerateReport(t *testing.T) {
 		messagesOnNode1 := scaffold.getMessagesFromTopic(t, 0, messageTopic)
 		messagesOnNode2 := scaffold.getMessagesFromTopic(t, 1, messageTopic)
 		return len(messagesOnNode1) == 2 && len(messagesOnNode2) == 2
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 10*time.Second, 50*time.Millisecond)
 
 	advanceUnsettledUsage(t, &scaffold)
 
@@ -480,7 +482,7 @@ func TestFullReportLifecycle(t *testing.T) {
 		messagesOnNode1 := scaffold.getMessagesFromTopic(t, 0, messageTopic)
 		messagesOnNode2 := scaffold.getMessagesFromTopic(t, 1, messageTopic)
 		return len(messagesOnNode1) == 2 && len(messagesOnNode2) == 2
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 10*time.Second, 50*time.Millisecond)
 
 	advanceUnsettledUsage(t, &scaffold)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -173,7 +173,7 @@ func TestCreateServer(t *testing.T) {
 			}
 		}
 		return false
-	}, 5000*time.Millisecond, 200*time.Millisecond)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		q2, err := client2.QueryEnvelopes(ctx, &connect.Request[message_api.QueryEnvelopesRequest]{
@@ -327,7 +327,7 @@ func TestGRPCHealthEndpoint(t *testing.T) {
 			healthClient := grpc_health_v1.NewHealthClient(conn)
 			grpcResp, err = healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 			return err == nil && grpcResp.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
-		}, 3*time.Second, 100*time.Millisecond)
+		}, 10*time.Second, 100*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
It happened to me a few times locally, as well as part of CI, that a few tests failed because a condition was not met in the expected time period.

For me locally I have identified the culprit as, weirdly, GRPC stream setup, which took ~5 seconds, which was also the deadline for the test condition, so the test did not manage to complete in time. The issue is also transient as after docker restart the stream setup completed promptly.

Not sure what was the reason for this stream setup overhead (in the grpc generated code), but since it seems to have appeared also in CI tests, increasing the test timeout seems like a safe change to make. We do polling anyway, so if the test condition is met earlier all the better.