### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/pkg/blockchain/oracle/oracle_test.go
+++ b/pkg/blockchain/oracle/oracle_test.go
@@ -63,12 +63,10 @@ func TestOracleConcurrentGetGasPrice(t *testing.T) {
 	// GetGasPrice is safe for concurrent calls
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			price := o.GetGasPrice()
 			require.Greater(t, price, int64(0))
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -81,14 +79,12 @@ func TestOracleGetGasPriceRandom(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// Force the oracle to fetch a new gas price for some goroutines.
 			time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
 			price := o.GetGasPrice()
 			require.Greater(t, price, int64(0))
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/pkg/db/gateway_envelope_batch_test.go
+++ b/pkg/db/gateway_envelope_batch_test.go
@@ -481,9 +481,7 @@ func TestBatchInsert_ParallelDuplicates(t *testing.T) {
 
 	// All goroutines try to insert the SAME batch (duplicates).
 	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			p := buildBatchInput(payerID, originatorID, 1, batchSize, spendPerMessage)
 			n, err := xmtpd_db.InsertGatewayEnvelopeBatchAndIncrementUnsettledUsage(
 				ctx,
@@ -492,7 +490,7 @@ func TestBatchInsert_ParallelDuplicates(t *testing.T) {
 			)
 			require.NoError(t, err)
 			atomic.AddInt64(&totalInserted, n)
-		}()
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION
use WaitGroup.Go to simplify code. More info: https://github.com/golang/go/issues/63796