### PR TITLE
refactor: replace context.WithCancel with t.Context

### DIFF
--- a/pkg/db/subscription_test.go
+++ b/pkg/db/subscription_test.go
@@ -321,8 +321,7 @@ func TestSubscriptionDeliversContiguousSequencesPerOriginator(t *testing.T) {
 		},
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Start polling at seq=1, 1 row per poll so we can observe ordering across batches.
 	sub := db.NewDBSubscription(


### PR DESCRIPTION
The addition of the Context method to Go's testing.T provides significant improvements for writing concurrent tests. It allows better management of goroutines, ensuring they properly exit and preventing issues like deadlocks and unfinished processes.

By using Context, errors and cancellations can be handled more effectively, making tests more robust and easier to reason about. This change also enables tighter integration between tests and the application code, especially for systems that span multiple concurrent components. Overall, it simplifies test code and enhances test stability and maintainability.

More info: [golang/go#18368](https://github.com/golang/go/issues/18368)