### PR TITLE
Deploy to testnet and testnet-staging in parallel

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -86,15 +86,16 @@ jobs:
           name: ${{ matrix.image }}-digest
           path: ${{ matrix.image }}.txt
 
-  deploy:
-    name: Aggregate digests & deploy to infra
+  prepare:
+    name: Aggregate digests
     runs-on: ubuntu-latest
     needs: push_to_registry
     if: github.ref == 'refs/heads/main'
+    outputs:
+      xmtpd_image: ${{ steps.digests.outputs.xmtpd_image }}
+      prune_image: ${{ steps.digests.outputs.prune_image }}
+      gateway_image: ${{ steps.digests.outputs.gateway_image }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Download xmtpd digest
         uses: actions/download-artifact@v4
         with:
@@ -134,17 +135,16 @@ jobs:
             exit 1
           fi
 
-          XMTPD_IMAGE="ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"
-          CLI_IMAGE="ghcr.io/xmtp/xmtpd-cli@$CLI_DIGEST"
-          PRUNE_IMAGE="ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"
-          GATEWAY_IMAGE="ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"
+          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"         >> $GITHUB_OUTPUT
+          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"   >> $GITHUB_OUTPUT
+          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST" >> $GITHUB_OUTPUT
 
-          echo "xmtpd_image=$XMTPD_IMAGE"     >> $GITHUB_OUTPUT
-          echo "cli_image=$CLI_IMAGE"         >> $GITHUB_OUTPUT
-          echo "prune_image=$PRUNE_IMAGE"     >> $GITHUB_OUTPUT
-          echo "gateway_image=$GATEWAY_IMAGE" >> $GITHUB_OUTPUT
-
-      - name: Deploy Testnet
+  deploy_testnet_staging:
+    name: Deploy to testnet-staging
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Deploy Testnet Staging
         uses: xmtp-labs/terraform-deployer@v1
         timeout-minutes: 45
         with:
@@ -153,5 +153,22 @@ jobs:
           terraform-org: xmtp
           terraform-workspace: testnet-staging
           variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image"
-          variable-value: "${{ steps.digests.outputs.xmtpd_image }},${{ steps.digests.outputs.prune_image }},${{ steps.digests.outputs.gateway_image }},${{ steps.digests.outputs.xmtpd_image }}"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }}"
+          variable-value-required-prefix: "ghcr.io/xmtp/"
+
+  deploy_testnet:
+    name: Deploy to testnet
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Deploy Testnet
+        uses: xmtp-labs/terraform-deployer@v1
+        timeout-minutes: 45
+        with:
+          timeout: 45m
+          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
+          terraform-org: xmtp
+          terraform-workspace: testnet
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"


### PR DESCRIPTION
## Summary

- Adds deployment to the `testnet` Terraform workspace (previously only `testnet-staging` was deployed)
- Splits the single `deploy` job into three jobs: `prepare`, `deploy_testnet_staging`, and `deploy_testnet`
- The two deploy jobs both depend on `prepare` but not on each other, so they run concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deploy testnet and testnet-staging in parallel by introducing a `prepare` job that outputs `xmtpd_image`, `prune_image`, and `gateway_image` for downstream Terraform deployments in [.github/workflows/build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1724/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9)
> Introduce a `prepare` job that aggregates digests and exposes `xmtpd_image`, `prune_image`, and `gateway_image`; add `deploy_testnet_staging` using these outputs; update the existing deployment as `deploy_testnet` to target the `testnet` workspace and consume `needs.prepare.outputs` in [.github/workflows/build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1724/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9).
>
> #### 📍Where to Start
> Start with the `prepare` job and its `digests` step in [.github/workflows/build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1724/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9), then review `deploy_testnet_staging` and `deploy_testnet` for consumption of `needs.prepare.outputs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37abbd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->