### PR TITLE
Honor gRPC limits on streams

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -13,9 +13,8 @@ const (
 	GroupMessageOriginatorID   = 0
 	IdentityUpdateOriginatorID = 1
 
-	// TODO: Revert to 25 * 1024 * 1024 after node sync is migrated to use the new API with pagination.
 	// Has to be in sync with xmtp/libxmtp/crates/xmtp_configuration/src/common/api.rs GRPC_PAYLOAD_LIMIT.
-	GRPCPayloadLimit = 50 * 1024 * 1024
+	GRPCPayloadLimit = 25 * 1024 * 1024
 )
 
 type VerifiedNodeRequestCtxKey struct{}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Chunk gRPC stream messages in `sendEnvelopes` to honor `GRPCPayloadLimit`
- Rewrites `message.Service.sendEnvelopes` in [service.go](https://github.com/xmtp/xmtpd/pull/1744/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) to flush envelopes in size-bounded batches instead of a single send, ensuring no stream message exceeds `GRPCPayloadLimit`.
- Adds `envelopeOverhead` helper to compute per-item protobuf wire overhead (tag byte + varint length) for accurate batch size estimation.
- Reduces `GRPCPayloadLimit` in [constants.go](https://github.com/xmtp/xmtpd/pull/1744/files#diff-36043890c52c8201a8bc84238c219be45ce07bf172d89f693c7c54ffe70d046e) from 50 MiB to 25 MiB to match client configuration.
- Behavioral Change: outgoing envelope metrics are now emitted once per flushed batch rather than once per call, and subscribers may receive multiple stream messages per originator batch.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 401085a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->