### PR TITLE
Speed up payer report conflict resolution

### DIFF
--- a/pkg/payerreport/workers/generator.go
+++ b/pkg/payerreport/workers/generator.go
@@ -209,12 +209,12 @@ func (w *GeneratorWorker) maybeGenerateReport(nodeID uint32) error {
 	// From the same snapshot:
 	//   - Expire reports that are too old: consider only pending reports for this.
 	//   - Collect valid (non-expired) reports that start exactly at the boundary.
-	//   - A valid report is one that is submitted or settled, and:
-	//     - Our local attestation status does not matter.
-	//     - Even if we rejected the report, others might submit and settle it if there is sufficient consensus.
-	//     - All other attestation status states are managed by the Attestation Worker and not relevant to generation.
+	//   - Valid reports blocking generation are:
+	//     - Submitted/settled reports.
+	//     - Pending reports that are non-expired and not locally attestation-rejected.
 	validReports := make([]*payerreport.PayerReportWithStatus, 0, len(reports))
 	for _, report := range reports {
+		// If report is pending and expired, expire it.
 		if report.SubmissionStatus == payerreport.SubmissionPending && w.isReportExpired(report) {
 			w.logger.Debug(
 				"expiring old report",
@@ -225,6 +225,18 @@ func (w *GeneratorWorker) maybeGenerateReport(nodeID uint32) error {
 			if err := w.store.SetReportSubmissionRejected(w.ctx, report.ID); err != nil {
 				return err
 			}
+
+			continue
+		}
+
+		// If report is pending and locally rejected, ignore it.
+		if report.SubmissionStatus == payerreport.SubmissionPending &&
+			report.AttestationStatus == payerreport.AttestationRejected {
+			w.logger.Debug(
+				"ignore locally rejected report",
+				utils.OriginatorIDField(nodeID),
+				utils.PayerReportIDField(report.ID.String()),
+			)
 
 			continue
 		}


### PR DESCRIPTION
Current behavior can stall convergence when a node keeps generating a pending report that peers locally reject.

Generator blocking currently treats non-expired pending reports at the boundary as valid blockers regardless of local attestation result.

Current Knuth distribution in testnet:

Node ID | Generator (w=1) | Submitter (w=2) | Settlement (w=3)
--      | --              |     --          | --
100     | :47             | :52             | :57
200     | :35             | :40             | :45
300     | :22             | :27             | :32


Example loop:

```text
T0 = 10:47
Node 100 (generator minute :47) creates pending report R0 at boundary start=0.

T0+
Nodes 200 (:35) and 300 (:22) receive R0, locally reject attestation (attestation_status=2) due to divergent history.

10:47 -> 04:47 (+18h)
R0 remains submission_status=pending and non-expired.
On each generator tick, peers see a valid boundary blocker (start=0, pending, non-expired), so they skip generating replacements.

T1 = 04:47 next day (+18h)
Node 100 runs again, expires R0 (sets submission_status=rejected), then immediately generates R1 at the same boundary in the same run.

T1+
Peers still disagree with node 100’s history, locally reject R1 too.

Repeat every ~18h
Until some node can propose an alternative report that gets majority attestation, payer-report progression at that boundary can remain stalled.
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip attestation-rejected pending reports when resolving payer report generation conflicts
> In [`GeneratorWorker.maybeGenerateReport`](https://github.com/xmtp/xmtpd/pull/1810/files#diff-17472e1deed3c885c038e81ae1eaa077ec92f7ccdc92cc1f75addc0ff607080e), pending reports with `AttestationRejected` status are now excluded from the set of valid reports that block generation at a boundary. Previously, these locally rejected reports would prevent `generateReport` from running. Behavioral Change: generation now proceeds when the only blocking reports are locally attestation-rejected, which may cause duplicate or overlapping report generation in edge cases where rejection state diverges across nodes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e8ba9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->