### PR TITLE
Filter vector clock

### DIFF
--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -83,6 +83,17 @@ func ToVectorClock(rows []queries.GatewayEnvelopesLatest) VectorClock {
 	return vc
 }
 
+// FilterVectorClock filters the vector clock to only include the given originator node IDs.
+func FilterVectorClock(vc VectorClock, originatorNodeIDs []uint32) VectorClock {
+	filteredVC := make(VectorClock)
+	for _, nodeID := range originatorNodeIDs {
+		if _, ok := vc[nodeID]; ok {
+			filteredVC[nodeID] = vc[nodeID]
+		}
+	}
+	return filteredVC
+}
+
 func TransformRowsByTopic(
 	rows []queries.SelectGatewayEnvelopesByTopicsRow,
 ) []queries.GatewayEnvelopesView {

--- a/pkg/sync/sync_worker.go
+++ b/pkg/sync/sync_worker.go
@@ -352,7 +352,6 @@ func (s *syncWorker) setupStream(
 	conn *grpc.ClientConn,
 	writeQueue chan *envUtils.OriginatorEnvelope,
 ) (_ *originatorStream, retErr error) {
-	// Create span for stream setup
 	span, ctx := tracing.StartSpanFromContext(ctx, tracing.SpanSyncSetupStream)
 	defer func() {
 		if retErr != nil {
@@ -371,20 +370,12 @@ func (s *syncWorker) setupStream(
 
 	var (
 		client            = message_api.NewReplicationApiClient(conn)
-		vc                = db.ToVectorClock(result)
+		rawVectorClock    = db.ToVectorClock(result)
 		localNodeID       = s.registrant.NodeID()
 		syncNodeID        = node.NodeID
 		migratorNodeID    = s.migration.FromNodeID
 		originatorNodeIDs = []uint32{syncNodeID}
 	)
-
-	if s.logger.Core().Enabled(zap.DebugLevel) {
-		s.logger.Debug(
-			"vector clock for sync subscription",
-			utils.OriginatorIDField(node.NodeID),
-			utils.BodyField(vc),
-		)
-	}
 
 	if s.migration.Enable && syncNodeID == migratorNodeID && migratorNodeID != localNodeID {
 		originatorNodeIDs = append(originatorNodeIDs, migrator.MigratorOriginatorIDs()...)
@@ -400,6 +391,16 @@ func (s *syncWorker) setupStream(
 		}
 	}
 
+	filteredVectorClock := db.FilterVectorClock(rawVectorClock, originatorNodeIDs)
+
+	if s.logger.Core().Enabled(zap.DebugLevel) {
+		s.logger.Debug(
+			"vector clock for sync subscription",
+			utils.OriginatorIDField(node.NodeID),
+			utils.BodyField(filteredVectorClock),
+		)
+	}
+
 	tracing.SpanTag(span, "num_originator_ids", len(originatorNodeIDs))
 
 	subscribeSpan, subscribeCtx := tracing.StartSpanFromContext(ctx, tracing.SpanSyncSubscribe)
@@ -409,7 +410,7 @@ func (s *syncWorker) setupStream(
 			Query: &message_api.EnvelopesQuery{
 				OriginatorNodeIds: originatorNodeIDs,
 				LastSeen: &envelopes.Cursor{
-					NodeIdToSequenceId: vc,
+					NodeIdToSequenceId: filteredVectorClock,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Filter vector clock to originator node IDs in `syncWorker.setupStream`
Adds a `db.FilterVectorClock` helper that returns a new `VectorClock` containing only entries matching a given set of originator node IDs. In `syncWorker.setupStream`, the full vector clock is now filtered before being passed to `SubscribeEnvelopesRequest.LastSeen.NodeIdToSequenceId`, so only relevant entries are sent. The debug log is also updated to print the filtered clock.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2035b43.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->