### PR TITLE
Fix grpc_server_handling_seconds in streams

### DIFF
--- a/pkg/interceptors/server/grpc_metrics.go
+++ b/pkg/interceptors/server/grpc_metrics.go
@@ -82,12 +82,14 @@ func (i *GRPCMetricsInterceptor) WrapStreamingHandler(
 		// Record that the RPC has started.
 		metrics.EmitGRPCServerStarted(grpcType, service, method)
 
-		// Wrap the connection to count messages.
+		// Wrap the connection to count messages and record per-message latency.
+		// lastSent is initialized to start so the first Send() measures time-to-first-message.
 		wrappedConn := &metricsStreamingHandlerConn{
 			StreamingHandlerConn: conn,
 			grpcType:             grpcType,
 			service:              service,
 			method:               method,
+			lastSent:             start,
 		}
 
 		// Call the next handler.
@@ -102,19 +104,18 @@ func (i *GRPCMetricsInterceptor) WrapStreamingHandler(
 		// Record completion metrics.
 		metrics.EmitGRPCServerHandled(grpcType, service, method, code)
 
-		duration := time.Since(start)
-		metrics.EmitGRPCServerHandlingTime(grpcType, service, method, duration)
-
 		return err
 	}
 }
 
-// metricsStreamingHandlerConn wraps a StreamingHandlerConn to count sent and received messages.
+// metricsStreamingHandlerConn wraps a StreamingHandlerConn to count sent/received messages
+// and record per-message handling time.
 type metricsStreamingHandlerConn struct {
 	connect.StreamingHandlerConn
 	grpcType string
 	service  string
 	method   string
+	lastSent time.Time
 }
 
 func (c *metricsStreamingHandlerConn) Receive(msg any) error {
@@ -129,6 +130,9 @@ func (c *metricsStreamingHandlerConn) Send(msg any) error {
 	err := c.StreamingHandlerConn.Send(msg)
 	if err == nil {
 		metrics.EmitGRPCServerMsgSent(c.grpcType, c.service, c.method)
+		now := time.Now()
+		metrics.EmitGRPCServerHandlingTime(c.grpcType, c.service, c.method, now.Sub(c.lastSent))
+		c.lastSent = now
 	}
 	return err
 }

--- a/pkg/interceptors/server/grpc_metrics_test.go
+++ b/pkg/interceptors/server/grpc_metrics_test.go
@@ -176,6 +176,29 @@ func TestGRPCMetricsInterceptorStreamError(t *testing.T) {
 	require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 }
 
+func TestGRPCMetricsInterceptorStreamMultipleSends(t *testing.T) {
+	interceptor := NewGRPCMetricsInterceptor()
+
+	next := func(_ context.Context, conn connect.StreamingHandlerConn) error {
+		_ = conn.Send(nil)
+		_ = conn.Send(nil)
+		_ = conn.Send(nil)
+		return nil
+	}
+
+	ctx := context.Background()
+	conn := &mockStreamingConnGRPCMetrics{
+		procedure:  "/test.TestService/TestStream",
+		streamType: connect.StreamTypeServer,
+	}
+
+	wrappedStream := interceptor.WrapStreamingHandler(next)
+	err := wrappedStream(ctx, conn)
+
+	require.NoError(t, err)
+	require.Equal(t, 3, conn.sent, "expected 3 sends")
+}
+
 func TestGRPCMetricsInterceptorWrapStreamingClientNoop(t *testing.T) {
 	interceptor := NewGRPCMetricsInterceptor()
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `grpc_server_handling_seconds` metric in streaming RPCs to emit per-message latency
- Previously, streaming RPCs emitted a single `GRPCServerHandlingTime` metric at the end of the call; this changes it to emit one metric per successful `Send`, measuring elapsed time since the previous send (or since RPC start for the first message).
- Adds a `lastSent` timestamp field to `metricsStreamingHandlerConn` in [grpc_metrics.go](https://github.com/xmtp/xmtpd/pull/1775/files#diff-692a64c906e8258ba5fdd94aaa374eb57e24ea3b61c36a7f20af7e1ba52bf88d), initialized at RPC start and updated after each successful send.
- Behavioral Change: streaming RPCs no longer produce a single end-of-call handling time observation; consumers of this metric will see N observations per stream instead of one.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 03815e7. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>pkg/interceptors/server/grpc_metrics.go — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 105](https://github.com/xmtp/xmtpd/blob/03815e7af088bf7102b70f79f7ce81228d0bb59f/pkg/interceptors/server/grpc_metrics.go#L105): The removal of `EmitGRPCServerHandlingTime` at the end of `WrapStreamingHandler` means total RPC handling time is no longer recorded for streaming RPCs. The new per-message latency tracking in `Send()` only fires when messages are successfully sent. This causes complete loss of `grpc_server_handling_seconds` metrics for: (1) client-streaming RPCs that receive but never send, (2) any streaming RPC that errors before sending its first message, and (3) streaming RPCs that complete successfully but send zero messages. The metric description says "response latency...that had been application-level handled" implying overall handling time should be tracked. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->