### PR TITLE
fix: make originator cache TTL configurable to unblock integration tests

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -11,6 +11,7 @@ type APIOptions struct {
 	Enable                bool          `long:"enable"                   env:"XMTPD_API_ENABLE"                   description:"Enable the client API"`
 	SendKeepAliveInterval time.Duration `long:"send-keep-alive-interval" env:"XMTPD_API_SEND_KEEP_ALIVE_INTERVAL" description:"Send empty application level keepalive package interval" default:"30s"`
 	Port                  int           `long:"port"                     env:"XMTPD_API_PORT"                     description:"Port to listen on"                                       default:"5050" short:"p"`
+	OriginatorCacheTTL    time.Duration `long:"originator-cache-ttl"     env:"XMTPD_API_ORIGINATOR_CACHE_TTL"     description:"TTL for originator list cache"                           default:"5m"`
 }
 
 type ContractsOptions struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,7 +493,7 @@ func startAPIServer(
 			cfg.Options.API,
 			isMigrationEnabled,
 			10*time.Millisecond,
-			db.NewCachedOriginatorList(cfg.DB.ReadQuery(), 5*time.Minute),
+			db.NewCachedOriginatorList(cfg.DB.ReadQuery(), cfg.Options.API.OriginatorCacheTTL),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -217,7 +217,7 @@ func NewTestAPIServer(
 			},
 			false,
 			10*time.Millisecond,
-			dbPkg.NewCachedOriginatorList(db.ReadQuery(), 5*time.Minute),
+			dbPkg.NewCachedOriginatorList(db.ReadQuery(), 100*time.Millisecond),
 		)
 		require.NoError(t, err)
 

--- a/pkg/testutils/server/server.go
+++ b/pkg/testutils/server/server.go
@@ -55,6 +55,7 @@ func NewTestBaseServer(
 				Port:                  cfg.Port,
 				Enable:                cfg.Services.API,
 				SendKeepAliveInterval: 30 * time.Second,
+				OriginatorCacheTTL:    100 * time.Millisecond,
 			},
 			Contracts: *cfg.ContractsOptions,
 			MlsValidation: config.MlsValidationOptions{


### PR DESCRIPTION
The V3b LATERAL query requires all originators to be pre-listed in cursor
arrays. FillMissingOriginators depends on CachedOriginatorList which
caches for 5 minutes — too long for integration tests with 10s timeouts.

Add OriginatorCacheTTL to APIOptions (default 5m for production) and set
it to 100ms in test helpers so replicated messages from other nodes
become visible quickly.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>