### PR TITLE
Better batching

### DIFF
--- a/pkg/migrations/00016_insert-gateway-envelopes-batch.up.sql
+++ b/pkg/migrations/00016_insert-gateway-envelopes-batch.up.sql
@@ -15,7 +15,9 @@ RETURNS TABLE (
 )
 LANGUAGE SQL
 AS $$
-WITH input AS (
+WITH
+
+input_meta AS MATERIALIZED (
     SELECT
         originator_node_id,
         originator_sequence_id,
@@ -23,7 +25,6 @@ WITH input AS (
         NULLIF(payer_id, 0) AS payer_id,
         gateway_time,
         expiry,
-        originator_envelope,
         spend_picodollars
     FROM unnest(
         p_originator_node_ids,
@@ -32,7 +33,6 @@ WITH input AS (
         p_payer_ids,
         p_gateway_times,
         p_expiries,
-        p_originator_envelopes,
         p_spend_picodollars
     ) AS t(
         originator_node_id,
@@ -41,8 +41,24 @@ WITH input AS (
         payer_id,
         gateway_time,
         expiry,
-        originator_envelope,
         spend_picodollars
+    )
+),
+
+-- Wide input (payload only). Do NOT materialize.
+input_blob AS (
+    SELECT
+        originator_node_id,
+        originator_sequence_id,
+        originator_envelope
+    FROM unnest(
+        p_originator_node_ids,
+        p_originator_sequence_ids,
+        p_originator_envelopes
+    ) AS t(
+        originator_node_id,
+        originator_sequence_id,
+        originator_envelope
     )
 ),
 
@@ -55,20 +71,32 @@ m AS (
         gateway_time,
         expiry
     )
-    SELECT originator_node_id, originator_sequence_id, topic, payer_id, gateway_time, expiry
-    FROM input
+    SELECT
+        originator_node_id,
+        originator_sequence_id,
+        topic,
+        payer_id,
+        gateway_time,
+        expiry
+    FROM input_meta
     ON CONFLICT DO NOTHING
     RETURNING originator_node_id, originator_sequence_id, payer_id, gateway_time
 ),
 
+-- Drive blob insert from m to avoid work for rows conflict-skipped in meta.
 b AS (
     INSERT INTO gateway_envelope_blobs (
         originator_node_id,
         originator_sequence_id,
         originator_envelope
     )
-    SELECT originator_node_id, originator_sequence_id, originator_envelope
-    FROM input
+    SELECT
+        m.originator_node_id,
+        m.originator_sequence_id,
+        ib.originator_envelope
+    FROM m
+    JOIN input_blob ib
+      USING (originator_node_id, originator_sequence_id)
     ON CONFLICT DO NOTHING
     RETURNING originator_node_id, originator_sequence_id
 ),
@@ -79,23 +107,25 @@ m_with_spend AS (
         m.originator_sequence_id,
         m.payer_id,
         m.gateway_time,
-        i.spend_picodollars
+        im.spend_picodollars
     FROM m
-    JOIN b USING (originator_node_id, originator_sequence_id)
-    JOIN input i USING (originator_node_id, originator_sequence_id)
+    JOIN b
+      USING (originator_node_id, originator_sequence_id)
+    JOIN input_meta im
+      USING (originator_node_id, originator_sequence_id)
 ),
 
 u_prep AS (
     SELECT
         payer_id,
         originator_node_id AS originator_id,
-        floor(extract(epoch from gateway_time) / 60)::int AS minutes_since_epoch,
+        (extract(epoch from gateway_time)::bigint / 60)::int AS minutes_since_epoch,
         sum(spend_picodollars)::bigint AS spend_picodollars,
         max(originator_sequence_id)::bigint AS last_sequence_id,
         count(*)::int AS message_count
     FROM m_with_spend
     WHERE payer_id IS NOT NULL
-    GROUP BY 1, 2, 3
+    GROUP BY 1,2,3
 ),
 
 u AS (
@@ -107,7 +137,13 @@ u AS (
         last_sequence_id,
         message_count
     )
-    SELECT payer_id, originator_id, minutes_since_epoch, spend_picodollars, last_sequence_id, message_count
+    SELECT
+        payer_id,
+        originator_id,
+        minutes_since_epoch,
+        spend_picodollars,
+        last_sequence_id,
+        message_count
     FROM u_prep
     ORDER BY payer_id, originator_id, minutes_since_epoch
     ON CONFLICT (payer_id, originator_id, minutes_since_epoch) DO UPDATE


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Rework batching in `pkg.migrations.insert_gateway_envelopes_batch` to insert `gateway_envelope_blobs` only for meta rows returned by `m` and compute `minutes_since_epoch` via bigint integer division (/ 60)::int
Split the input into `input_meta` (MATERIALIZED) and `input_blob`, drive blob inserts from `m RETURNING` joined to `input_blob`, and replace double-precision floor with bigint integer division for `minutes_since_epoch` in [00016_insert-gateway-envelopes-batch.up.sql](https://github.com/xmtp/xmtpd/pull/1566/files#diff-8667a1452def6a5ad2912a4b60b609d3a14a753e160c51502391cbdd2c7d2593).

#### 📍Where to Start
Start with the `insert_gateway_envelopes_batch` function body in [00016_insert-gateway-envelopes-batch.up.sql](https://github.com/xmtp/xmtpd/pull/1566/files#diff-8667a1452def6a5ad2912a4b60b609d3a14a753e160c51502391cbdd2c7d2593).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized eed296d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->