### PR TITLE
Fix sync service

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -39,7 +39,6 @@ import (
 
 const (
 	maxRequestedRows     int32         = 1000
-	minRowsPerOriginator int32         = 50
 	maxQueriesPerRequest int           = 10000
 	maxTopicLength       int           = 128
 	maxVectorClockLength int           = 100
@@ -499,15 +498,9 @@ func (s *Service) fetchEnvelopes(
 		return db.TransformRowsByTopic(rows), nil
 	}
 
-	// TODO: Consider a limit on the number of originators that can be subscribed to.
 	if len(query.GetOriginatorNodeIds()) != 0 {
-		rowsPerOriginator := calculateEnvelopesPerOriginator(
-			len(query.GetOriginatorNodeIds()),
-		)
-
 		params := queries.SelectGatewayEnvelopesByOriginatorsParams{
 			OriginatorNodeIds: make([]int32, 0, len(query.GetOriginatorNodeIds())),
-			RowsPerOriginator: rowsPerOriginator,
 			RowLimit:          rowLimit,
 			CursorNodeIds:     nil,
 			CursorSequenceIds: nil,
@@ -534,19 +527,6 @@ func (s *Service) fetchEnvelopes(
 	rows := make([]queries.GatewayEnvelopesView, 0)
 
 	return rows, nil
-}
-
-// calculateEnvelopesPerOriginator calculates the number of envelopes to fetch per originator.
-// It ensures that the number of envelopes fetched per originator is at least minRowsPerOriginator
-// and at most maxRequestedRows.
-func calculateEnvelopesPerOriginator(numOriginators int) int32 {
-	if numOriginators == 0 {
-		return 0
-	}
-
-	rowsPerOriginator := max(maxRequestedRows/int32(numOriginators), minRowsPerOriginator)
-
-	return rowsPerOriginator
 }
 
 type ValidatedBytesWithTopic struct {

--- a/pkg/db/queries/envelopes_v2.sql.go
+++ b/pkg/db/queries/envelopes_v2.sql.go
@@ -131,44 +131,40 @@ func (q *Queries) InsertGatewayEnvelopeBatchAndIncrementUnsettledUsage(ctx conte
 const selectGatewayEnvelopesByOriginators = `-- name: SelectGatewayEnvelopesByOriginators :many
 WITH cursors AS (
     SELECT x.node_id AS cursor_node_id, y.seq_id AS cursor_sequence_id
-    FROM unnest($4::INT[]) WITH ORDINALITY AS x(node_id, ord)
-    JOIN unnest($5::BIGINT[]) WITH ORDINALITY AS y(seq_id, ord) USING (ord)
-)
-SELECT m.originator_node_id,
-       m.originator_sequence_id,
-       m.gateway_time,
-       m.topic,
-       m.originator_envelope
-FROM unnest($1::INT[]) AS o(node_id)
-CROSS JOIN LATERAL (
+    FROM unnest($1::INT[]) WITH ORDINALITY AS x(node_id, ord)
+    JOIN unnest($2::BIGINT[]) WITH ORDINALITY AS y(seq_id, ord)
+    USING (ord)
+),
+filtered AS (
     SELECT m.originator_node_id,
            m.originator_sequence_id,
            m.gateway_time,
-           m.topic,
-           b.originator_envelope
+           m.topic
     FROM gateway_envelopes_meta AS m
-    JOIN gateway_envelope_blobs AS b
-        ON b.originator_node_id = m.originator_node_id
-       AND b.originator_sequence_id = m.originator_sequence_id
-       AND b.originator_node_id = o.node_id
-    WHERE m.originator_node_id = o.node_id
-      AND m.originator_sequence_id > COALESCE(
-          (SELECT c.cursor_sequence_id FROM cursors c WHERE c.cursor_node_id = o.node_id),
-          0
-      )
-    ORDER BY m.originator_sequence_id
-    LIMIT NULLIF($2::INT, 0)
-) AS m
-ORDER BY m.originator_node_id, m.originator_sequence_id
-LIMIT NULLIF($3::INT, 0)
+    LEFT JOIN cursors AS c
+        ON m.originator_node_id = c.cursor_node_id
+    WHERE m.originator_node_id = ANY ($3::INT[])
+    AND m.originator_sequence_id > COALESCE(c.cursor_sequence_id, 0)
+    ORDER BY m.originator_node_id, m.originator_sequence_id
+    LIMIT NULLIF($4::INT, 0)
+)
+SELECT f.originator_node_id,
+       f.originator_sequence_id,
+       f.gateway_time,
+       f.topic,
+       b.originator_envelope
+FROM filtered AS f
+JOIN gateway_envelope_blobs AS b
+    ON b.originator_node_id = f.originator_node_id
+    AND b.originator_sequence_id = f.originator_sequence_id
+ORDER BY f.originator_node_id, f.originator_sequence_id
 `
 
 type SelectGatewayEnvelopesByOriginatorsParams struct {
-	OriginatorNodeIds []int32
-	RowsPerOriginator int32
-	RowLimit          int32
 	CursorNodeIds     []int32
 	CursorSequenceIds []int64
+	OriginatorNodeIds []int32
+	RowLimit          int32
 }
 
 type SelectGatewayEnvelopesByOriginatorsRow struct {
@@ -179,15 +175,12 @@ type SelectGatewayEnvelopesByOriginatorsRow struct {
 	OriginatorEnvelope   []byte
 }
 
-// Uses LATERAL join with scalar subquery to push cursor filter into index scan.
-// This avoids full table scans when using LEFT JOIN + COALESCE pattern.
 func (q *Queries) SelectGatewayEnvelopesByOriginators(ctx context.Context, arg SelectGatewayEnvelopesByOriginatorsParams) ([]SelectGatewayEnvelopesByOriginatorsRow, error) {
 	rows, err := q.db.QueryContext(ctx, selectGatewayEnvelopesByOriginators,
-		pq.Array(arg.OriginatorNodeIds),
-		arg.RowsPerOriginator,
-		arg.RowLimit,
 		pq.Array(arg.CursorNodeIds),
 		pq.Array(arg.CursorSequenceIds),
+		pq.Array(arg.OriginatorNodeIds),
+		arg.RowLimit,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR reverts the SelectGatewayEnvelopesByOriginators to its previous state.

Introduces a regression test which makes sure that:
- Syncing from originators will always catch up completely. That's why 1001 envelopes are used, to test also the max rows per request (1000).
- Syncing multiple originator ids won't break the system invariant that all messages from all those originator ids are synced.