### PR TITLE
Enhance FindOrCreatePayer performance

### DIFF
--- a/pkg/db/queries/payer_reports.sql.go
+++ b/pkg/db/queries/payer_reports.sql.go
@@ -327,10 +327,13 @@ WITH ins AS (
   VALUES ($1)
   ON CONFLICT (address) DO NOTHING
   RETURNING id
+), u AS (
+  SELECT id FROM ins
+  UNION ALL
+  SELECT id FROM payers WHERE address = $1
 )
-SELECT id FROM ins
-UNION ALL
-SELECT id FROM payers WHERE address = $1
+SELECT id
+FROM u
 LIMIT 1
 `
 

--- a/pkg/db/sqlc/payer_reports.sql
+++ b/pkg/db/sqlc/payer_reports.sql
@@ -4,12 +4,14 @@ WITH ins AS (
   VALUES (@address)
   ON CONFLICT (address) DO NOTHING
   RETURNING id
+), u AS (
+  SELECT id FROM ins
+  UNION ALL
+  SELECT id FROM payers WHERE address = @address
 )
-SELECT id FROM ins
-UNION ALL
-SELECT id FROM payers WHERE address = @address
+SELECT id
+FROM u
 LIMIT 1;
-
 -- name: GetPayerByAddress :one
 SELECT id
 FROM payers


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update `FindOrCreatePayer` query to use a union CTE for id selection to improve performance in [payer_reports.sql](https://github.com/xmtp/xmtpd/pull/1565/files#diff-97545094488668ce28bf8f7d5f9097251e81edd37419dedc2371df3fb0f447ba) and regenerate [payer_reports.sql.go](https://github.com/xmtp/xmtpd/pull/1565/files#diff-268288671ce8effd768fd5970f7336ae5f38daf2d4e6983927ec12ca0ebbed8c)
Add CTE `u` that unions `ins` and existing payer lookup, and change the final select to `SELECT id FROM u LIMIT 1` in [payer_reports.sql](https://github.com/xmtp/xmtpd/pull/1565/files#diff-97545094488668ce28bf8f7d5f9097251e81edd37419dedc2371df3fb0f447ba); regenerate corresponding code in [payer_reports.sql.go](https://github.com/xmtp/xmtpd/pull/1565/files#diff-268288671ce8effd768fd5970f7336ae5f38daf2d4e6983927ec12ca0ebbed8c).

#### 📍Where to Start
Start with the `FindOrCreatePayer` SQL in [payer_reports.sql](https://github.com/xmtp/xmtpd/pull/1565/files#diff-97545094488668ce28bf8f7d5f9097251e81edd37419dedc2371df3fb0f447ba), then review the generated changes in [payer_reports.sql.go](https://github.com/xmtp/xmtpd/pull/1565/files#diff-268288671ce8effd768fd5970f7336ae5f38daf2d4e6983927ec12ca0ebbed8c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4b0ae57.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->