### PR TITLE
Migrator backpressure control

### DIFF
--- a/pkg/config/migrator.go
+++ b/pkg/config/migrator.go
@@ -13,7 +13,6 @@ type MigrationServerOptions struct {
 	WaitForDB              time.Duration `long:"wait-for"                 env:"XMTPD_MIGRATION_DB_WAIT_FOR"                 description:"wait for DB on start, up to specified duration" default:"30s"`
 	BatchSize              int32         `long:"batch-size"               env:"XMTPD_MIGRATION_DB_BATCH_SIZE"               description:"Batch size for migration"                       default:"1000"`
 	PollInterval           time.Duration `long:"process-interval"         env:"XMTPD_MIGRATION_DB_PROCESS_INTERVAL"         description:"Interval for processing migration"              default:"10s"`
-	DatabaseWriterWorkers  int           `long:"database-writer-workers"  env:"XMTPD_MIGRATION_DB_WRITER_WORKERS"           description:"Number of database writer workers"              default:"2"`
 	Namespace              string        `long:"namespace"                env:"XMTPD_MIGRATION_DB_NAMESPACE"                description:"Namespace for migration"                        default:""`
 	StartDate              time.Time     `long:"start-date"               env:"XMTPD_MIGRATION_START_DATE"                  description:"Start date for migration"                       default:"2025-10-01T00:00:00Z"`
 }

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -109,10 +109,9 @@ type Migrator struct {
 	blockchainPublisher blockchain.IBlockchainPublisher
 
 	// Configuration.
-	pollInterval          time.Duration
-	batchSize             int32
-	databaseWriterWorkers int
-	running               atomic.Bool
+	pollInterval time.Duration
+	batchSize    int32
+	running      atomic.Bool
 }
 
 func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
@@ -212,20 +211,19 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 	ctx, cancel := context.WithCancel(cfg.ctx)
 
 	return &Migrator{
-		ctx:                   ctx,
-		cancel:                cancel,
-		wg:                    sync.WaitGroup{},
-		mu:                    sync.RWMutex{},
-		logger:                logger,
-		target:                cfg.db,
-		source:                readDB,
-		readers:               readers,
-		transformer:           transformer,
-		blockchainPublisher:   blockchainPublisher,
-		pollInterval:          cfg.options.PollInterval,
-		batchSize:             cfg.options.BatchSize,
-		databaseWriterWorkers: cfg.options.DatabaseWriterWorkers,
-		running:               atomic.Bool{},
+		ctx:                 ctx,
+		cancel:              cancel,
+		wg:                  sync.WaitGroup{},
+		mu:                  sync.RWMutex{},
+		logger:              logger,
+		target:              cfg.db,
+		source:              readDB,
+		readers:             readers,
+		transformer:         transformer,
+		blockchainPublisher: blockchainPublisher,
+		pollInterval:        cfg.options.PollInterval,
+		batchSize:           cfg.options.BatchSize,
+		running:             atomic.Bool{},
 	}, nil
 }
 
@@ -290,7 +288,6 @@ func (m *Migrator) startKeyPackagesWorker() error {
 		nil,
 		m.logger,
 		m.pollInterval,
-		m.databaseWriterWorkers,
 	)
 
 	if err := keyPackagesWorker.StartReader(m.ctx, m.readers[keyPackagesTableName]); err != nil {
@@ -316,7 +313,6 @@ func (m *Migrator) startWelcomeMessagesWorker() error {
 		nil,
 		m.logger,
 		m.pollInterval,
-		m.databaseWriterWorkers,
 	)
 
 	if err := welcomeMessagesWorker.StartReader(m.ctx, m.readers[welcomeMessagesTableName]); err != nil {
@@ -342,7 +338,6 @@ func (m *Migrator) startGroupMessagesWorker() error {
 		nil,
 		m.logger,
 		m.pollInterval,
-		m.databaseWriterWorkers,
 	)
 
 	if err := groupMessagesWorker.StartReader(m.ctx, m.readers[groupMessagesTableName]); err != nil {
@@ -368,7 +363,6 @@ func (m *Migrator) startCommitMessagesWorker() error {
 		m.blockchainPublisher,
 		m.logger,
 		m.pollInterval,
-		m.databaseWriterWorkers,
 	)
 
 	if err := commitMessagesWorker.StartReader(m.ctx, m.readers[commitMessagesTableName]); err != nil {
@@ -394,7 +388,6 @@ func (m *Migrator) startInboxLogWorker() error {
 		m.blockchainPublisher,
 		m.logger,
 		m.pollInterval,
-		m.databaseWriterWorkers,
 	)
 
 	if err := inboxLogWorker.StartReader(m.ctx, m.readers[inboxLogTableName]); err != nil {

--- a/pkg/migrator/worker.go
+++ b/pkg/migrator/worker.go
@@ -36,10 +36,9 @@ type Worker struct {
 	inflight   map[int64]time.Time
 
 	// Configuration.
-	tableName             string
-	pollInterval          time.Duration
-	batchSize             int32
-	databaseWriterWorkers int
+	tableName    string
+	pollInterval time.Duration
+	batchSize    int32
 }
 
 func NewWorker(
@@ -49,7 +48,6 @@ func NewWorker(
 	blockchainPublisher blockchain.IBlockchainPublisher,
 	logger *zap.Logger,
 	pollInterval time.Duration,
-	databaseWriterWorkers int,
 ) *Worker {
 	maxInflight := int(batchSize) * 4
 
@@ -62,17 +60,16 @@ func NewWorker(
 	}
 
 	return &Worker{
-		logger:                logger,
-		writer:                writer,
-		blockchainPublisher:   blockchainPublisher,
-		recvChan:              make(chan ISourceRecord, batchSize*2),
-		wrtrChan:              make(chan *envelopes.OriginatorEnvelope, batchSize*2),
-		sem:                   sem,
-		inflight:              make(map[int64]time.Time),
-		tableName:             tableName,
-		pollInterval:          pollInterval,
-		batchSize:             batchSize,
-		databaseWriterWorkers: databaseWriterWorkers,
+		logger:              logger,
+		writer:              writer,
+		blockchainPublisher: blockchainPublisher,
+		recvChan:            make(chan ISourceRecord, batchSize*2),
+		wrtrChan:            make(chan *envelopes.OriginatorEnvelope, batchSize*2),
+		sem:                 sem,
+		inflight:            make(map[int64]time.Time),
+		tableName:           tableName,
+		pollInterval:        pollInterval,
+		batchSize:           batchSize,
 	}
 }
 
@@ -107,7 +104,6 @@ func (w *Worker) StartReader(ctx context.Context, reader ISourceReader) error {
 
 				case <-ticker.C:
 					ticksSinceLastFetch++
-
 					// semaphore max capacity is batchSize * 4. If we're at 75% capacity, it means the writer is behind.
 					// This is a simple way to prevent the reader from overwhelming the writer.
 					semUsed := cap(w.sem) - len(w.sem)
@@ -303,35 +299,13 @@ func (w *Worker) StartDatabaseWriter(ctx context.Context) error {
 	logger := w.logger.Named(utils.MigratorWriterDatabaseLoggerName).
 		With(zap.String(tableField, w.tableName))
 
-	logger.Info("started", zap.Int("parallel_writers", w.databaseWriterWorkers))
-
-	// Channel for batches ready to be inserted.
-	// Buffer size matches number of writers for optimal double-buffering.
-	insertChan := make(chan *types.GatewayEnvelopeBatch, w.databaseWriterWorkers)
-
-	// Start parallel insert workers.
-	var insertWg sync.WaitGroup
-	for i := range w.databaseWriterWorkers {
-		insertWg.Add(1)
-		go w.databaseWriterWorker(
-			ctx,
-			logger.With(zap.Int("worker_id", i)),
-			insertChan,
-			&insertWg,
-		)
-	}
+	logger.Info("started")
 
 	tracing.GoPanicWrap(
 		ctx,
 		&w.wg,
 		fmt.Sprintf("writer-database-%s", w.tableName),
 		func(ctx context.Context) {
-			// Ensure insert workers are stopped when collector exits.
-			defer func() {
-				close(insertChan)
-				insertWg.Wait()
-			}()
-
 			ticker := time.NewTicker(250 * time.Millisecond)
 			defer ticker.Stop()
 
@@ -339,29 +313,104 @@ func (w *Worker) StartDatabaseWriter(ctx context.Context) error {
 
 			ticksSinceLastFlush := 0
 
-			sendBatchToWorkers := func() {
-				if batch.Len() == 0 {
+			triggerBatchFlush := func() {
+				var (
+					batchLen            = batch.Len()
+					batchLastSequenceID = batch.LastSequenceID()
+				)
+
+				ticksSinceLastFlush = 0
+
+				logger.Info(
+					"publishing batch",
+					utils.LengthField(batchLen),
+					utils.SequenceIDField(batchLastSequenceID),
+				)
+
+				err := metrics.MeasureWriterLatency(
+					w.tableName,
+					destinationDatabase,
+					func() error {
+						return retry(
+							ctx,
+							50*time.Millisecond,
+							w.tableName,
+							destinationDatabase,
+							func() re.RetryableError {
+								return w.insertOriginatorEnvelopeDatabaseBatch(
+									ctx,
+									logger,
+									batch,
+								)
+							},
+						)
+					},
+				)
+				if err != nil {
+					if errors.Is(err, context.Canceled) ||
+						errors.Is(err, context.DeadlineExceeded) {
+						logger.Info(contextCancelledMessage)
+						return
+					}
+
+					logger.Error(
+						"failed to insert batch",
+						zap.Error(err),
+						utils.LengthField(batchLen),
+						utils.SequenceIDField(batchLastSequenceID),
+					)
+
+					metrics.EmitMigratorWriterError(
+						w.tableName,
+						destinationDatabase,
+						err.Error(),
+					)
+
+					for _, envelope := range batch.All() {
+						w.cleanupInflight(ctx, envelope.OriginatorSequenceID)
+					}
+
+					batch.Reset()
+
 					return
 				}
 
 				logger.Info(
-					"sending batch to insert workers",
-					utils.LengthField(batch.Len()),
-					utils.SequenceIDField(batch.LastSequenceID()),
+					"batch published successfully",
+					utils.LengthField(batchLen),
+					utils.SequenceIDField(batchLastSequenceID),
 				)
 
-				// Send batch to insert workers (blocks if all workers busy).
-				select {
-				case insertChan <- batch:
-					batch = types.NewGatewayEnvelopeBatch()
-					ticksSinceLastFlush = 0
+				metrics.EmitMigratorWriterRowsMigrated(w.tableName, int64(batch.Len()))
 
-				case <-ctx.Done():
-					return
+				for _, envelope := range batch.All() {
+					startTime, exists := w.isInflight(envelope.OriginatorSequenceID)
+
+					if exists {
+						metrics.EmitMigratorE2ELatency(
+							w.tableName,
+							destinationDatabase,
+							time.Since(startTime).Seconds(),
+						)
+					}
+
+					metrics.EmitMigratorWriterBytesMigrated(
+						w.tableName,
+						destinationDatabase,
+						len(envelope.OriginatorEnvelope),
+					)
+
+					metrics.EmitMigratorDestLastSequenceID(
+						w.tableName,
+						envelope.OriginatorSequenceID,
+					)
+
+					w.cleanupInflight(ctx, envelope.OriginatorSequenceID)
 				}
+
+				batch.Reset()
 			}
 
-			// Collect envelopes and send to insert workers.
 			for {
 				select {
 				case <-ctx.Done():
@@ -377,18 +426,22 @@ func (w *Worker) StartDatabaseWriter(ctx context.Context) error {
 					ticksSinceLastFlush++
 
 					// Do not flush prematurely.
-					if batch.Len() <= int(w.batchSize)/2 && ticksSinceLastFlush < 8 {
+					if batch.Len() <= int(w.batchSize)/2 && ticksSinceLastFlush < 10 {
 						continue
 					}
 
-					sendBatchToWorkers()
+					triggerBatchFlush()
 
 				case envelope, open := <-w.wrtrChan:
 					if !open {
 						logger.Info(channelClosedMessage)
 
+						if batch.Len() <= 0 {
+							return
+						}
+
 						// Flush remaining messages before exiting.
-						sendBatchToWorkers()
+						triggerBatchFlush()
 
 						return
 					}
@@ -403,7 +456,7 @@ func (w *Worker) StartDatabaseWriter(ctx context.Context) error {
 					}
 
 					if batch.Len() >= int(w.batchSize) {
-						sendBatchToWorkers()
+						triggerBatchFlush()
 					}
 
 					payerID, err := w.payerIDFromEnvelope(ctx, envelope)
@@ -438,126 +491,6 @@ func (w *Worker) StartDatabaseWriter(ctx context.Context) error {
 	)
 
 	return nil
-}
-
-// databaseWriterWorker processes batches from the insert channel.
-// Multiple workers run in parallel for concurrent inserts.
-func (w *Worker) databaseWriterWorker(
-	ctx context.Context,
-	logger *zap.Logger,
-	batches <-chan *types.GatewayEnvelopeBatch,
-	wg *sync.WaitGroup,
-) {
-	defer wg.Done()
-
-	logger.Info("database writer worker started")
-	defer logger.Info("database writer worker stopped")
-
-	for batch := range batches {
-		select {
-		case <-ctx.Done():
-			// Cleanup inflight for remaining batch on shutdown.
-			for _, envelope := range batch.All() {
-				w.cleanupInflight(ctx, envelope.OriginatorSequenceID)
-			}
-			return
-
-		default:
-		}
-
-		var (
-			batchLen            = batch.Len()
-			batchLastSequenceID = batch.LastSequenceID()
-		)
-
-		logger.Info(
-			"publishing batch",
-			utils.LengthField(batchLen),
-			utils.SequenceIDField(batchLastSequenceID),
-		)
-
-		err := metrics.MeasureWriterLatency(
-			w.tableName,
-			destinationDatabase,
-			func() error {
-				return retry(
-					ctx,
-					50*time.Millisecond,
-					w.tableName,
-					destinationDatabase,
-					func() re.RetryableError {
-						return w.insertOriginatorEnvelopeDatabaseBatch(
-							ctx,
-							logger,
-							batch,
-						)
-					},
-				)
-			},
-		)
-		if err != nil {
-			if errors.Is(err, context.Canceled) ||
-				errors.Is(err, context.DeadlineExceeded) {
-				logger.Info(contextCancelledMessage)
-				for _, envelope := range batch.All() {
-					w.cleanupInflight(ctx, envelope.OriginatorSequenceID)
-				}
-				return
-			}
-
-			logger.Error(
-				"failed to insert batch",
-				zap.Error(err),
-				utils.LengthField(batchLen),
-				utils.SequenceIDField(batchLastSequenceID),
-			)
-
-			metrics.EmitMigratorWriterError(
-				w.tableName,
-				destinationDatabase,
-				err.Error(),
-			)
-
-			for _, envelope := range batch.All() {
-				w.cleanupInflight(ctx, envelope.OriginatorSequenceID)
-			}
-
-			continue
-		}
-
-		logger.Info(
-			"batch published successfully",
-			utils.LengthField(batchLen),
-			utils.SequenceIDField(batchLastSequenceID),
-		)
-
-		metrics.EmitMigratorWriterRowsMigrated(w.tableName, int64(batchLen))
-
-		for _, envelope := range batch.All() {
-			startTime, exists := w.isInflight(envelope.OriginatorSequenceID)
-
-			if exists {
-				metrics.EmitMigratorE2ELatency(
-					w.tableName,
-					destinationDatabase,
-					time.Since(startTime).Seconds(),
-				)
-			}
-
-			metrics.EmitMigratorWriterBytesMigrated(
-				w.tableName,
-				destinationDatabase,
-				len(envelope.OriginatorEnvelope),
-			)
-
-			metrics.EmitMigratorDestLastSequenceID(
-				w.tableName,
-				envelope.OriginatorSequenceID,
-			)
-
-			w.cleanupInflight(ctx, envelope.OriginatorSequenceID)
-		}
-	}
 }
 
 func (w *Worker) payerIDFromEnvelope(


### PR DESCRIPTION
`maxDatabaseBatchSize` introduced a bug: when migrator batchSize is lower than the maxDatabaseBatchSize/2 the migrator does not progress.

Also, introduce a simple backpressure mechanism control the reader reads less times but likely more meaningful data, as by skipping one read iteration can give space to the writer to advance the migration progress table. 