### PR TITLE
Use WriteQuery for publish worker

### DIFF
--- a/pkg/api/message/publish_worker.go
+++ b/pkg/api/message/publish_worker.go
@@ -43,7 +43,7 @@ func startPublishWorker(
 	logger.Info("starting")
 
 	query := func(ctx context.Context, lastSeenID int64, numRows int32) ([]queries.StagedOriginatorEnvelope, int64, error) {
-		results, err := store.ReadQuery().SelectStagedOriginatorEnvelopes(
+		results, err := store.WriteQuery().SelectStagedOriginatorEnvelopes(
 			ctx,
 			queries.SelectStagedOriginatorEnvelopesParams{
 				LastSeenID: lastSeenID,


### PR DESCRIPTION
The publish worker was using ReadQuery() to poll for staged envelopes immediately after they were written to the database. Read-replica lag was causing the notification-triggered poll to find 0 results, triggering the 1-second fallback.

This was adding ~1s of latency on every publish.