### PR TITLE
Add git skill for consistent branch and PR conventions

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: git
+description: >-
+  Use when creating branches, committing changes, pushing, or opening pull
+  requests. Triggers on "make a PR", "open a PR", "create a branch", "push
+  this", "commit and push", or any request to ship code to GitHub.
+---
+
+# Creating Branches and Pull Requests
+
+## Branch Naming Convention
+
+**Always** use `<github-username>/<branch-description>`:
+
+- GitHub username: !`gh api user --jq '.login'`
+
+```
+<username>/payer-id-lru-cache
+<username>/fix-fee-calculation
+<username>/add-congestion-metrics
+```
+
+- Prefix is always the result of `gh api user --jq '.login'`
+- Description is kebab-case, concise, imperative
+- Never use `main`, a bare description, or any other prefix


### PR DESCRIPTION
## Problem

Branch names and PR formats were inconsistent across contributors — no shared convention for Claude to follow when creating branches or opening PRs.

## Solution

Adds `.claude/skills/git/SKILL.md`, a Claude skill that activates whenever branches or PRs are being created. It encodes:

- Branch naming: `<github-username>/<description>` (username resolved at runtime via `gh api user`, so it works for any team member)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git skill defining branch and PR naming conventions
> Adds [SKILL.md](.claude/skills/git/SKILL.md) defining a `git` skill for Claude. It enforces a `<github-username>/<kebab-case-imperative-description>` branch naming convention, with the username fetched via `gh api user --jq '.login'`. Using `main`, bare descriptions, or other prefixes as branch names is explicitly forbidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 804e5c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->