### PR TITLE
docs: fix broken links in networking and onboarding

### DIFF
--- a/doc/networking.md
+++ b/doc/networking.md
@@ -411,7 +411,7 @@ message GetPayerInfoResponse {
 
 ### Health Check API
 
-gRPC Health Check API, implemented using [Connect-RPC grpchealth](connectrpc.com/grpchealth).
+gRPC Health Check API, implemented using [Connect-RPC grpchealth](https://connectrpc.com/grpchealth).
 
 **Service Name**: `grpc.health.v1.Health`
 
@@ -431,7 +431,7 @@ curl -X POST http://localhost:5050/grpc.health.v1.Health/Check \
 
 ### Reflection API
 
-gRPC Server Reflection API for service discovery, implemented using [Connect-RPC grpcreflect](connectrpc.com/grpcreflect).
+gRPC Server Reflection API for service discovery, implemented using [Connect-RPC grpcreflect](https://connectrpc.com/grpcreflect).
 
 **Service Names**:
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -42,4 +42,4 @@ Once you've confirmed that their node is registered, let the node operator know.
 You can provide them with the following links:
 
 - Take the next step in deploying your node to the XMTP testnet: [Step 3: Set up dependencies](https://github.com/xmtp/xmtpd-infrastructure/blob/main/helm/README.md#step-3-set-up-dependencies)
-- Optionally, you can use Kubernetes and Prometheus to set up observability: [Set up Prometheus service discovery for xmtpd in Kubernetes using Helm](/doc/k8s-prometheus-monitoring.md)
+- Optionally, you can use Kubernetes and Prometheus to set up observability: Set up Prometheus service discovery for xmtpd in Kubernetes using Helm


### PR DESCRIPTION
Adds missing https:// scheme to external Connect-RPC links in doc/networking.md and removes a broken internal link in doc/onboarding.md (target file not present in this repository).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken links in networking and onboarding documentation
> - Adds `https://` protocol to Connect-RPC references in [doc/networking.md](https://github.com/xmtp/xmtpd/pull/1747/files#diff-e86ddf50e452125d83df29f983e155aff37a3f3e4dc32afdf0833c1f050c3104) to make URLs fully qualified
> - Removes broken link to k8s-prometheus-monitoring.md in [doc/onboarding.md](https://github.com/xmtp/xmtpd/pull/1747/files#diff-15b2b14d12fea87bf870aaa1b2572d0ecfa491aa87293ad6177cc3c65d895fca), leaving the text as plain prose
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72fe7a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->