### PR TITLE
Migrator has to pay

### DIFF
--- a/pkg/migrator/worker.go
+++ b/pkg/migrator/worker.go
@@ -478,7 +478,7 @@ func (w *Worker) StartDatabaseWriter(ctx context.Context) error {
 						SpendPicodollars: int64(
 							envelope.UnsignedOriginatorEnvelope.Proto().GetBaseFeePicodollars(),
 						),
-						CountUsage:      false,
+						CountUsage:      true,
 						CountCongestion: false,
 					})
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Set `CountUsage=true` for envelopes published by the migrator database writer
In [worker.go](https://github.com/xmtp/xmtpd/pull/1796/files#diff-98d986f4e853aaa039c51a1e336347facf3ecc8a9c45ff146d1dcfd8883c94b8), the `CountUsage` field on each published envelope in `StartDatabaseWriter` was changed from `false` to `true`, so migrated records now count toward usage metrics.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e58aed3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->