### PR TITLE
Add missing checkout step for deployer tooling

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -144,6 +144,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Deploy Testnet Staging
         uses: xmtp-labs/terraform-deployer@v1
         timeout-minutes: 45
@@ -161,6 +163,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Deploy Testnet
         uses: xmtp-labs/terraform-deployer@v1
         timeout-minutes: 45


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add checkout step to `deploy_testnet_staging` and `deploy_testnet` jobs
Adds `actions/checkout@v6` as the first step in the `deploy_testnet_staging` and `deploy_testnet` jobs within [.github/workflows/build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1731/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9). This ensures the repository code is available when the terraform-deployer action runs.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 805f1fb.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->