### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To keep up with and provide feedback about `xmtpd` development, see the [Issues 
 
 ## Prerequisites
 
-- [Go 1.25](https://go.dev/doc/install) -- On macOS install with `brew install go@1.25`
+- [Go 1.26](https://go.dev/doc/install) -- On macOS install with `brew install go@1.26`
 - [Docker](https://www.docker.com/get-started/)
 - [Foundry](https://github.com/foundry-rs/foundry)
 

--- a/dev/docker/devcontainer.Dockerfile
+++ b/dev/docker/devcontainer.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26
 
 # Install golangci-lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
 
 # Add spellcheck and jq
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Upgrade golangci-lint from v2.0.2 to v2.11.3 in devcontainer
- Updates [devcontainer.Dockerfile](https://github.com/xmtp/xmtpd/pull/1811/files#diff-9d77843ba6c424b81c3b362904ad3b5c2a7cc45f0ff6d9d2c0b4613d087acb3f) to install golangci-lint v2.11.3 via the official `https://golangci-lint.run/install.sh` script instead of v2.0.2 via the GitHub raw script.
- Updates [README.md](https://github.com/xmtp/xmtpd/pull/1811/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect the Go prerequisite version change from 1.25 to 1.26.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized edb277f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->