### PR TITLE
nitpick: maintain log format lowcase

### DIFF
--- a/pkg/indexer/common/log_handler.go
+++ b/pkg/indexer/common/log_handler.go
@@ -34,9 +34,10 @@ func IndexLogs(
 				contract.Logger().Info("indexLogs event channel closed, exiting log handler")
 				return
 			}
+
 			if time.Since(lastProgressLogTime) > 5*time.Minute {
 				contract.Logger().
-					Info("Reached block number", utils.BlockNumberField(event.BlockNumber))
+					Info("reached block number", utils.BlockNumberField(event.BlockNumber))
 				lastProgressLogTime = time.Now()
 			}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Standardize the Info-level progress log in `common.IndexLogs` to lowercase "reached block number" in [log_handler.go](https://github.com/xmtp/xmtpd/pull/1553/files#diff-a31c080b060abb8bd9dfa4d6092255d7f851497acd426d985f03ee9c70389d3c)
Update the progress message string to lowercase and add a blank line after reading the event channel in [log_handler.go](https://github.com/xmtp/xmtpd/pull/1553/files#diff-a31c080b060abb8bd9dfa4d6092255d7f851497acd426d985f03ee9c70389d3c).

#### 📍Where to Start
Start with the `common.IndexLogs` handler in [log_handler.go](https://github.com/xmtp/xmtpd/pull/1553/files#diff-a31c080b060abb8bd9dfa4d6092255d7f851497acd426d985f03ee9c70389d3c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 03ab5b8.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->