### PR TITLE
Honor gRPC message size limits

### DIFF
--- a/doc/networking.md
+++ b/doc/networking.md
@@ -23,13 +23,11 @@ This document describes the communication protocols and APIs implemented in the 
 The xmtpd system uses a **dual-protocol architecture**:
 
 - **External/Client-Facing APIs**: Implemented with **Connect-RPC handlers** that automatically support three protocols:
-
   - Connect (HTTP/1.1 or HTTP/2 with standard HTTP semantics). **Currently not allowed**.
   - gRPC (HTTP/2 with gRPC protocol)
   - gRPC-Web (browser-compatible gRPC)
 
 - **Internal Node-to-Node Communication**: Uses **native gRPC clients** for:
-
   - Sync worker (node-to-node envelope replication)
   - MLS validation service
   - Gateway client manager (gateway-to-node communication)
@@ -136,11 +134,9 @@ When running in production, prefer HTTPS with HTTP/2 (no h2c) unless traffic is 
 ### When to use which protocol
 
 - Connect (default via connect-go)
-
   - Not supported currently.
 
 - gRPC (classic)
-
   - Use when interoperating with existing gRPC-only clients/infra
   - Requires HTTP/2; commonly secured with TLS in production
   - Strong ecosystem of tooling (`grpcurl`, language SDKs)
@@ -665,6 +661,19 @@ grpcurl -plaintext -d 'DATA_FRAME' \
 grpcurl -plaintext \
   localhost:5050 \
   xmtp.xmtpv4.metadata_api.MetadataApi/GetVersion
+
+# Query envelopes
+grpcurl --plaintext -d '{
+    "query": {
+        "originator_node_ids": [10],
+        "last_seen": {
+            "node_id_to_sequence_id": {
+                "10": "191604"
+            }
+        }
+    },
+    "limit":1000
+}' localhost:5050 xmtp.xmtpv4.message_api.ReplicationApi/QueryEnvelopes
 ```
 
 **Subscribe to a stream**:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,6 +12,10 @@ const (
 	// Indexer originator IDs for group messages and identity updates.
 	GroupMessageOriginatorID   = 0
 	IdentityUpdateOriginatorID = 1
+
+	// TODO: Revert to 25 * 1024 * 1024 after node sync is migrated to use the new API with pagination.
+	// Has to be in sync with xmtp/libxmtp/crates/xmtp_configuration/src/common/api.rs GRPC_PAYLOAD_LIMIT.
+	GRPCPayloadLimit = 50 * 1024 * 1024
 )
 
 type VerifiedNodeRequestCtxKey struct{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/xmtp/xmtpd/pkg/api/metadata"
+	"github.com/xmtp/xmtpd/pkg/constants"
 	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/fees"
 	"github.com/xmtp/xmtpd/pkg/migrator"
@@ -508,6 +509,8 @@ func startAPIServer(
 
 		replicationPath, replicationHandler := message_apiconnect.NewReplicationApiHandler(
 			replicationService,
+			connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
+			connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
 			connect.WithInterceptors(interceptors...),
 		)
 
@@ -534,6 +537,8 @@ func startAPIServer(
 
 		metadataPath, metadataHandler := metadata_apiconnect.NewMetadataApiHandler(
 			metadataService,
+			connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
+			connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
 			connect.WithInterceptors(interceptors...),
 		)
 

--- a/pkg/utils/api_clients.go
+++ b/pkg/utils/api_clients.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/xmtp/xmtpd/pkg/constants"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api/message_apiconnect"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/metadata_api/metadata_apiconnect"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/payer_api/payer_apiconnect"
@@ -26,7 +27,6 @@ import (
 // For metadata and gateway APIs, only the base client is provided, and the consumer has to specify the api options.
 
 const (
-	maxMessageSize  = 25 * 1024 * 1024
 	readIdleTimeout = 10 * time.Second
 	pingTimeout     = 30 * time.Second
 	clientTimeout   = 10 * time.Second
@@ -172,8 +172,8 @@ func NewGRPCConn(
 
 	dialOptions := append([]grpc.DialOption{
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallSendMsgSize(maxMessageSize),
-			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(constants.GRPCPayloadLimit),
+			grpc.MaxCallRecvMsgSize(constants.GRPCPayloadLimit),
 		),
 	}, extraDialOpts...)
 
@@ -339,8 +339,8 @@ func HTTPAddressToConnectProtocolTarget(httpAddress string) (target string, isTL
 func getBaseDialOptions(extraDialOpts ...connect.ClientOption) []connect.ClientOption {
 	// TODO: Extend with compression options?
 	return append([]connect.ClientOption{
-		connect.WithReadMaxBytes(maxMessageSize),
-		connect.WithSendMaxBytes(maxMessageSize),
+		connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
+		connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
 		connect.WithSendGzip(),
 	}, extraDialOpts...)
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Enforce 50 MiB gRPC payload limits across Replication and Metadata APIs and client connections
Add `constants.GRPCPayloadLimit` (50 MiB) and apply it to server handlers in `pkg/server/server.go` and client options in `pkg/utils/api_clients.go`; add a failing-over-limit test in `pkg/server/server_test.go`; update `doc/networking.md` with a `grpcurl` example.

#### 📍Where to Start
Start with `startAPIServer` in [server.go](https://github.com/xmtp/xmtpd/pull/1720/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996) to see how `connect.WithReadMaxBytes` and `connect.WithSendMaxBytes` use `constants.GRPCPayloadLimit`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30b8f28.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->