### PR TITLE
Fix log

### DIFF
--- a/pkg/api/message/subscribe_worker.go
+++ b/pkg/api/message/subscribe_worker.go
@@ -251,7 +251,7 @@ func (s *subscribeWorker) dispatchToListeners(
 		select {
 		case <-l.ctx.Done():
 			if s.logger.Core().Enabled(zap.DebugLevel) {
-				s.logger.Debug("stream closed, removing listener", utils.BodyField(l.ch))
+				s.logger.Debug("stream closed, removing listener")
 			}
 
 			s.closeListener(l)


### PR DESCRIPTION
This line results in `json: unsupported type: chan<- []*envelopes.OriginatorEnvelope` as the type is not serializable.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove channel field from debug log in `message.subscribeWorker.dispatchToListeners` to fix log
> Update `message.subscribeWorker.dispatchToListeners` to omit `utils.BodyField(l.ch)` from the "stream closed, removing listener" debug log in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1713/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab).
>
> #### 📍Where to Start
> Start at `message.subscribeWorker.dispatchToListeners` in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1713/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4c5dcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->