### PR TITLE
Honor gRPC maximum message size

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,6 +12,8 @@ const (
 	// Indexer originator IDs for group messages and identity updates.
 	GroupMessageOriginatorID   = 0
 	IdentityUpdateOriginatorID = 1
+
+	GRPCPayloadLimit = 1024 * 1024 * 25 // 25MB
 )
 
 type VerifiedNodeRequestCtxKey struct{}

--- a/pkg/utils/api_clients.go
+++ b/pkg/utils/api_clients.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/xmtp/xmtpd/pkg/constants"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api/message_apiconnect"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/metadata_api/metadata_apiconnect"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api/payer_apiconnect"
@@ -26,7 +27,6 @@ import (
 // For metadata and gateway APIs, only the base client is provided, and the consumer has to specify the api options.
 
 const (
-	maxMessageSize  = 25 * 1024 * 1024
 	readIdleTimeout = 10 * time.Second
 	pingTimeout     = 30 * time.Second
 	clientTimeout   = 10 * time.Second
@@ -172,8 +172,8 @@ func NewGRPCConn(
 
 	dialOptions := append([]grpc.DialOption{
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallSendMsgSize(maxMessageSize),
-			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(constants.GRPCPayloadLimit),
+			grpc.MaxCallRecvMsgSize(constants.GRPCPayloadLimit),
 		),
 	}, extraDialOpts...)
 
@@ -339,8 +339,8 @@ func HTTPAddressToConnectProtocolTarget(httpAddress string) (target string, isTL
 func getBaseDialOptions(extraDialOpts ...connect.ClientOption) []connect.ClientOption {
 	// TODO: Extend with compression options?
 	return append([]connect.ClientOption{
-		connect.WithReadMaxBytes(maxMessageSize),
-		connect.WithSendMaxBytes(maxMessageSize),
+		connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
+		connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
 		connect.WithSendGzip(),
 	}, extraDialOpts...)
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Enforce a 25MB gRPC payload limit in `pkg/api/message.Service.catchUpFromCursor` and `pkg/api/message.Service.QueryEnvelopes` to honor maximum message size
Add byte-size limiting to streaming and unary message responses, skip envelopes exceeding the limit, and truncate batches when adding another envelope would exceed 25MB; introduce `constants.GRPCPayloadLimit` and use it for client call options.

#### 📍Where to Start
Start with the batching and size-check logic in `Service.catchUpFromCursor` in [service.go](https://github.com/xmtp/xmtpd/pull/1714/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2), then review the unary response assembly in `Service.QueryEnvelopes` in the same file.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0209ef1.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->