### PR TITLE
Batch envelope inserts in benchmarks

### DIFF
--- a/pkg/db/bench/envelopes_bench_test.go
+++ b/pkg/db/bench/envelopes_bench_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmtp/xmtpd/pkg/db"
 	"github.com/xmtp/xmtpd/pkg/db/queries"
+	"github.com/xmtp/xmtpd/pkg/db/types"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	"github.com/xmtp/xmtpd/pkg/utils"
 )
@@ -69,9 +70,11 @@ func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
 	}
 
 	// Seed envelopes distributed across originators and topics
-	batchSize := 10_000
+	const seedBatchSize = 500
+	const logEvery = 10_000
 	blob := testutils.RandomBytes(blobSize) // reuse same blob for speed
 	seqIDs := make([]int64, numOriginators)
+	batch := types.NewGatewayEnvelopeBatch()
 
 	for i := range tier.count {
 		origIdx := i % numOriginators
@@ -79,28 +82,48 @@ func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
 		seqIDs[origIdx]++
 		topicIdx := i % numTopics
 
-		_, err := db.InsertGatewayEnvelopeWithChecksStandalone(
-			ctx,
-			q,
-			queries.InsertGatewayEnvelopeParams{
-				OriginatorNodeID:     origID,
-				OriginatorSequenceID: seqIDs[origIdx],
-				Topic:                tier.topics[topicIdx],
-				Expiry:               time.Now().Add(24 * time.Hour).Unix(),
-				OriginatorEnvelope:   blob,
-			},
-		)
-		if err != nil {
-			log.Fatalf("seed envelope %d: %v", i, err)
+		now := time.Now()
+		batch.Add(types.GatewayEnvelopeRow{
+			OriginatorNodeID:     origID,
+			OriginatorSequenceID: seqIDs[origIdx],
+			Topic:                tier.topics[topicIdx],
+			GatewayTime:          now,
+			Expiry:               now.Add(24 * time.Hour).Unix(),
+			OriginatorEnvelope:   blob,
+		})
+
+		if batch.Len() == seedBatchSize {
+			_, err := db.InsertGatewayEnvelopeBatchAndIncrementUnsettledUsage(
+				ctx,
+				tier.db,
+				batch,
+			)
+			if err != nil {
+				log.Fatalf("seed envelope batch at %d: %v", i, err)
+			}
+			batch.Reset()
 		}
 
-		if (i+1)%batchSize == 0 {
+		if (i+1)%logEvery == 0 {
 			log.Printf(
 				"seeded %d/%d envelopes for tier %s",
 				i+1, tier.count, tier.name,
 			)
 		}
 	}
+
+	// Flush remaining envelopes
+	if batch.Len() > 0 {
+		_, err := db.InsertGatewayEnvelopeBatchAndIncrementUnsettledUsage(
+			ctx,
+			tier.db,
+			batch,
+		)
+		if err != nil {
+			log.Fatalf("seed envelope final batch: %v", err)
+		}
+	}
+
 	log.Printf("seeded envelopes: %d rows for tier %s", tier.count, tier.name)
 }
 

--- a/pkg/db/bench/hot_path_bench_test.go
+++ b/pkg/db/bench/hot_path_bench_test.go
@@ -5,7 +5,6 @@ package bench
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"log"
 	"sync/atomic"
 	"testing"
@@ -257,104 +256,5 @@ func BenchmarkHotPathFullCycle(b *testing.B) {
 		// 4. Worker removes the processed staged envelope.
 		_, err = q.DeleteStagedOriginatorEnvelope(benchCtx, staged.ID)
 		require.NoError(b, err)
-	}
-}
-
-// BenchmarkHotPathBatchCycle measures the publish-worker's per-envelope
-// processing loop at different batch sizes. This is the critical path that
-// determines end-to-end latency: the last envelope in a batch must wait for
-// all preceding envelopes to complete their DB operations.
-//
-// Each iteration:
-//
-//	[untimed] Seeds N staged envelopes and selects them as a batch.
-//	[timed]   For each envelope: FindOrCreatePayer → gateway insert tx → delete staged.
-//
-// Sub-benchmarks: batch=1, batch=10, batch=100, batch=500
-func BenchmarkHotPathBatchCycle(b *testing.B) {
-	batchSizes := []int{1, 10, 100, 500}
-
-	for _, batchSize := range batchSizes {
-		b.Run(fmt.Sprintf("batch=%d", batchSize), func(b *testing.B) {
-			var (
-				q          = queries.New(hotPathDB)
-				topic      = testutils.RandomBytes(32)
-				blob       = testutils.RandomBytes(hotPathBlobSize)
-				payerAddr  = utils.HexEncode(testutils.RandomBytes(20))
-				now        = time.Now()
-				expiry     = now.Add(24 * time.Hour).Unix()
-				minute     = utils.MinutesSinceEpoch(now)
-				gatewaySeq atomic.Int64
-			)
-
-			// Start at 30M to avoid collisions with other hot path benchmarks.
-			gatewaySeq.Store(30_000_000)
-
-			for b.Loop() {
-				// --- Untimed: seed N staged envelopes ---
-				b.StopTimer()
-				var lastSeenID int64
-				for range batchSize {
-					staged, err := q.InsertStagedOriginatorEnvelope(
-						benchCtx,
-						queries.InsertStagedOriginatorEnvelopeParams{
-							Topic:         topic,
-							PayerEnvelope: blob,
-						},
-					)
-					require.NoError(b, err)
-					if lastSeenID == 0 {
-						lastSeenID = staged.ID - 1
-					}
-				}
-
-				// Fetch the batch (single SELECT, untimed).
-				batch, err := q.SelectStagedOriginatorEnvelopes(
-					benchCtx,
-					queries.SelectStagedOriginatorEnvelopesParams{
-						LastSeenID: lastSeenID,
-						NumRows:    int32(batchSize),
-					},
-				)
-				require.NoError(b, err)
-				require.Len(b, batch, batchSize)
-				b.StartTimer()
-
-				// --- Timed: process each envelope sequentially ---
-				for _, stagedEnv := range batch {
-					// 1. Find or create payer.
-					payerID, err := q.FindOrCreatePayer(benchCtx, payerAddr)
-					require.NoError(b, err)
-
-					// 2. Insert gateway envelope + usage + congestion (atomic tx).
-					seqID := gatewaySeq.Add(1)
-					_, err = db.InsertGatewayEnvelopeAndIncrementUnsettledUsage(
-						benchCtx,
-						hotPathDB,
-						queries.InsertGatewayEnvelopeParams{
-							OriginatorNodeID:     hotPathOriginatorID,
-							OriginatorSequenceID: seqID,
-							Topic:                topic,
-							OriginatorEnvelope:   blob,
-							PayerID:              db.NullInt32(payerID),
-							GatewayTime:          now,
-							Expiry:               expiry,
-						},
-						queries.IncrementUnsettledUsageParams{
-							PayerID:           payerID,
-							OriginatorID:      hotPathOriginatorID,
-							MinutesSinceEpoch: minute,
-							SpendPicodollars:  1_000_000,
-						},
-						true,
-					)
-					require.NoError(b, err)
-
-					// 3. Delete the staged envelope.
-					_, err = q.DeleteStagedOriginatorEnvelope(benchCtx, stagedEnv.ID)
-					require.NoError(b, err)
-				}
-			}
-		})
 	}
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Batch envelope inserts in benchmark seeding to groups of 500
- Reworks `seedEnvelopes` in [envelopes_bench_test.go](https://github.com/xmtp/xmtpd/pull/1766/files#diff-122d539eebdccf50dc48c948f585f1bdda1e940b829b247e4c10b1abcf7fec73) to accumulate rows into batches of 500 and call `InsertGatewayEnvelopeBatchAndIncrementUnsettledUsage` per batch instead of inserting one row at a time. Each row now includes a `GatewayTime` field and a per-row `Expiry`.
- Increases the pre-created gateway partition range in `seedHotPath` from 10 to 50 partitions in [hot_path_bench_test.go](https://github.com/xmtp/xmtpd/pull/1766/files#diff-03728ce32883d606049dd7c4e8f90efc3e616c1a08bb079068060ce684467b1d).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87e3c4d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->