### PR TITLE
Increase sync writeQueue buffer to match server batch size

### DIFF
--- a/pkg/sync/sync_worker.go
+++ b/pkg/sync/sync_worker.go
@@ -143,7 +143,10 @@ func (s *syncWorker) subscribeToNode(nodeID uint32) {
 
 	s.subscriptions[nodeID] = struct{}{}
 
-	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	// Buffer size matches the server-side maxRequestedRows (1000) so that the
+	// stream reader goroutine can drain a full backfill batch from Recv() without
+	// blocking, preventing HTTP/2 flow control back-pressure on the sender.
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 1000)
 
 	tracing.GoPanicWrap(
 		s.ctx,


### PR DESCRIPTION
## Summary

- Increases `writeQueue` buffer from 10 → 1000 in the sync worker to match `maxRequestedRows` on the server side

## Background

During backfill, the server fetches up to 1000 envelopes per DB query and sends them as a single gRPC message. On the client side, `originatorStream.listen()` has two goroutines:

1. **Reader goroutine**: calls `stream.Recv()` in a loop, forwards each response to an unbuffered `recvChan`
2. **Main goroutine**: reads from `recvChan`, iterates over the envelopes, and pushes each one individually into `writeQueue`

With `writeQueue = 10`, the main goroutine blocks after the 11th envelope. While blocked it cannot return to `select`, so the reader goroutine stays blocked on `recvChan <- envs` and cannot call `Recv()` again. With no `Recv()` calls in flight, the client stops sending HTTP/2 `WINDOW_UPDATE` frames, the server's flow control window drains, and **`stream.Send()` on the server blocks for the entire duration it takes the sink to drain the queue**.

## The math

The sink currently processes one envelope at a time. Each call to `storeEnvelope` makes two sequential DB round-trips:

- `FindOrCreatePayer` ≈ <1ms
- `InsertGatewayEnvelopeAndIncrementUnsettledUsage` ≈ 4–8 ms

**T_consumer ≈ 10 ms/envelope**

With `writeQueue = 10` and a 1000-envelope batch, the server's `stream.Send()` is blocked for roughly:

```
(1000 - 10) × 10 ms ≈ 10 seconds per batch
```

The steady-state minimum buffer to avoid back-pressure is:

```
buffer ≥ T_consumer / T_producer
       = 10 ms / (query_time_ms / 1000)
```

Assuming the read query can be brought down significantly and the 100 ms `pagingInterval` sleep removed, the producer interval per envelope approaches the query time / 1000. At a 10 ms query (target), `T_producer = 0.01 ms/envelope`, giving a required buffer of ~1000 — which is also the natural bound of one full batch arriving atomically from a single `Recv()`.

Setting `writeQueue = 1000` means the main goroutine can push all 1000 envelopes from one `Recv()` without blocking, immediately returns to `select`, and the reader goroutine can issue the next `Recv()` — keeping the HTTP/2 window open and `stream.Send()` unblocked on the server.

I have also considered doing a 2000 envelope buffer to absorb further DB delays.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `writeQueue` buffer capacity from 10 to 1000 in `syncWorker.subscribeToNode`
> The `writeQueue` channel in [sync_worker.go](https://github.com/xmtp/xmtpd/pull/1769/files#diff-566958c8832792b443513b0e677f3bdb0b96ffbd906d68b1cccc257aae31c852) previously had a buffer of 10, which could cause the stream reader to block when the server sends envelopes in large batches. The buffer is now sized to 1000 to match the server's batch size.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62a6e6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->