### PR TITLE
Separate build and run steps

### DIFF
--- a/dev/docker/up
+++ b/dev/docker/up
@@ -26,8 +26,15 @@ docker compose \
   --env-file dev/local.env \
   --profile "${profile}" \
   -p "xmtpd_register_nodes" \
+  build \
+  register-node-1
+
+docker compose \
+  -f dev/docker/docker-compose-register.yml \
+  --env-file dev/local.env \
+  --profile "${profile}" \
+  -p "xmtpd_register_nodes" \
   up \
-  --build \
   --remove-orphans
 
 echo


### PR DESCRIPTION
## tl;dr

- Apparently newer Docker clients have problems concurrently running builds for the same image/tag. This separates the build and run steps.

## Side note

Now that I am looking at this workflow, we should really replace these 4 services with a single CLI entry that we can run different commands with through `docker-compose run` or `docker compose exec` rather than trying this weird approach of having them all as services depending on each other.