### PR TITLE
Increase performance of FindOrCreatePayer

### DIFF
--- a/pkg/db/sqlc/payer_reports.sql
+++ b/pkg/db/sqlc/payer_reports.sql
@@ -1,9 +1,14 @@
 -- name: FindOrCreatePayer :one
-INSERT INTO payers(address)
-VALUES (@address) ON CONFLICT (address) DO
-UPDATE
-SET address = @address
-RETURNING id;
+WITH ins AS (
+  INSERT INTO payers(address)
+  VALUES (@address)
+  ON CONFLICT (address) DO NOTHING
+  RETURNING id
+)
+SELECT id FROM ins
+UNION ALL
+SELECT id FROM payers WHERE address = @address
+LIMIT 1;
 
 -- name: GetPayerByAddress :one
 SELECT id


### PR DESCRIPTION
This query optimizes the conflict path, while maintaining the same functionality.

Tests show insert path remains at 300-400ms, while the conflict path has been reduced from hitting 5s some times to a stable 200ms.