### PR TITLE
Upgrade to new RateRegistry contract

### DIFF
--- a/cmd/xmtpd-cli/commands/rate_registry.go
+++ b/cmd/xmtpd-cli/commands/rate_registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/xmtp/xmtpd/pkg/currency"
 	"github.com/xmtp/xmtpd/pkg/fees"
+	"github.com/xmtp/xmtpd/pkg/utils"
 	"go.uber.org/zap"
 )
 
@@ -19,6 +20,7 @@ type AddRatesOpts struct {
 	StorageFee    int64
 	CongestionFee int64
 	TargetRate    uint64
+	StartTime     uint64
 }
 
 // ---- Root ----
@@ -49,10 +51,12 @@ func addRatesCommand() *cobra.Command {
 			return addRatesHandler(opts)
 		},
 		Example: `
-Usage: xmtpd-cli rates add --message-fee <message-fee> --storage-fee <storage-fee> --congestion-fee <congestion-fee> --target-rate <target-rate>
+Usage: xmtpd-cli rates add --message-fee <message-fee> --storage-fee <storage-fee> --congestion-fee <congestion-fee> --target-rate <target-rate> [--start-time <unix-timestamp>]
 
 Example:
-xmtpd-cli rates add --message-fee 1000000000000000000 --storage-fee 1000000000000000000 --congestion-fee 1000000000000000000 --target-rate 1000000000000000000
+xmtpd-cli rates add --message-fee 1000000000000000000 --storage-fee 1000000000000000000 --congestion-fee 1000000000000000000 --target-rate 1000000000000000000 --start-time 1739188800
+
+If --start-time is omitted, it defaults to 2 hours from now.
 `,
 	}
 
@@ -60,6 +64,8 @@ xmtpd-cli rates add --message-fee 1000000000000000000 --storage-fee 100000000000
 	cmd.Flags().Int64Var(&opts.StorageFee, "storage-fee", 0, "storage fee to use")
 	cmd.Flags().Int64Var(&opts.CongestionFee, "congestion-fee", 0, "congestion fee to use")
 	cmd.Flags().Uint64Var(&opts.TargetRate, "target-rate", 0, "target rate to use")
+	cmd.Flags().
+		Uint64Var(&opts.StartTime, "start-time", 0, "unix timestamp when rates take effect (defaults to 2 hours from now)")
 
 	_ = cmd.MarkFlagRequired("message-fee")
 	_ = cmd.MarkFlagRequired("storage-fee")
@@ -84,11 +90,21 @@ func addRatesHandler(opts AddRatesOpts) error {
 		return err
 	}
 
+	startTime := opts.StartTime
+	if startTime == 0 {
+		startTime = uint64(time.Now().Add(2 * time.Hour).Unix())
+	}
+
+	if err := validateStartTime(startTime); err != nil {
+		return err
+	}
+
 	rates := fees.Rates{
 		MessageFee:          currency.PicoDollar(opts.MessageFee),
 		StorageFee:          currency.PicoDollar(opts.StorageFee),
 		CongestionFee:       currency.PicoDollar(opts.CongestionFee),
 		TargetRatePerMinute: opts.TargetRate,
+		StartTime:           startTime,
 	}
 
 	if err := registryAdmin.AddRates(ctx, rates); err != nil {
@@ -97,6 +113,21 @@ func addRatesHandler(opts AddRatesOpts) error {
 	}
 
 	logger.Info("rates added to rate registry", zap.Any("rates", rates))
+	return nil
+}
+
+func validateStartTime(startTime uint64) error {
+	startTimeInt, err := utils.Uint64ToInt64(startTime)
+	if err != nil {
+		return fmt.Errorf("--start-time value overflows: %w", err)
+	}
+	startAt := time.Unix(startTimeInt, 0)
+	if startAt.Before(time.Now()) {
+		return fmt.Errorf("--start-time must be in the future")
+	}
+	if startAt.After(time.Now().Add(365 * 24 * time.Hour)) {
+		return fmt.Errorf("--start-time must be less than 1 year in the future")
+	}
 	return nil
 }
 

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   chain:
     platform: linux/amd64
-    image: ghcr.io/xmtp/contracts:v2025.11.26-1
+    image: ghcr.io/xmtp/contracts:v2026.02.10-1
     ports:
       - 7545:8545
 

--- a/pkg/abi/rateregistry/RateRegistry.go
+++ b/pkg/abi/rateregistry/RateRegistry.go
@@ -40,7 +40,7 @@ type IRateRegistryRates struct {
 
 // RateRegistryMetaData contains all meta data concerning the RateRegistry contract.
 var RateRegistryMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"parameterRegistry_\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"congestionFeeParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"contractName\",\"inputs\":[],\"outputs\":[{\"name\":\"contractName_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getRates\",\"inputs\":[{\"name\":\"fromIndex_\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"count_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"rates_\",\"type\":\"tuple[]\",\"internalType\":\"structIRateRegistry.Rates[]\",\"components\":[{\"name\":\"messageFee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"storageFee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"congestionFee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"targetRatePerMinute\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"startTime\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRatesCount\",\"inputs\":[],\"outputs\":[{\"name\":\"count_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"implementation\",\"inputs\":[],\"outputs\":[{\"name\":\"implementation_\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"messageFeeParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"migrate\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"migratorParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"parameterRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"storageFeeParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"targetRatePerMinuteParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"updateRates\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"version_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Migrated\",\"inputs\":[{\"name\":\"migrator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RatesUpdated\",\"inputs\":[{\"name\":\"messageFee\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"storageFee\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"congestionFee\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"targetRatePerMinute\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"EmptyCode\",\"inputs\":[{\"name\":\"migrator_\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EndIndexOutOfRange\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FromIndexOutOfRange\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MigrationFailed\",\"inputs\":[{\"name\":\"migrator_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"revertData_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NoChange\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ParameterOutOfTypeBounds\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroCount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroMigrator\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroParameterRegistry\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"parameterRegistry_\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"congestionFeeParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"contractName\",\"inputs\":[],\"outputs\":[{\"name\":\"contractName_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getRates\",\"inputs\":[{\"name\":\"fromIndex_\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"count_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"rates_\",\"type\":\"tuple[]\",\"internalType\":\"structIRateRegistry.Rates[]\",\"components\":[{\"name\":\"messageFee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"storageFee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"congestionFee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"targetRatePerMinute\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"startTime\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRatesCount\",\"inputs\":[],\"outputs\":[{\"name\":\"count_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"implementation\",\"inputs\":[],\"outputs\":[{\"name\":\"implementation_\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"messageFeeParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"migrate\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"migratorParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"parameterRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"ratesInEffectAfterParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"storageFeeParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"targetRatePerMinuteParameterKey\",\"inputs\":[],\"outputs\":[{\"name\":\"key_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"updateRates\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"version_\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Migrated\",\"inputs\":[{\"name\":\"migrator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RatesUpdated\",\"inputs\":[{\"name\":\"messageFee\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"storageFee\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"congestionFee\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"targetRatePerMinute\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"startTime\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"EmptyCode\",\"inputs\":[{\"name\":\"migrator_\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EndIndexOutOfRange\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FromIndexOutOfRange\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidStartTime\",\"inputs\":[{\"name\":\"startTime\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"lastStartTime\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]},{\"type\":\"error\",\"name\":\"MigrationFailed\",\"inputs\":[{\"name\":\"migrator_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"revertData_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NoChange\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ParameterOutOfTypeBounds\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroCount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroMigrator\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroParameterRegistry\",\"inputs\":[]}]",
 }
 
 // RateRegistryABI is the input ABI used to generate the binding from.
@@ -435,6 +435,37 @@ func (_RateRegistry *RateRegistrySession) ParameterRegistry() (common.Address, e
 // Solidity: function parameterRegistry() view returns(address)
 func (_RateRegistry *RateRegistryCallerSession) ParameterRegistry() (common.Address, error) {
 	return _RateRegistry.Contract.ParameterRegistry(&_RateRegistry.CallOpts)
+}
+
+// RatesInEffectAfterParameterKey is a free data retrieval call binding the contract method 0xf392c428.
+//
+// Solidity: function ratesInEffectAfterParameterKey() pure returns(string key_)
+func (_RateRegistry *RateRegistryCaller) RatesInEffectAfterParameterKey(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _RateRegistry.contract.Call(opts, &out, "ratesInEffectAfterParameterKey")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// RatesInEffectAfterParameterKey is a free data retrieval call binding the contract method 0xf392c428.
+//
+// Solidity: function ratesInEffectAfterParameterKey() pure returns(string key_)
+func (_RateRegistry *RateRegistrySession) RatesInEffectAfterParameterKey() (string, error) {
+	return _RateRegistry.Contract.RatesInEffectAfterParameterKey(&_RateRegistry.CallOpts)
+}
+
+// RatesInEffectAfterParameterKey is a free data retrieval call binding the contract method 0xf392c428.
+//
+// Solidity: function ratesInEffectAfterParameterKey() pure returns(string key_)
+func (_RateRegistry *RateRegistryCallerSession) RatesInEffectAfterParameterKey() (string, error) {
+	return _RateRegistry.Contract.RatesInEffectAfterParameterKey(&_RateRegistry.CallOpts)
 }
 
 // StorageFeeParameterKey is a free data retrieval call binding the contract method 0xba3261d5.
@@ -944,12 +975,13 @@ type RateRegistryRatesUpdated struct {
 	StorageFee          uint64
 	CongestionFee       uint64
 	TargetRatePerMinute uint64
+	StartTime           uint64
 	Raw                 types.Log // Blockchain specific contextual infos
 }
 
-// FilterRatesUpdated is a free log retrieval operation binding the contract event 0xabd2140443b16c364d95086ebf21b45137b5f0af53e10a6e792c0cb3d0e2db62.
+// FilterRatesUpdated is a free log retrieval operation binding the contract event 0x8aa9960c80aa047e81f0b89c422f689e9b6adc187f3f2b2ccb957baf2e6f761b.
 //
-// Solidity: event RatesUpdated(uint64 messageFee, uint64 storageFee, uint64 congestionFee, uint64 targetRatePerMinute)
+// Solidity: event RatesUpdated(uint64 messageFee, uint64 storageFee, uint64 congestionFee, uint64 targetRatePerMinute, uint64 startTime)
 func (_RateRegistry *RateRegistryFilterer) FilterRatesUpdated(opts *bind.FilterOpts) (*RateRegistryRatesUpdatedIterator, error) {
 
 	logs, sub, err := _RateRegistry.contract.FilterLogs(opts, "RatesUpdated")
@@ -959,9 +991,9 @@ func (_RateRegistry *RateRegistryFilterer) FilterRatesUpdated(opts *bind.FilterO
 	return &RateRegistryRatesUpdatedIterator{contract: _RateRegistry.contract, event: "RatesUpdated", logs: logs, sub: sub}, nil
 }
 
-// WatchRatesUpdated is a free log subscription operation binding the contract event 0xabd2140443b16c364d95086ebf21b45137b5f0af53e10a6e792c0cb3d0e2db62.
+// WatchRatesUpdated is a free log subscription operation binding the contract event 0x8aa9960c80aa047e81f0b89c422f689e9b6adc187f3f2b2ccb957baf2e6f761b.
 //
-// Solidity: event RatesUpdated(uint64 messageFee, uint64 storageFee, uint64 congestionFee, uint64 targetRatePerMinute)
+// Solidity: event RatesUpdated(uint64 messageFee, uint64 storageFee, uint64 congestionFee, uint64 targetRatePerMinute, uint64 startTime)
 func (_RateRegistry *RateRegistryFilterer) WatchRatesUpdated(opts *bind.WatchOpts, sink chan<- *RateRegistryRatesUpdated) (event.Subscription, error) {
 
 	logs, sub, err := _RateRegistry.contract.WatchLogs(opts, "RatesUpdated")
@@ -996,9 +1028,9 @@ func (_RateRegistry *RateRegistryFilterer) WatchRatesUpdated(opts *bind.WatchOpt
 	}), nil
 }
 
-// ParseRatesUpdated is a log parse operation binding the contract event 0xabd2140443b16c364d95086ebf21b45137b5f0af53e10a6e792c0cb3d0e2db62.
+// ParseRatesUpdated is a log parse operation binding the contract event 0x8aa9960c80aa047e81f0b89c422f689e9b6adc187f3f2b2ccb957baf2e6f761b.
 //
-// Solidity: event RatesUpdated(uint64 messageFee, uint64 storageFee, uint64 congestionFee, uint64 targetRatePerMinute)
+// Solidity: event RatesUpdated(uint64 messageFee, uint64 storageFee, uint64 congestionFee, uint64 targetRatePerMinute, uint64 startTime)
 func (_RateRegistry *RateRegistryFilterer) ParseRatesUpdated(log types.Log) (*RateRegistryRatesUpdated, error) {
 	event := new(RateRegistryRatesUpdated)
 	if err := _RateRegistry.contract.UnpackLog(event, "RatesUpdated", log); err != nil {

--- a/pkg/blockchain/parameter_registry_admin.go
+++ b/pkg/blockchain/parameter_registry_admin.go
@@ -41,6 +41,7 @@ const (
 	RateRegistryCongestionFeeKey       = "xmtp.rateRegistry.congestionFee"
 	RateRegistryMessageFeeKey          = "xmtp.rateRegistry.messageFee"
 	RateRegistryMigratorKey            = "xmtp.rateRegistry.migrator"
+	RateRegistryRatesInEffectAfterKey  = "xmtp.rateRegistry.ratesInEffectAfter"
 	RateRegistryStorageFeeKey          = "xmtp.rateRegistry.storageFee"
 	RateRegistryTargetRatePerMinuteKey = "xmtp.rateRegistry.targetRatePerMinute"
 

--- a/pkg/blockchain/rate_registry_admin.go
+++ b/pkg/blockchain/rate_registry_admin.go
@@ -76,12 +76,18 @@ func (r *RatesAdmin) AddRates(ctx context.Context, rates fees.Rates) ProtocolErr
 			fmt.Errorf("%s must be positive", RateRegistryCongestionFeeKey),
 		)
 	}
+	if rates.StartTime == 0 {
+		return NewBlockchainError(
+			fmt.Errorf("%s must be set", RateRegistryRatesInEffectAfterKey),
+		)
+	}
 
 	params := []Uint64Param{
 		{Name: RateRegistryMessageFeeKey, Value: uint64(rates.MessageFee)},
 		{Name: RateRegistryStorageFeeKey, Value: uint64(rates.StorageFee)},
 		{Name: RateRegistryCongestionFeeKey, Value: uint64(rates.CongestionFee)},
 		{Name: RateRegistryTargetRatePerMinuteKey, Value: rates.TargetRatePerMinute},
+		{Name: RateRegistryRatesInEffectAfterKey, Value: rates.StartTime},
 	}
 	if err := r.paramAdmin.SetManyUint64Parameters(ctx, params); err != nil {
 		return err
@@ -109,6 +115,7 @@ func (r *RatesAdmin) AddRates(ctx context.Context, rates fees.Rates) ProtocolErr
 				zap.Uint64(RateRegistryStorageFeeKey, e.StorageFee),
 				zap.Uint64(RateRegistryCongestionFeeKey, e.CongestionFee),
 				zap.Uint64(RateRegistryTargetRatePerMinuteKey, e.TargetRatePerMinute),
+				zap.Uint64(RateRegistryRatesInEffectAfterKey, e.StartTime),
 			)
 		},
 	)
@@ -119,6 +126,7 @@ func (r *RatesAdmin) AddRates(ctx context.Context, rates fees.Rates) ProtocolErr
 				zap.Uint64(RateRegistryStorageFeeKey, uint64(rates.StorageFee)),
 				zap.Uint64(RateRegistryCongestionFeeKey, uint64(rates.CongestionFee)),
 				zap.Uint64(RateRegistryTargetRatePerMinuteKey, rates.TargetRatePerMinute),
+				zap.Uint64(RateRegistryRatesInEffectAfterKey, rates.StartTime),
 			)
 			return nil
 		}

--- a/pkg/blockchain/rate_registry_admin_test.go
+++ b/pkg/blockchain/rate_registry_admin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/blockchain"
@@ -58,6 +59,7 @@ func TestAddRates(t *testing.T) {
 		StorageFee:          200,
 		CongestionFee:       300,
 		TargetRatePerMinute: 100 * 60,
+		StartTime:           uint64(time.Now().Add(2 * time.Hour).Unix()),
 	}
 
 	err := ratesAdmin.AddRates(context.Background(), rates)
@@ -69,16 +71,19 @@ func TestAddNegativeRates(t *testing.T) {
 
 	err := ratesAdmin.AddRates(context.Background(), fees.Rates{
 		MessageFee: -100,
+		StartTime:  uint64(time.Now().Add(2 * time.Hour).Unix()),
 	})
 	require.ErrorContains(t, err, "must be positive")
 
 	err = ratesAdmin.AddRates(context.Background(), fees.Rates{
 		StorageFee: -100,
+		StartTime:  uint64(time.Now().Add(2 * time.Hour).Unix()),
 	})
 	require.ErrorContains(t, err, "must be positive")
 
 	err = ratesAdmin.AddRates(context.Background(), fees.Rates{
 		CongestionFee: -100,
+		StartTime:     uint64(time.Now().Add(2 * time.Hour).Unix()),
 	})
 	require.ErrorContains(t, err, "must be positive")
 }
@@ -91,6 +96,7 @@ func TestAdd0Rates(t *testing.T) {
 		StorageFee:          0,
 		CongestionFee:       0,
 		TargetRatePerMinute: 0,
+		StartTime:           uint64(time.Now().Add(2 * time.Hour).Unix()),
 	})
 	require.NoError(t, err)
 }
@@ -103,6 +109,7 @@ func TestAddLargeRates(t *testing.T) {
 		StorageFee:          math.MaxInt64,
 		CongestionFee:       math.MaxInt64,
 		TargetRatePerMinute: math.MaxUint64,
+		StartTime:           uint64(time.Now().Add(2 * time.Hour).Unix()),
 	})
 	require.NoError(t, err)
 }
@@ -110,16 +117,20 @@ func TestAddLargeRates(t *testing.T) {
 func TestAddRatesAgain(t *testing.T) {
 	ratesAdmin, _ := buildRatesAdmin(t)
 
+	startTime := uint64(time.Now().Add(2 * time.Hour).Unix())
+
 	rates := fees.Rates{
 		MessageFee:          5,
 		StorageFee:          16,
 		CongestionFee:       700,
 		TargetRatePerMinute: 1000,
+		StartTime:           startTime,
 	}
 
 	err := ratesAdmin.AddRates(context.Background(), rates)
 	require.NoError(t, err)
 
+	rates.StartTime = startTime + 3600
 	err = ratesAdmin.AddRates(context.Background(), rates)
 	require.NoError(t, err)
 }
@@ -157,6 +168,7 @@ func TestRates_WriteThenRead(t *testing.T) {
 		StorageFee:          456,
 		CongestionFee:       789,
 		TargetRatePerMinute: 60,
+		StartTime:           uint64(time.Now().Add(2 * time.Hour).Unix()),
 	}
 	require.NoError(t, ratesAdmin.AddRates(ctx, want))
 
@@ -187,6 +199,7 @@ func TestRates_WriteZeroes_ReadZeroes(t *testing.T) {
 		StorageFee:          0,
 		CongestionFee:       0,
 		TargetRatePerMinute: 0,
+		StartTime:           uint64(time.Now().Add(2 * time.Hour).Unix()),
 	}
 	require.NoError(t, ratesAdmin.AddRates(ctx, zero))
 

--- a/pkg/fees/interface.go
+++ b/pkg/fees/interface.go
@@ -15,6 +15,7 @@ type Rates struct {
 	StorageFee          currency.PicoDollar // The fee per byte-day of storage
 	CongestionFee       currency.PicoDollar // The fee per unit of congestion
 	TargetRatePerMinute uint64              // The target rate per minute for each node
+	StartTime           uint64              // Unix timestamp when these rates become active
 }
 
 // IRatesFetcher is responsible for loading the rates for a given message time.


### PR DESCRIPTION
### TL;DR

Added support for scheduled rate changes by introducing a `--start-time` parameter to the `xmtpd-cli rates add` command.

### What changed?

- Added a `StartTime` field to the `AddRatesOpts` struct in the CLI
- Added a `--start-time` flag to the `rates add` command that accepts a Unix timestamp
- If `--start-time` is omitted, it defaults to 2 hours from now
- Added validation to ensure the start time is in the future but not more than a year ahead
- Updated the contract ABI to support the new `startTime` parameter in the `RatesUpdated` event
- Updated the blockchain package to handle the new `startTime` parameter
- Updated the Docker image for the blockchain contracts to `v2026.02.10-1`

### How to test?

1. Use the CLI to add rates with a specific start time:
```
xmtpd-cli rates add --message-fee 1000000000000000000 --storage-fee 1000000000000000000 --congestion-fee 1000000000000000000 --target-rate 1000000000000000000 --start-time 1739188800
```

2. Add rates without specifying a start time (will default to 2 hours from now):
```
xmtpd-cli rates add --message-fee 1000000000000000000 --storage-fee 1000000000000000000 --congestion-fee 1000000000000000000 --target-rate 1000000000000000000
```

3. Verify the validation works by trying invalid start times (in the past or too far in the future)

### Why make this change?

This change enables operators to schedule rate changes in advance, allowing for better planning and communication of fee adjustments. By supporting a start time parameter, the system can now transition between different rate structures at predetermined times without requiring manual intervention at the exact moment of change.