### PR TITLE
devcontainer improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,28 +4,38 @@
     // Sets the run context to one level up instead of the .devcontainer folder.
     "context": "..",
     // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-    "dockerfile": "../dev/docker/devcontainer.Dockerfile"
+    "dockerfile": "../dev/docker/devcontainer.Dockerfile",
   },
-  "remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}", "HOST_DOCKER_DEV_FOLDER": "${localWorkspaceFolder}/dev/docker" },
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+    "HOST_DOCKER_DEV_FOLDER": "${localWorkspaceFolder}/dev/docker",
+  },
   "customizations": {
     "vscode": {
       "settings": {
         "go.gopath": "/go",
-        "go.useLanguageServer": true
+        "go.useLanguageServer": true,
       },
       "extensions": [
         "mtxr.sqltools",
         "golang.go",
         "emeraldwalk.runonsave",
-        "ms-azuretools.vscode-docker"
-      ]
-    }
+        "ms-azuretools.vscode-docker",
+      ],
+    },
   },
   "postCreateCommand": "go mod tidy",
   "forwardPorts": [],
-  "runArgs": ["--network=host"],
   "remoteUser": "vscode",
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
-  }
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers-extra/features/graphite-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "vscode",
+      "installZsh": true,
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false,
+    },
+  },
 }

--- a/dev/docker/devcontainer.Dockerfile
+++ b/dev/docker/devcontainer.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1.25
+FROM golang:1.26
 
 # Install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2


### PR DESCRIPTION
### Upgrade devcontainer configuration and base image

Updates the devcontainer base image from `mcr.microsoft.com/vscode/devcontainers/go:1.25` to `golang:1.26`. Replaces the `docker-outside-of-docker` feature with `docker-in-docker` (with moby disabled) and adds `common-utils` feature with zsh installation enabled. Removes the `--network=host` run argument from the devcontainer configuration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade devcontainer to Go 1.26 and switch from Docker-outside-of-Docker to Docker-in-Docker
> - Updates the base image in [devcontainer.Dockerfile](https://github.com/xmtp/xmtpd/pull/1791/files#diff-9d77843ba6c424b81c3b362904ad3b5c2a7cc45f0ff6d9d2c0b4613d087acb3f) from `mcr.microsoft.com/vscode/devcontainers/go:1.25` to `golang:1.26`.
> - Adds GitHub CLI, Graphite CLI, zsh (via `common-utils` for user `vscode`), and `docker-in-docker` (moby disabled) as devcontainer features in [devcontainer.json](https://github.com/xmtp/xmtpd/pull/1791/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686).
> - Removes `docker-outside-of-docker` and the `--network=host` run arg.
> - Behavioral Change: the container now runs its own Docker daemon rather than sharing the host socket, and no longer uses host networking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfbe92f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->