### PR TITLE
fix: replace minor-locked semver constraint with MinCompatibleVersion floor

### DIFF
--- a/pkg/authn/claims.go
+++ b/pkg/authn/claims.go
@@ -11,10 +11,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// MinCompatibleVersion is the minimum peer version this node will accept connections from.
+// Update this constant when introducing breaking wire protocol changes; do not change it
+// for routine minor releases.
+var MinCompatibleVersion = semver.MustParse("1.1.0")
+
 type XmtpdClaims struct {
 	Version *semver.Version `json:"version,omitempty"`
 	jwt.RegisteredClaims
 }
+
 type ClaimValidator struct {
 	constraint semver.Constraints
 }
@@ -24,8 +30,14 @@ func NewClaimValidator(logger *zap.Logger, serverVersion *semver.Version) (*Clai
 		return nil, errors.New("serverVersion is nil")
 	}
 
-	// https://github.com/Masterminds/semver?tab=readme-ov-file#caret-range-comparisons-major
-	constraintStr := fmt.Sprintf("^%d.%d", serverVersion.Major(), serverVersion.Minor())
+	// Accept peers in [floor, next major) where floor is MinCompatibleVersion when the server
+	// is on the same major, or major.0.0 otherwise. Minor bumps are backward-compatible;
+	// only a major bump or an explicit MinCompatibleVersion update signals a breaking change.
+	floor := MinCompatibleVersion.String()
+	if serverVersion.Major() != MinCompatibleVersion.Major() {
+		floor = fmt.Sprintf("%d.0.0", serverVersion.Major())
+	}
+	constraintStr := fmt.Sprintf(">=%s, <%d.0.0", floor, serverVersion.Major()+1)
 
 	logger.Debug(
 		"using semver constraint for sync compatibility",

--- a/pkg/authn/claims_test.go
+++ b/pkg/authn/claims_test.go
@@ -162,10 +162,11 @@ func TestClaimsValidator(t *testing.T) {
 			true,
 		},
 		{
-			"future-minor-rejects-us",
+			// A server on a newer minor accepts older peers; minor bumps are backward-compatible.
+			"future-minor-accepts-us",
 			currentVersion,
 			currentVersion.IncMinor(),
-			true,
+			false,
 		},
 		{
 			"future-patch-accepts-us",


### PR DESCRIPTION
## Problem

  The previous `^MAJOR.MINOR` constraint rejected peers running any older minor version — e.g. a node at `1.1.0-72-g18c570b` could not connect to a node running `1.2.0`. This broke rolling upgrades and mixed-version networks.

  ## Solution

  Replace the dynamically-derived constraint with a `[MinCompatibleVersion, next major)` range:

  - **`MinCompatibleVersion = 1.1.0`** — explicit floor, lives in `pkg/authn/claims.go`
  - Minor bumps are backward-compatible by default (follows semver intent)
  - Major bumps remain a hard compatibility break
  - When a genuine wire protocol breaking change is shipped, update `MinCompatibleVersion` — that one-line change is the deliberate, reviewable signal


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace minor-locked semver constraint with `MinCompatibleVersion` floor in `NewClaimValidator`
> - Adds `authn.MinCompatibleVersion` (set to `1.1.0`) as the explicit lower bound for acceptable peer versions during connection validation.
> - Changes the version range in `NewClaimValidator` from `^<major>.<minor>` to `[floor, <major+1>.0.0)`, where floor is `MinCompatibleVersion` when the server shares the same major, or `<serverMajor>.0.0` otherwise.
> - Behavioral Change: peers running an older minor version within the same major are now accepted instead of rejected; a server on v1.2.0 will now accept peers down to v1.1.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c968712.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->