### PR TITLE
docs: fix fenced code block in ratelimiter README

### DIFF
--- a/pkg/ratelimiter/README.md
+++ b/pkg/ratelimiter/README.md
@@ -192,7 +192,6 @@ Redis (v7+) with jemalloc allocator has significant per-key overhead:
 
 **For 10,000 active IPv4 subjects with 2 limits:**
 - 10,000 × 262 bytes = **~2.62 MB**
-```
 
 **Notes:**
 - Keys automatically expire based on inactivity, so memory usage reflects only active subjects


### PR DESCRIPTION
Removes a stray fenced code block delimiter in pkg/ratelimiter/README.md that caused the remainder of the file to render incorrectly as a code block on GitHub.
No content changes. Markdown structure only

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix code block formatting in ratelimiter README
> Removes a stray closing triple-backtick that incorrectly terminated a code block in [README.md](https://github.com/xmtp/xmtpd/pull/1746/files#diff-b21f52a6163d810c848ddebad8f8a56eda5b56999bf65e4d6bc7025230a759ce).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cf69ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->