### PR TITLE
Log migrator lower limits

### DIFF
--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -184,6 +184,30 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 
 	readDB := db.NewDBHandler(reader, db.WithReadReplica(reader))
 
+	logger.Info(
+		"running migration service with lower limits configured as",
+		zap.Int64(
+			string(config.MigrationSourceGroupMessages),
+			cfg.options.LowerLimits.Get(config.MigrationSourceGroupMessages),
+		),
+		zap.Int64(
+			string(config.MigrationSourceKeyPackages),
+			cfg.options.LowerLimits.Get(config.MigrationSourceKeyPackages),
+		),
+		zap.Int64(
+			string(config.MigrationSourceWelcomeMessages),
+			cfg.options.LowerLimits.Get(config.MigrationSourceWelcomeMessages),
+		),
+		zap.Int64(
+			string(config.MigrationSourceInboxLog),
+			cfg.options.LowerLimits.Get(config.MigrationSourceInboxLog),
+		),
+		zap.Int64(
+			string(config.MigrationSourceCommitMessages),
+			cfg.options.LowerLimits.Get(config.MigrationSourceCommitMessages),
+		),
+	)
+
 	readers := map[string]ISourceReader{
 		groupMessagesTableName: NewGroupMessageReader(
 			readDB.DB(),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Log configured lower limits during service init by adding an info-level zap statement in `pkg/migrator/migrator.go:NewMigrationService`
Add an info-level structured log in `pkg/migrator/migrator.go` within `NewMigrationService` to emit lower limit values for group messages, key packages, welcome messages, inbox log, and commit messages after initializing the read replica and before building the readers map.

#### 📍Where to Start
Start with `NewMigrationService` in [migrator.go](https://github.com/xmtp/xmtpd/pull/1715/files#diff-ccb0d31b1e7491838a2e4c7f2f6523eed971d6f18d4c04f006e14e2767671693).

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5e14fd9. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->