### PR TITLE
Add prepared plans option to bench database tests

### DIFF
--- a/dev/bench
+++ b/dev/bench
@@ -14,6 +14,10 @@ Environment variables:
   BENCH_TIER    Optional tier filter from pkg/db/bench/main_test.go.
                 Valid values: 100K, 1M, 10M (case-insensitive).
                 If unset, all tiers run.
+  BENCH_USE_PREPARED
+                Optional query mode toggle consumed by bench tests.
+                true/1/t enables prepared queries (default).
+                false/0/f disables prepared queries.
 
 Examples:
   dev/bench
@@ -39,12 +43,14 @@ fi
 RESULTS_DIR="benchmarks/results"
 mkdir -p "$RESULTS_DIR"
 
-OUTFILE="$RESULTS_DIR/${BENCH_TIER:-all}-$(date +%Y-%m-%d-T%H%M%S).txt"
+BENCH_MODE="${BENCH_USE_PREPARED:-true}"
+OUTFILE="$RESULTS_DIR/${BENCH_TIER:-all}-$(date +%Y-%m-%d-T%H%M%S)-prepared-${BENCH_MODE}.txt"
 RAWFILE=$(mktemp)
 trap 'rm -f "$RAWFILE"' EXIT
 
 echo "Running benchmarks..."
 echo "Tier filter: ${BENCH_TIER:-all}"
+echo "Prepared queries: ${BENCH_MODE}"
 echo "Output: $OUTFILE"
 echo
 

--- a/pkg/db/bench/congestion_bench_test.go
+++ b/pkg/db/bench/congestion_bench_test.go
@@ -4,7 +4,6 @@ package bench
 
 import (
 	"context"
-	"database/sql"
 	"log"
 	"sync/atomic"
 	"testing"
@@ -19,14 +18,13 @@ const (
 )
 
 // seedCongestion populates originator_congestion with time-bucketed message counts.
-func seedCongestion(ctx context.Context, db *sql.DB) {
-	q := queries.New(db)
+func seedCongestion(ctx context.Context) {
 	congestionOriginators = make([]int32, numCongestionOriginators)
 	for i := range numCongestionOriginators {
 		origID := int32(500 + i)
 		congestionOriginators[i] = origID
 		for minute := range int32(numCongestionMinutes) {
-			err := q.IncrementOriginatorCongestion(
+			err := congestionQueries.IncrementOriginatorCongestion(
 				ctx,
 				queries.IncrementOriginatorCongestionParams{
 					OriginatorID:      origID,
@@ -46,13 +44,12 @@ func seedCongestion(ctx context.Context, db *sql.DB) {
 }
 
 func BenchmarkIncrementOriginatorCongestion(b *testing.B) {
-	q := queries.New(congestionDB)
 	origID := congestionOriginators[0]
 	var counter atomic.Int32
 	counter.Store(100_000) // start beyond seeded range
 	for b.Loop() {
 		minute := counter.Add(1)
-		err := q.IncrementOriginatorCongestion(
+		err := congestionQueries.IncrementOriginatorCongestion(
 			benchCtx,
 			queries.IncrementOriginatorCongestionParams{
 				OriginatorID:      origID,
@@ -64,27 +61,25 @@ func BenchmarkIncrementOriginatorCongestion(b *testing.B) {
 }
 
 func BenchmarkGetRecentOriginatorCongestion(b *testing.B) {
-	q := queries.New(congestionDB)
 	params := queries.GetRecentOriginatorCongestionParams{
 		OriginatorID: congestionOriginators[0],
 		EndMinute:    congestionMaxMinute,
 		NumMinutes:   60, // last hour
 	}
 	for b.Loop() {
-		_, err := q.GetRecentOriginatorCongestion(benchCtx, params)
+		_, err := congestionQueries.GetRecentOriginatorCongestion(benchCtx, params)
 		require.NoError(b, err)
 	}
 }
 
 func BenchmarkSumOriginatorCongestion(b *testing.B) {
-	q := queries.New(congestionDB)
 	params := queries.SumOriginatorCongestionParams{
 		OriginatorID:        congestionOriginators[0],
 		MinutesSinceEpochGt: 0,
 		MinutesSinceEpochLt: int64(congestionMaxMinute),
 	}
 	for b.Loop() {
-		_, err := q.SumOriginatorCongestion(benchCtx, params)
+		_, err := congestionQueries.SumOriginatorCongestion(benchCtx, params)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/db/bench/envelopes_bench_test.go
+++ b/pkg/db/bench/envelopes_bench_test.go
@@ -30,7 +30,6 @@ var envelopeOriginators = []int32{100, 200, 300}
 
 // seedEnvelopes populates gateway_envelopes_meta and gateway_envelope_blobs.
 func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
-	q := queries.New(tier.db)
 	tier.originators = envelopeOriginators
 
 	// Generate topics
@@ -43,7 +42,7 @@ func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
 	tier.payerIDs = make([]int32, numBenchPayers)
 	for i := range numBenchPayers {
 		addr := utils.HexEncode(testutils.RandomBytes(20))
-		id, err := q.FindOrCreatePayer(ctx, addr)
+		id, err := tier.queries.FindOrCreatePayer(ctx, addr)
 		if err != nil {
 			log.Fatalf("seed envelope payer: %v", err)
 		}
@@ -54,7 +53,7 @@ func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
 	perOriginator := tier.count / numOriginators
 	for seqID := int64(0); seqID < int64(perOriginator)+db.GatewayEnvelopeBandWidth; seqID += db.GatewayEnvelopeBandWidth {
 		for _, origID := range tier.originators {
-			_ = q.EnsureGatewayParts(ctx, queries.EnsureGatewayPartsParams{
+			_ = tier.queries.EnsureGatewayParts(ctx, queries.EnsureGatewayPartsParams{
 				OriginatorNodeID:     origID,
 				OriginatorSequenceID: seqID,
 				BandWidth:            db.GatewayEnvelopeBandWidth,
@@ -63,7 +62,7 @@ func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
 	}
 	// Partitions for write benchmark originator
 	for seqID := int64(0); seqID < 10*db.GatewayEnvelopeBandWidth; seqID += db.GatewayEnvelopeBandWidth {
-		_ = q.EnsureGatewayParts(ctx, queries.EnsureGatewayPartsParams{
+		_ = tier.queries.EnsureGatewayParts(ctx, queries.EnsureGatewayPartsParams{
 			OriginatorNodeID:     writeOriginatorID,
 			OriginatorSequenceID: seqID,
 			BandWidth:            db.GatewayEnvelopeBandWidth,
@@ -135,7 +134,6 @@ func seedEnvelopes(ctx context.Context, tier *envelopeTier) {
 func BenchmarkSelectGatewayEnvelopesByTopics(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			midSeq := int64(tier.count / numOriginators / 2)
 			params := queries.SelectGatewayEnvelopesByTopicsParams{
 				Topics:            tier.topics[:10],
@@ -144,7 +142,7 @@ func BenchmarkSelectGatewayEnvelopesByTopics(b *testing.B) {
 				CursorSequenceIds: []int64{midSeq, midSeq, midSeq},
 			}
 			for b.Loop() {
-				_, err := q.SelectGatewayEnvelopesByTopics(benchCtx, params)
+				_, err := tier.queries.SelectGatewayEnvelopesByTopics(benchCtx, params)
 				require.NoError(b, err)
 			}
 		})
@@ -154,7 +152,6 @@ func BenchmarkSelectGatewayEnvelopesByTopics(b *testing.B) {
 func BenchmarkSelectGatewayEnvelopesByOriginators(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			midSeq := int64(tier.count / numOriginators / 2)
 			params := queries.SelectGatewayEnvelopesByOriginatorsParams{
 				RowLimit:          100,
@@ -162,7 +159,7 @@ func BenchmarkSelectGatewayEnvelopesByOriginators(b *testing.B) {
 				CursorSequenceIds: []int64{midSeq, midSeq, midSeq},
 			}
 			for b.Loop() {
-				_, err := q.SelectGatewayEnvelopesByOriginators(
+				_, err := tier.queries.SelectGatewayEnvelopesByOriginators(
 					benchCtx,
 					params,
 				)
@@ -175,7 +172,6 @@ func BenchmarkSelectGatewayEnvelopesByOriginators(b *testing.B) {
 func BenchmarkSelectGatewayEnvelopesBySingleOriginator(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			midSeq := int64(tier.count / numOriginators / 2)
 			params := queries.SelectGatewayEnvelopesBySingleOriginatorParams{
 				OriginatorNodeID: tier.originators[0],
@@ -183,7 +179,7 @@ func BenchmarkSelectGatewayEnvelopesBySingleOriginator(b *testing.B) {
 				RowLimit:         100,
 			}
 			for b.Loop() {
-				_, err := q.SelectGatewayEnvelopesBySingleOriginator(
+				_, err := tier.queries.SelectGatewayEnvelopesBySingleOriginator(
 					benchCtx,
 					params,
 				)
@@ -196,7 +192,6 @@ func BenchmarkSelectGatewayEnvelopesBySingleOriginator(b *testing.B) {
 func BenchmarkSelectGatewayEnvelopesUnfiltered(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			midSeq := int64(tier.count / numOriginators / 2)
 			params := queries.SelectGatewayEnvelopesUnfilteredParams{
 				RowLimit:          100,
@@ -204,7 +199,7 @@ func BenchmarkSelectGatewayEnvelopesUnfiltered(b *testing.B) {
 				CursorSequenceIds: []int64{midSeq, midSeq, midSeq},
 			}
 			for b.Loop() {
-				_, err := q.SelectGatewayEnvelopesUnfiltered(
+				_, err := tier.queries.SelectGatewayEnvelopesUnfiltered(
 					benchCtx,
 					params,
 				)
@@ -217,10 +212,9 @@ func BenchmarkSelectGatewayEnvelopesUnfiltered(b *testing.B) {
 func BenchmarkSelectNewestFromTopics(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			topics := tier.topics[:10]
 			for b.Loop() {
-				_, err := q.SelectNewestFromTopics(benchCtx, topics)
+				_, err := tier.queries.SelectNewestFromTopics(benchCtx, topics)
 				require.NoError(b, err)
 			}
 		})
@@ -232,7 +226,6 @@ func BenchmarkSelectNewestFromTopics(b *testing.B) {
 func BenchmarkInsertGatewayEnvelope(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			blob := testutils.RandomBytes(blobSize)
 			topic := tier.topics[0]
 			expiry := time.Now().Add(24 * time.Hour).Unix()
@@ -240,7 +233,7 @@ func BenchmarkInsertGatewayEnvelope(b *testing.B) {
 			counter.Store(1_000_000)
 			for b.Loop() {
 				seqID := counter.Add(1)
-				_, err := q.InsertGatewayEnvelope(
+				_, err := tier.queries.InsertGatewayEnvelope(
 					benchCtx,
 					queries.InsertGatewayEnvelopeParams{
 						OriginatorNodeID:     writeOriginatorID,
@@ -259,7 +252,6 @@ func BenchmarkInsertGatewayEnvelope(b *testing.B) {
 func BenchmarkInsertGatewayEnvelopeBatch(b *testing.B) {
 	for _, tier := range envelopeTiers {
 		b.Run(tier.name, func(b *testing.B) {
-			q := queries.New(tier.db)
 			blob := testutils.RandomBytes(blobSize)
 			batchLen := 10
 
@@ -296,7 +288,7 @@ func BenchmarkInsertGatewayEnvelopeBatch(b *testing.B) {
 				for j := range batchLen {
 					countFlags[j] = true
 				}
-				_, err := q.InsertGatewayEnvelopeBatchV2(
+				_, err := tier.queries.InsertGatewayEnvelopeBatchV2(
 					benchCtx,
 					queries.InsertGatewayEnvelopeBatchV2Params{
 						OriginatorNodeIds:     nodeIDs,

--- a/pkg/db/bench/hot_path_bench_test.go
+++ b/pkg/db/bench/hot_path_bench_test.go
@@ -4,7 +4,6 @@ package bench
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"sync/atomic"
@@ -30,14 +29,13 @@ const (
 
 // seedHotPath pre-creates payers and gateway partitions, and seeds staged rows
 // for SELECT benchmarks.
-func seedHotPath(ctx context.Context, benchDB *sql.DB) {
-	q := queries.New(benchDB)
+func seedHotPath(ctx context.Context) {
 	hotPathPayerIDs = make([]int32, hotPathPayerCount)
 
 	for i := range hotPathPayerCount {
 		addr := utils.HexEncode(testutils.RandomBytes(20))
 
-		id, err := q.FindOrCreatePayer(ctx, addr)
+		id, err := hotPathQueries.FindOrCreatePayer(ctx, addr)
 		if err != nil {
 			log.Fatalf("seed hot path payer: %v", err)
 		}
@@ -47,7 +45,7 @@ func seedHotPath(ctx context.Context, benchDB *sql.DB) {
 
 	// Pre-create gateway partitions so write benchmarks never hit partition-creation overhead.
 	for seqID := int64(0); seqID < 50*db.GatewayEnvelopeBandWidth; seqID += db.GatewayEnvelopeBandWidth {
-		_ = q.EnsureGatewayParts(ctx, queries.EnsureGatewayPartsParams{
+		_ = hotPathQueries.EnsureGatewayParts(ctx, queries.EnsureGatewayPartsParams{
 			OriginatorNodeID:     hotPathOriginatorID,
 			OriginatorSequenceID: seqID,
 			BandWidth:            db.GatewayEnvelopeBandWidth,
@@ -61,7 +59,7 @@ func seedHotPath(ctx context.Context, benchDB *sql.DB) {
 	)
 
 	for i := range hotPathStagedSeedRows {
-		_, err := q.InsertStagedOriginatorEnvelope(
+		_, err := hotPathQueries.InsertStagedOriginatorEnvelope(
 			ctx,
 			queries.InsertStagedOriginatorEnvelopeParams{
 				Topic:         topic,
@@ -84,13 +82,12 @@ func seedHotPath(ctx context.Context, benchDB *sql.DB) {
 // ID assignment, so this reflects the true serialised ingest cost.
 func BenchmarkHotPathInsertStaged(b *testing.B) {
 	var (
-		q     = queries.New(hotPathDB)
 		topic = testutils.RandomBytes(32)
 		blob  = testutils.RandomBytes(hotPathBlobSize)
 	)
 
 	for b.Loop() {
-		_, err := q.InsertStagedOriginatorEnvelope(
+		_, err := hotPathQueries.InsertStagedOriginatorEnvelope(
 			benchCtx,
 			queries.InsertStagedOriginatorEnvelopeParams{
 				Topic:         topic,
@@ -104,9 +101,8 @@ func BenchmarkHotPathInsertStaged(b *testing.B) {
 // BenchmarkHotPathSelectStaged measures SELECT from staged_originator_envelopes
 // as the publish worker does — fetching the next batch from a cursor position.
 func BenchmarkHotPathSelectStaged(b *testing.B) {
-	q := queries.New(hotPathDB)
 	for b.Loop() {
-		_, err := q.SelectStagedOriginatorEnvelopes(
+		_, err := hotPathQueries.SelectStagedOriginatorEnvelopes(
 			benchCtx,
 			queries.SelectStagedOriginatorEnvelopesParams{
 				LastSeenID: 0,
@@ -167,14 +163,13 @@ func BenchmarkHotPathInsertGatewayWithUsage(b *testing.B) {
 // measured delete always hits a real row.
 func BenchmarkHotPathDeleteStaged(b *testing.B) {
 	var (
-		q     = queries.New(hotPathDB)
 		topic = testutils.RandomBytes(32)
 		blob  = testutils.RandomBytes(hotPathBlobSize)
 	)
 
 	for b.Loop() {
 		b.StopTimer()
-		row, err := q.InsertStagedOriginatorEnvelope(
+		row, err := hotPathQueries.InsertStagedOriginatorEnvelope(
 			benchCtx,
 			queries.InsertStagedOriginatorEnvelopeParams{
 				Topic:         topic,
@@ -184,7 +179,7 @@ func BenchmarkHotPathDeleteStaged(b *testing.B) {
 		require.NoError(b, err)
 		b.StartTimer()
 
-		_, err = q.BulkDeleteStagedOriginatorEnvelopes(benchCtx, []int64{row.ID})
+		_, err = hotPathQueries.BulkDeleteStagedOriginatorEnvelopes(benchCtx, []int64{row.ID})
 		require.NoError(b, err)
 	}
 }
@@ -197,7 +192,6 @@ func BenchmarkHotPathDeleteStaged(b *testing.B) {
 //  4. DELETE the staged row
 func BenchmarkHotPathFullCycle(b *testing.B) {
 	var (
-		q          = queries.New(hotPathDB)
 		topic      = testutils.RandomBytes(32)
 		blob       = testutils.RandomBytes(hotPathBlobSize)
 		payerID    = hotPathPayerIDs[0]
@@ -212,7 +206,7 @@ func BenchmarkHotPathFullCycle(b *testing.B) {
 
 	for b.Loop() {
 		// 1. Payer client stages the envelope.
-		staged, err := q.InsertStagedOriginatorEnvelope(
+		staged, err := hotPathQueries.InsertStagedOriginatorEnvelope(
 			benchCtx,
 			queries.InsertStagedOriginatorEnvelopeParams{
 				Topic:         topic,
@@ -222,7 +216,7 @@ func BenchmarkHotPathFullCycle(b *testing.B) {
 		require.NoError(b, err)
 
 		// 2. Publish worker polls and fetches the staged envelope.
-		_, err = q.SelectStagedOriginatorEnvelopes(
+		_, err = hotPathQueries.SelectStagedOriginatorEnvelopes(
 			benchCtx,
 			queries.SelectStagedOriginatorEnvelopesParams{
 				LastSeenID: staged.ID - 1,
@@ -256,7 +250,7 @@ func BenchmarkHotPathFullCycle(b *testing.B) {
 		require.NoError(b, err)
 
 		// 4. Worker removes the processed staged envelope.
-		_, err = q.BulkDeleteStagedOriginatorEnvelopes(benchCtx, []int64{staged.ID})
+		_, err = hotPathQueries.BulkDeleteStagedOriginatorEnvelopes(benchCtx, []int64{staged.ID})
 		require.NoError(b, err)
 	}
 }
@@ -278,7 +272,6 @@ func BenchmarkHotPathBatchCycle(b *testing.B) {
 	for _, batchSize := range batchSizes {
 		b.Run(fmt.Sprintf("batch=%d", batchSize), func(b *testing.B) {
 			var (
-				q          = queries.New(hotPathDB)
 				topic      = testutils.RandomBytes(32)
 				blob       = testutils.RandomBytes(hotPathBlobSize)
 				payerAddr  = utils.HexEncode(testutils.RandomBytes(20))
@@ -295,7 +288,7 @@ func BenchmarkHotPathBatchCycle(b *testing.B) {
 				b.StopTimer()
 				var lastSeenID int64
 				for range batchSize {
-					staged, err := q.InsertStagedOriginatorEnvelope(
+					staged, err := hotPathQueries.InsertStagedOriginatorEnvelope(
 						benchCtx,
 						queries.InsertStagedOriginatorEnvelopeParams{
 							Topic:         topic,
@@ -309,7 +302,7 @@ func BenchmarkHotPathBatchCycle(b *testing.B) {
 				}
 
 				// Fetch the batch (single SELECT, untimed).
-				batch, err := q.SelectStagedOriginatorEnvelopes(
+				batch, err := hotPathQueries.SelectStagedOriginatorEnvelopes(
 					benchCtx,
 					queries.SelectStagedOriginatorEnvelopesParams{
 						LastSeenID: lastSeenID,
@@ -323,7 +316,7 @@ func BenchmarkHotPathBatchCycle(b *testing.B) {
 				// --- Timed: batch DB operations (3 round-trips) ---
 
 				// 1. Bulk find/create payers.
-				_, err = q.BulkFindOrCreatePayers(benchCtx, []string{payerAddr})
+				_, err = hotPathQueries.BulkFindOrCreatePayers(benchCtx, []string{payerAddr})
 				require.NoError(b, err)
 
 				// 2. Build batch and insert via V2 function.
@@ -352,7 +345,7 @@ func BenchmarkHotPathBatchCycle(b *testing.B) {
 				require.NoError(b, err)
 
 				// 3. Bulk delete staged envelopes.
-				_, err = q.BulkDeleteStagedOriginatorEnvelopes(benchCtx, stagedIDs)
+				_, err = hotPathQueries.BulkDeleteStagedOriginatorEnvelopes(benchCtx, stagedIDs)
 				require.NoError(b, err)
 			}
 		})

--- a/pkg/db/bench/indexer_bench_test.go
+++ b/pkg/db/bench/indexer_bench_test.go
@@ -4,7 +4,6 @@ package bench
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"sync/atomic"
@@ -18,13 +17,12 @@ import (
 const numContracts = 100
 
 // seedIndexer populates the latest_block table with contract addresses.
-func seedIndexer(ctx context.Context, db *sql.DB) {
-	q := queries.New(db)
+func seedIndexer(ctx context.Context) {
 	indexerContracts = make([]string, numContracts)
 	for i := range numContracts {
 		addr := fmt.Sprintf("0x%040x", i)
 		indexerContracts[i] = addr
-		err := q.SetLatestBlock(ctx, queries.SetLatestBlockParams{
+		err := indexerQueries.SetLatestBlock(ctx, queries.SetLatestBlockParams{
 			ContractAddress: addr,
 			BlockNumber:     int64(1000 + i),
 			BlockHash:       testutils.RandomBytes(32),
@@ -37,22 +35,20 @@ func seedIndexer(ctx context.Context, db *sql.DB) {
 }
 
 func BenchmarkGetLatestBlock(b *testing.B) {
-	q := queries.New(indexerDB)
 	contract := indexerContracts[0]
 	for b.Loop() {
-		_, err := q.GetLatestBlock(benchCtx, contract)
+		_, err := indexerQueries.GetLatestBlock(benchCtx, contract)
 		require.NoError(b, err)
 	}
 }
 
 func BenchmarkSetLatestBlock(b *testing.B) {
-	q := queries.New(indexerDB)
 	blockHash := testutils.RandomBytes(32) // pre-generate to avoid crypto/rand in hot path
 	var counter atomic.Int64
 	counter.Store(100_000)
 	for b.Loop() {
 		blockNum := counter.Add(1)
-		err := q.SetLatestBlock(benchCtx, queries.SetLatestBlockParams{
+		err := indexerQueries.SetLatestBlock(benchCtx, queries.SetLatestBlockParams{
 			ContractAddress: indexerContracts[0],
 			BlockNumber:     blockNum,
 			BlockHash:       blockHash,

--- a/pkg/db/bench/ledger_bench_test.go
+++ b/pkg/db/bench/ledger_bench_test.go
@@ -4,7 +4,6 @@ package bench
 
 import (
 	"context"
-	"database/sql"
 	"log"
 	"sync/atomic"
 	"testing"
@@ -21,13 +20,12 @@ const (
 )
 
 // seedLedger creates payers and populates payer_ledger_events.
-func seedLedger(ctx context.Context, db *sql.DB) {
-	q := queries.New(db)
+func seedLedger(ctx context.Context) {
 	ledgerPayerIDs = make([]int32, numLedgerPayers)
 
 	for i := range numLedgerPayers {
 		addr := utils.HexEncode(testutils.RandomBytes(20))
-		id, err := q.FindOrCreatePayer(ctx, addr)
+		id, err := ledgerQueries.FindOrCreatePayer(ctx, addr)
 		if err != nil {
 			log.Fatalf("seed ledger payer: %v", err)
 		}
@@ -40,7 +38,7 @@ func seedLedger(ctx context.Context, db *sql.DB) {
 			if eventType == 2 {
 				amount = -amount
 			}
-			err := q.InsertPayerLedgerEvent(
+			err := ledgerQueries.InsertPayerLedgerEvent(
 				ctx,
 				queries.InsertPayerLedgerEventParams{
 					EventID:           testutils.RandomBytes(32),
@@ -62,7 +60,6 @@ func seedLedger(ctx context.Context, db *sql.DB) {
 }
 
 func BenchmarkInsertPayerLedgerEvent(b *testing.B) {
-	q := queries.New(ledgerDB)
 	payerID := ledgerPayerIDs[0]
 	// Pre-generate a pool of unique event IDs to avoid crypto/rand in hot path.
 	const poolSize = 10_000
@@ -73,7 +70,7 @@ func BenchmarkInsertPayerLedgerEvent(b *testing.B) {
 	var counter atomic.Int64
 	for b.Loop() {
 		idx := counter.Add(1)
-		err := q.InsertPayerLedgerEvent(
+		err := ledgerQueries.InsertPayerLedgerEvent(
 			benchCtx,
 			queries.InsertPayerLedgerEventParams{
 				EventID:           eventIDs[idx%poolSize],
@@ -87,22 +84,20 @@ func BenchmarkInsertPayerLedgerEvent(b *testing.B) {
 }
 
 func BenchmarkGetPayerBalance(b *testing.B) {
-	q := queries.New(ledgerDB)
 	payerID := ledgerPayerIDs[0]
 	for b.Loop() {
-		_, err := q.GetPayerBalance(benchCtx, payerID)
+		_, err := ledgerQueries.GetPayerBalance(benchCtx, payerID)
 		require.NoError(b, err)
 	}
 }
 
 func BenchmarkGetLastEvent(b *testing.B) {
-	q := queries.New(ledgerDB)
 	params := queries.GetLastEventParams{
 		PayerID:   ledgerPayerIDs[0],
 		EventType: 1, // deposits
 	}
 	for b.Loop() {
-		_, err := q.GetLastEvent(benchCtx, params)
+		_, err := ledgerQueries.GetLastEvent(benchCtx, params)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/db/bench/main_test.go
+++ b/pkg/db/bench/main_test.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/xmtp/xmtpd/pkg/db/migrations"
+	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 )
 
@@ -26,6 +28,7 @@ const (
 type envelopeTier struct {
 	name        string // sub-benchmark name, e.g. "rows=100K"
 	db          *sql.DB
+	queries     *queries.Queries
 	count       int      // total envelope rows seeded
 	topics      [][]byte // topics seeded into this DB
 	originators []int32  // originator node IDs seeded
@@ -35,13 +38,19 @@ type envelopeTier struct {
 // Package-level handles, populated by TestMain.
 // testing.M has no Context() or Cleanup() methods, so we manage lifecycle manually.
 var (
-	benchCtx      = context.Background()
-	envelopeTiers []*envelopeTier
-	congestionDB  *sql.DB
-	ledgerDB      *sql.DB
-	indexerDB     *sql.DB
-	usageDB       *sql.DB
-	hotPathDB     *sql.DB
+	benchCtx          = context.Background()
+	usePreparedPlans  = parseBenchUsePrepared()
+	envelopeTiers     []*envelopeTier
+	congestionDB      *sql.DB
+	congestionQueries *queries.Queries
+	ledgerDB          *sql.DB
+	ledgerQueries     *queries.Queries
+	indexerDB         *sql.DB
+	indexerQueries    *queries.Queries
+	usageDB           *sql.DB
+	usageQueries      *queries.Queries
+	hotPathDB         *sql.DB
+	hotPathQueries    *queries.Queries
 
 	// Seeded data references for non-envelope groups.
 	congestionOriginators []int32
@@ -55,21 +64,17 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	log.Printf("benchmark prepared queries enabled: %t", usePreparedPlans)
+
 	ctlDB, err := connectDB(localDSNPrefix + localDSNSuffix)
 	if err != nil {
 		log.Fatalf("failed to connect to control DB: %v", err)
 	}
-	defer func() { _ = ctlDB.Close() }()
 
 	// Track cleanups so they run even if a seed function calls log.Fatalf
 	// (log.Fatalf calls os.Exit, so defers in this function won't run either —
 	// but at least we get cleanup for the normal exit path).
 	var cleanups []func()
-	defer func() {
-		for _, fn := range cleanups {
-			fn()
-		}
-	}()
 
 	// --- Envelope tiers ---
 	tiers := []struct {
@@ -86,13 +91,14 @@ func TestMain(m *testing.M) {
 		if benchTier != "" && !strings.EqualFold(benchTier, t.name) {
 			continue
 		}
-		db, cleanup := createBenchDB(ctlDB, "env_"+strings.ToLower(t.name))
+		db, querySet, cleanup := createBenchDB(ctlDB, "env_"+strings.ToLower(t.name))
 		cleanups = append(cleanups, cleanup)
 
 		tier := &envelopeTier{
-			name:  "rows=" + t.name,
-			db:    db,
-			count: t.count,
+			name:    "rows=" + t.name,
+			db:      db,
+			queries: querySet,
+			count:   t.count,
 		}
 		seedEnvelopes(benchCtx, tier)
 		envelopeTiers = append(envelopeTiers, tier)
@@ -100,27 +106,32 @@ func TestMain(m *testing.M) {
 
 	// --- Non-envelope groups ---
 	var cleanup func()
-	congestionDB, cleanup = createBenchDB(ctlDB, "congestion")
+	congestionDB, congestionQueries, cleanup = createBenchDB(ctlDB, "congestion")
 	cleanups = append(cleanups, cleanup)
-	seedCongestion(benchCtx, congestionDB)
+	seedCongestion(benchCtx)
 
-	ledgerDB, cleanup = createBenchDB(ctlDB, "ledger")
+	ledgerDB, ledgerQueries, cleanup = createBenchDB(ctlDB, "ledger")
 	cleanups = append(cleanups, cleanup)
-	seedLedger(benchCtx, ledgerDB)
+	seedLedger(benchCtx)
 
-	indexerDB, cleanup = createBenchDB(ctlDB, "indexer")
+	indexerDB, indexerQueries, cleanup = createBenchDB(ctlDB, "indexer")
 	cleanups = append(cleanups, cleanup)
-	seedIndexer(benchCtx, indexerDB)
+	seedIndexer(benchCtx)
 
-	usageDB, cleanup = createBenchDB(ctlDB, "usage")
+	usageDB, usageQueries, cleanup = createBenchDB(ctlDB, "usage")
 	cleanups = append(cleanups, cleanup)
-	seedUsage(benchCtx, usageDB)
+	seedUsage(benchCtx)
 
-	hotPathDB, cleanup = createBenchDB(ctlDB, "hot_path")
+	hotPathDB, hotPathQueries, cleanup = createBenchDB(ctlDB, "hot_path")
 	cleanups = append(cleanups, cleanup)
-	seedHotPath(benchCtx, hotPathDB)
+	seedHotPath(benchCtx)
 
-	os.Exit(m.Run())
+	code := m.Run()
+	for _, fn := range cleanups {
+		fn()
+	}
+	_ = ctlDB.Close()
+	os.Exit(code)
 }
 
 // connectDB opens a pgx-backed *sql.DB.
@@ -133,7 +144,10 @@ func connectDB(dsn string) (*sql.DB, error) {
 }
 
 // createBenchDB creates an isolated database, runs migrations, returns handle + cleanup.
-func createBenchDB(ctlDB *sql.DB, suffix string) (*sql.DB, func()) {
+func createBenchDB(
+	ctlDB *sql.DB,
+	suffix string,
+) (db *sql.DB, q *queries.Queries, cleanup func()) {
 	dbName := "bench_" + suffix + "_" + testutils.RandomStringLower(8)
 	log.Printf("creating benchmark database %s...", dbName)
 
@@ -151,8 +165,36 @@ func createBenchDB(ctlDB *sql.DB, suffix string) (*sql.DB, func()) {
 		log.Fatalf("migrate %s: %v", dbName, err)
 	}
 
-	return db, func() {
+	if !usePreparedPlans {
+		querySet := queries.New(db)
+		return db, querySet, func() {
+			_ = db.Close()
+			_, _ = ctlDB.Exec("DROP DATABASE " + dbName + " WITH (FORCE)")
+		}
+	}
+
+	querySet, err := queries.Prepare(benchCtx, db)
+	if err != nil {
+		log.Fatalf("prepare queries %s: %v", dbName, err)
+	}
+
+	return db, querySet, func() {
+		_ = querySet.Close()
 		_ = db.Close()
 		_, _ = ctlDB.Exec("DROP DATABASE " + dbName + " WITH (FORCE)")
 	}
+}
+
+func parseBenchUsePrepared() bool {
+	raw := os.Getenv("BENCH_USE_PREPARED")
+	if raw == "" {
+		return true
+	}
+
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		log.Fatalf("invalid BENCH_USE_PREPARED=%q: %v", raw, err)
+	}
+
+	return enabled
 }

--- a/pkg/db/bench/usage_bench_test.go
+++ b/pkg/db/bench/usage_bench_test.go
@@ -4,7 +4,6 @@ package bench
 
 import (
 	"context"
-	"database/sql"
 	"log"
 	"sync/atomic"
 	"testing"
@@ -22,8 +21,7 @@ const (
 )
 
 // seedUsage creates payers and populates unsettled_usage.
-func seedUsage(ctx context.Context, db *sql.DB) {
-	q := queries.New(db)
+func seedUsage(ctx context.Context) {
 	usagePayerIDs = make([]int32, numUsagePayers)
 	usageOriginators = make([]int32, numUsageOriginators)
 
@@ -33,7 +31,7 @@ func seedUsage(ctx context.Context, db *sql.DB) {
 
 	for i := range numUsagePayers {
 		addr := utils.HexEncode(testutils.RandomBytes(20))
-		id, err := q.FindOrCreatePayer(ctx, addr)
+		id, err := usageQueries.FindOrCreatePayer(ctx, addr)
 		if err != nil {
 			log.Fatalf("seed usage payer: %v", err)
 		}
@@ -41,7 +39,7 @@ func seedUsage(ctx context.Context, db *sql.DB) {
 
 		for _, origID := range usageOriginators {
 			for minute := range int32(numUsageMinutes) {
-				err := q.IncrementUnsettledUsage(
+				err := usageQueries.IncrementUnsettledUsage(
 					ctx,
 					queries.IncrementUnsettledUsageParams{
 						PayerID:           id,
@@ -66,14 +64,13 @@ func seedUsage(ctx context.Context, db *sql.DB) {
 }
 
 func BenchmarkIncrementUnsettledUsage(b *testing.B) {
-	q := queries.New(usageDB)
 	payerID := usagePayerIDs[0]
 	origID := usageOriginators[0]
 	var counter atomic.Int32
 	counter.Store(100_000) // beyond seeded range
 	for b.Loop() {
 		minute := counter.Add(1)
-		err := q.IncrementUnsettledUsage(
+		err := usageQueries.IncrementUnsettledUsage(
 			benchCtx,
 			queries.IncrementUnsettledUsageParams{
 				PayerID:           payerID,

--- a/pkg/db/queries/advisory_locks.sql.go
+++ b/pkg/db/queries/advisory_locks.sql.go
@@ -14,7 +14,7 @@ SELECT pg_advisory_xact_lock($1)
 `
 
 func (q *Queries) AdvisoryLockWithKey(ctx context.Context, lockingKey int64) error {
-	_, err := q.db.ExecContext(ctx, advisoryLockWithKey, lockingKey)
+	_, err := q.exec(ctx, q.advisoryLockWithKeyStmt, advisoryLockWithKey, lockingKey)
 	return err
 }
 
@@ -23,7 +23,7 @@ SELECT pg_try_advisory_xact_lock($1) as lock_succeeded
 `
 
 func (q *Queries) TryAdvisoryLockWithKey(ctx context.Context, lockingKey int64) (bool, error) {
-	row := q.db.QueryRowContext(ctx, tryAdvisoryLockWithKey, lockingKey)
+	row := q.queryRow(ctx, q.tryAdvisoryLockWithKeyStmt, tryAdvisoryLockWithKey, lockingKey)
 	var lock_succeeded bool
 	err := row.Scan(&lock_succeeded)
 	return lock_succeeded, err

--- a/pkg/db/queries/configuration.sql.go
+++ b/pkg/db/queries/configuration.sql.go
@@ -14,7 +14,7 @@ SELECT set_config('work_mem', $1::TEXT, true)
 `
 
 func (q *Queries) SetLocalWorkMem(ctx context.Context, dollar_1 string) (string, error) {
-	row := q.db.QueryRowContext(ctx, setLocalWorkMem, dollar_1)
+	row := q.queryRow(ctx, q.setLocalWorkMemStmt, setLocalWorkMem, dollar_1)
 	var set_config string
 	err := row.Scan(&set_config)
 	return set_config, err

--- a/pkg/db/queries/congestion.sql.go
+++ b/pkg/db/queries/congestion.sql.go
@@ -34,7 +34,7 @@ type GetRecentOriginatorCongestionRow struct {
 }
 
 func (q *Queries) GetRecentOriginatorCongestion(ctx context.Context, arg GetRecentOriginatorCongestionParams) ([]GetRecentOriginatorCongestionRow, error) {
-	rows, err := q.db.QueryContext(ctx, getRecentOriginatorCongestion, arg.OriginatorID, arg.EndMinute, arg.NumMinutes)
+	rows, err := q.query(ctx, q.getRecentOriginatorCongestionStmt, getRecentOriginatorCongestion, arg.OriginatorID, arg.EndMinute, arg.NumMinutes)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ type IncrementOriginatorCongestionParams struct {
 }
 
 func (q *Queries) IncrementOriginatorCongestion(ctx context.Context, arg IncrementOriginatorCongestionParams) error {
-	_, err := q.db.ExecContext(ctx, incrementOriginatorCongestion, arg.OriginatorID, arg.MinutesSinceEpoch)
+	_, err := q.exec(ctx, q.incrementOriginatorCongestionStmt, incrementOriginatorCongestion, arg.OriginatorID, arg.MinutesSinceEpoch)
 	return err
 }
 
@@ -94,7 +94,7 @@ type SumOriginatorCongestionParams struct {
 }
 
 func (q *Queries) SumOriginatorCongestion(ctx context.Context, arg SumOriginatorCongestionParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, sumOriginatorCongestion, arg.OriginatorID, arg.MinutesSinceEpochGt, arg.MinutesSinceEpochLt)
+	row := q.queryRow(ctx, q.sumOriginatorCongestionStmt, sumOriginatorCongestion, arg.OriginatorID, arg.MinutesSinceEpochGt, arg.MinutesSinceEpochLt)
 	var num_messages int64
 	err := row.Scan(&num_messages)
 	return num_messages, err

--- a/pkg/db/queries/db.go
+++ b/pkg/db/queries/db.go
@@ -7,6 +7,7 @@ package queries
 import (
 	"context"
 	"database/sql"
+	"fmt"
 )
 
 type DBTX interface {
@@ -20,12 +21,778 @@ func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
+func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
+	q := Queries{db: db}
+	var err error
+	if q.advisoryLockWithKeyStmt, err = db.PrepareContext(ctx, advisoryLockWithKey); err != nil {
+		return nil, fmt.Errorf("error preparing query AdvisoryLockWithKey: %w", err)
+	}
+	if q.buildPayerReportStmt, err = db.PrepareContext(ctx, buildPayerReport); err != nil {
+		return nil, fmt.Errorf("error preparing query BuildPayerReport: %w", err)
+	}
+	if q.bulkDeleteStagedOriginatorEnvelopesStmt, err = db.PrepareContext(ctx, bulkDeleteStagedOriginatorEnvelopes); err != nil {
+		return nil, fmt.Errorf("error preparing query BulkDeleteStagedOriginatorEnvelopes: %w", err)
+	}
+	if q.bulkFindOrCreatePayersStmt, err = db.PrepareContext(ctx, bulkFindOrCreatePayers); err != nil {
+		return nil, fmt.Errorf("error preparing query BulkFindOrCreatePayers: %w", err)
+	}
+	if q.clearUnsettledUsageStmt, err = db.PrepareContext(ctx, clearUnsettledUsage); err != nil {
+		return nil, fmt.Errorf("error preparing query ClearUnsettledUsage: %w", err)
+	}
+	if q.countExpiredEnvelopesStmt, err = db.PrepareContext(ctx, countExpiredEnvelopes); err != nil {
+		return nil, fmt.Errorf("error preparing query CountExpiredEnvelopes: %w", err)
+	}
+	if q.deleteAvailableNonceStmt, err = db.PrepareContext(ctx, deleteAvailableNonce); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteAvailableNonce: %w", err)
+	}
+	if q.deleteMigrationDeadLetterBoxStmt, err = db.PrepareContext(ctx, deleteMigrationDeadLetterBox); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteMigrationDeadLetterBox: %w", err)
+	}
+	if q.deleteObsoleteNoncesStmt, err = db.PrepareContext(ctx, deleteObsoleteNonces); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteObsoleteNonces: %w", err)
+	}
+	if q.ensureGatewayPartsStmt, err = db.PrepareContext(ctx, ensureGatewayParts); err != nil {
+		return nil, fmt.Errorf("error preparing query EnsureGatewayParts: %w", err)
+	}
+	if q.fetchPayerReportStmt, err = db.PrepareContext(ctx, fetchPayerReport); err != nil {
+		return nil, fmt.Errorf("error preparing query FetchPayerReport: %w", err)
+	}
+	if q.fetchPayerReportLockedStmt, err = db.PrepareContext(ctx, fetchPayerReportLocked); err != nil {
+		return nil, fmt.Errorf("error preparing query FetchPayerReportLocked: %w", err)
+	}
+	if q.fetchPayerReportsStmt, err = db.PrepareContext(ctx, fetchPayerReports); err != nil {
+		return nil, fmt.Errorf("error preparing query FetchPayerReports: %w", err)
+	}
+	if q.fillNonceSequenceStmt, err = db.PrepareContext(ctx, fillNonceSequence); err != nil {
+		return nil, fmt.Errorf("error preparing query FillNonceSequence: %w", err)
+	}
+	if q.findOrCreatePayerStmt, err = db.PrepareContext(ctx, findOrCreatePayer); err != nil {
+		return nil, fmt.Errorf("error preparing query FindOrCreatePayer: %w", err)
+	}
+	if q.getAddressLogsStmt, err = db.PrepareContext(ctx, getAddressLogs); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAddressLogs: %w", err)
+	}
+	if q.getGatewayEnvelopeByIDStmt, err = db.PrepareContext(ctx, getGatewayEnvelopeByID); err != nil {
+		return nil, fmt.Errorf("error preparing query GetGatewayEnvelopeByID: %w", err)
+	}
+	if q.getLastEventStmt, err = db.PrepareContext(ctx, getLastEvent); err != nil {
+		return nil, fmt.Errorf("error preparing query GetLastEvent: %w", err)
+	}
+	if q.getLastSequenceIDForOriginatorMinuteStmt, err = db.PrepareContext(ctx, getLastSequenceIDForOriginatorMinute); err != nil {
+		return nil, fmt.Errorf("error preparing query GetLastSequenceIDForOriginatorMinute: %w", err)
+	}
+	if q.getLatestBlockStmt, err = db.PrepareContext(ctx, getLatestBlock); err != nil {
+		return nil, fmt.Errorf("error preparing query GetLatestBlock: %w", err)
+	}
+	if q.getLatestSequenceIdStmt, err = db.PrepareContext(ctx, getLatestSequenceId); err != nil {
+		return nil, fmt.Errorf("error preparing query GetLatestSequenceId: %w", err)
+	}
+	if q.getMigrationProgressStmt, err = db.PrepareContext(ctx, getMigrationProgress); err != nil {
+		return nil, fmt.Errorf("error preparing query GetMigrationProgress: %w", err)
+	}
+	if q.getNextAvailableNonceStmt, err = db.PrepareContext(ctx, getNextAvailableNonce); err != nil {
+		return nil, fmt.Errorf("error preparing query GetNextAvailableNonce: %w", err)
+	}
+	if q.getPayerBalanceStmt, err = db.PrepareContext(ctx, getPayerBalance); err != nil {
+		return nil, fmt.Errorf("error preparing query GetPayerBalance: %w", err)
+	}
+	if q.getPayerByAddressStmt, err = db.PrepareContext(ctx, getPayerByAddress); err != nil {
+		return nil, fmt.Errorf("error preparing query GetPayerByAddress: %w", err)
+	}
+	if q.getPayerInfoReportStmt, err = db.PrepareContext(ctx, getPayerInfoReport); err != nil {
+		return nil, fmt.Errorf("error preparing query GetPayerInfoReport: %w", err)
+	}
+	if q.getPayerUnsettledUsageStmt, err = db.PrepareContext(ctx, getPayerUnsettledUsage); err != nil {
+		return nil, fmt.Errorf("error preparing query GetPayerUnsettledUsage: %w", err)
+	}
+	if q.getPrunableCeilingStmt, err = db.PrepareContext(ctx, getPrunableCeiling); err != nil {
+		return nil, fmt.Errorf("error preparing query GetPrunableCeiling: %w", err)
+	}
+	if q.getRecentOriginatorCongestionStmt, err = db.PrepareContext(ctx, getRecentOriginatorCongestion); err != nil {
+		return nil, fmt.Errorf("error preparing query GetRecentOriginatorCongestion: %w", err)
+	}
+	if q.getRetryableMigrationDeadLetterBoxesStmt, err = db.PrepareContext(ctx, getRetryableMigrationDeadLetterBoxes); err != nil {
+		return nil, fmt.Errorf("error preparing query GetRetryableMigrationDeadLetterBoxes: %w", err)
+	}
+	if q.getSecondNewestMinuteStmt, err = db.PrepareContext(ctx, getSecondNewestMinute); err != nil {
+		return nil, fmt.Errorf("error preparing query GetSecondNewestMinute: %w", err)
+	}
+	if q.incrementOriginatorCongestionStmt, err = db.PrepareContext(ctx, incrementOriginatorCongestion); err != nil {
+		return nil, fmt.Errorf("error preparing query IncrementOriginatorCongestion: %w", err)
+	}
+	if q.incrementUnsettledUsageStmt, err = db.PrepareContext(ctx, incrementUnsettledUsage); err != nil {
+		return nil, fmt.Errorf("error preparing query IncrementUnsettledUsage: %w", err)
+	}
+	if q.insertAddressLogStmt, err = db.PrepareContext(ctx, insertAddressLog); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertAddressLog: %w", err)
+	}
+	if q.insertAddressLogsBatchStmt, err = db.PrepareContext(ctx, insertAddressLogsBatch); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertAddressLogsBatch: %w", err)
+	}
+	if q.insertGatewayEnvelopeStmt, err = db.PrepareContext(ctx, insertGatewayEnvelope); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertGatewayEnvelope: %w", err)
+	}
+	if q.insertGatewayEnvelopeBatchV2Stmt, err = db.PrepareContext(ctx, insertGatewayEnvelopeBatchV2); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertGatewayEnvelopeBatchV2: %w", err)
+	}
+	if q.insertMigrationDeadLetterBoxStmt, err = db.PrepareContext(ctx, insertMigrationDeadLetterBox); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertMigrationDeadLetterBox: %w", err)
+	}
+	if q.insertNodeInfoStmt, err = db.PrepareContext(ctx, insertNodeInfo); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertNodeInfo: %w", err)
+	}
+	if q.insertOrIgnorePayerReportStmt, err = db.PrepareContext(ctx, insertOrIgnorePayerReport); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertOrIgnorePayerReport: %w", err)
+	}
+	if q.insertOrIgnorePayerReportAttestationStmt, err = db.PrepareContext(ctx, insertOrIgnorePayerReportAttestation); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertOrIgnorePayerReportAttestation: %w", err)
+	}
+	if q.insertPayerLedgerEventStmt, err = db.PrepareContext(ctx, insertPayerLedgerEvent); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertPayerLedgerEvent: %w", err)
+	}
+	if q.insertSavePointStmt, err = db.PrepareContext(ctx, insertSavePoint); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertSavePoint: %w", err)
+	}
+	if q.insertSavePointReleaseStmt, err = db.PrepareContext(ctx, insertSavePointRelease); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertSavePointRelease: %w", err)
+	}
+	if q.insertSavePointRollbackStmt, err = db.PrepareContext(ctx, insertSavePointRollback); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertSavePointRollback: %w", err)
+	}
+	if q.insertStagedOriginatorEnvelopeStmt, err = db.PrepareContext(ctx, insertStagedOriginatorEnvelope); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertStagedOriginatorEnvelope: %w", err)
+	}
+	if q.insertStagedOriginatorEnvelopeBatchStmt, err = db.PrepareContext(ctx, insertStagedOriginatorEnvelopeBatch); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertStagedOriginatorEnvelopeBatch: %w", err)
+	}
+	if q.makeBlobOriginatorPartStmt, err = db.PrepareContext(ctx, makeBlobOriginatorPart); err != nil {
+		return nil, fmt.Errorf("error preparing query MakeBlobOriginatorPart: %w", err)
+	}
+	if q.makeBlobSeqBandStmt, err = db.PrepareContext(ctx, makeBlobSeqBand); err != nil {
+		return nil, fmt.Errorf("error preparing query MakeBlobSeqBand: %w", err)
+	}
+	if q.makeMetaOriginatorPartStmt, err = db.PrepareContext(ctx, makeMetaOriginatorPart); err != nil {
+		return nil, fmt.Errorf("error preparing query MakeMetaOriginatorPart: %w", err)
+	}
+	if q.makeMetaSeqBandStmt, err = db.PrepareContext(ctx, makeMetaSeqBand); err != nil {
+		return nil, fmt.Errorf("error preparing query MakeMetaSeqBand: %w", err)
+	}
+	if q.revokeAddressFromLogStmt, err = db.PrepareContext(ctx, revokeAddressFromLog); err != nil {
+		return nil, fmt.Errorf("error preparing query RevokeAddressFromLog: %w", err)
+	}
+	if q.revokeAddressFromLogBatchStmt, err = db.PrepareContext(ctx, revokeAddressFromLogBatch); err != nil {
+		return nil, fmt.Errorf("error preparing query RevokeAddressFromLogBatch: %w", err)
+	}
+	if q.selectAndLockStagedEnvelopesStmt, err = db.PrepareContext(ctx, selectAndLockStagedEnvelopes); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectAndLockStagedEnvelopes: %w", err)
+	}
+	if q.selectGatewayEnvelopesByOriginatorsStmt, err = db.PrepareContext(ctx, selectGatewayEnvelopesByOriginators); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectGatewayEnvelopesByOriginators: %w", err)
+	}
+	if q.selectGatewayEnvelopesByPerTopicCursorsStmt, err = db.PrepareContext(ctx, selectGatewayEnvelopesByPerTopicCursors); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectGatewayEnvelopesByPerTopicCursors: %w", err)
+	}
+	if q.selectGatewayEnvelopesBySingleOriginatorStmt, err = db.PrepareContext(ctx, selectGatewayEnvelopesBySingleOriginator); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectGatewayEnvelopesBySingleOriginator: %w", err)
+	}
+	if q.selectGatewayEnvelopesByTopicsStmt, err = db.PrepareContext(ctx, selectGatewayEnvelopesByTopics); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectGatewayEnvelopesByTopics: %w", err)
+	}
+	if q.selectGatewayEnvelopesUnfilteredStmt, err = db.PrepareContext(ctx, selectGatewayEnvelopesUnfiltered); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectGatewayEnvelopesUnfiltered: %w", err)
+	}
+	if q.selectNewestFromTopicsStmt, err = db.PrepareContext(ctx, selectNewestFromTopics); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectNewestFromTopics: %w", err)
+	}
+	if q.selectNodeInfoStmt, err = db.PrepareContext(ctx, selectNodeInfo); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectNodeInfo: %w", err)
+	}
+	if q.selectOriginatorNodeIDsStmt, err = db.PrepareContext(ctx, selectOriginatorNodeIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectOriginatorNodeIDs: %w", err)
+	}
+	if q.selectStagedOriginatorEnvelopesStmt, err = db.PrepareContext(ctx, selectStagedOriginatorEnvelopes); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectStagedOriginatorEnvelopes: %w", err)
+	}
+	if q.selectVectorClockStmt, err = db.PrepareContext(ctx, selectVectorClock); err != nil {
+		return nil, fmt.Errorf("error preparing query SelectVectorClock: %w", err)
+	}
+	if q.setLatestBlockStmt, err = db.PrepareContext(ctx, setLatestBlock); err != nil {
+		return nil, fmt.Errorf("error preparing query SetLatestBlock: %w", err)
+	}
+	if q.setLocalWorkMemStmt, err = db.PrepareContext(ctx, setLocalWorkMem); err != nil {
+		return nil, fmt.Errorf("error preparing query SetLocalWorkMem: %w", err)
+	}
+	if q.setReportAttestationStatusStmt, err = db.PrepareContext(ctx, setReportAttestationStatus); err != nil {
+		return nil, fmt.Errorf("error preparing query SetReportAttestationStatus: %w", err)
+	}
+	if q.setReportSubmissionStatusStmt, err = db.PrepareContext(ctx, setReportSubmissionStatus); err != nil {
+		return nil, fmt.Errorf("error preparing query SetReportSubmissionStatus: %w", err)
+	}
+	if q.setReportSubmittedStmt, err = db.PrepareContext(ctx, setReportSubmitted); err != nil {
+		return nil, fmt.Errorf("error preparing query SetReportSubmitted: %w", err)
+	}
+	if q.sumOriginatorCongestionStmt, err = db.PrepareContext(ctx, sumOriginatorCongestion); err != nil {
+		return nil, fmt.Errorf("error preparing query SumOriginatorCongestion: %w", err)
+	}
+	if q.tryAdvisoryLockWithKeyStmt, err = db.PrepareContext(ctx, tryAdvisoryLockWithKey); err != nil {
+		return nil, fmt.Errorf("error preparing query TryAdvisoryLockWithKey: %w", err)
+	}
+	if q.updateMigrationProgressStmt, err = db.PrepareContext(ctx, updateMigrationProgress); err != nil {
+		return nil, fmt.Errorf("error preparing query UpdateMigrationProgress: %w", err)
+	}
+	return &q, nil
+}
+
+func (q *Queries) Close() error {
+	var err error
+	if q.advisoryLockWithKeyStmt != nil {
+		if cerr := q.advisoryLockWithKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing advisoryLockWithKeyStmt: %w", cerr)
+		}
+	}
+	if q.buildPayerReportStmt != nil {
+		if cerr := q.buildPayerReportStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing buildPayerReportStmt: %w", cerr)
+		}
+	}
+	if q.bulkDeleteStagedOriginatorEnvelopesStmt != nil {
+		if cerr := q.bulkDeleteStagedOriginatorEnvelopesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing bulkDeleteStagedOriginatorEnvelopesStmt: %w", cerr)
+		}
+	}
+	if q.bulkFindOrCreatePayersStmt != nil {
+		if cerr := q.bulkFindOrCreatePayersStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing bulkFindOrCreatePayersStmt: %w", cerr)
+		}
+	}
+	if q.clearUnsettledUsageStmt != nil {
+		if cerr := q.clearUnsettledUsageStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing clearUnsettledUsageStmt: %w", cerr)
+		}
+	}
+	if q.countExpiredEnvelopesStmt != nil {
+		if cerr := q.countExpiredEnvelopesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing countExpiredEnvelopesStmt: %w", cerr)
+		}
+	}
+	if q.deleteAvailableNonceStmt != nil {
+		if cerr := q.deleteAvailableNonceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteAvailableNonceStmt: %w", cerr)
+		}
+	}
+	if q.deleteMigrationDeadLetterBoxStmt != nil {
+		if cerr := q.deleteMigrationDeadLetterBoxStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteMigrationDeadLetterBoxStmt: %w", cerr)
+		}
+	}
+	if q.deleteObsoleteNoncesStmt != nil {
+		if cerr := q.deleteObsoleteNoncesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteObsoleteNoncesStmt: %w", cerr)
+		}
+	}
+	if q.ensureGatewayPartsStmt != nil {
+		if cerr := q.ensureGatewayPartsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing ensureGatewayPartsStmt: %w", cerr)
+		}
+	}
+	if q.fetchPayerReportStmt != nil {
+		if cerr := q.fetchPayerReportStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing fetchPayerReportStmt: %w", cerr)
+		}
+	}
+	if q.fetchPayerReportLockedStmt != nil {
+		if cerr := q.fetchPayerReportLockedStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing fetchPayerReportLockedStmt: %w", cerr)
+		}
+	}
+	if q.fetchPayerReportsStmt != nil {
+		if cerr := q.fetchPayerReportsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing fetchPayerReportsStmt: %w", cerr)
+		}
+	}
+	if q.fillNonceSequenceStmt != nil {
+		if cerr := q.fillNonceSequenceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing fillNonceSequenceStmt: %w", cerr)
+		}
+	}
+	if q.findOrCreatePayerStmt != nil {
+		if cerr := q.findOrCreatePayerStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing findOrCreatePayerStmt: %w", cerr)
+		}
+	}
+	if q.getAddressLogsStmt != nil {
+		if cerr := q.getAddressLogsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAddressLogsStmt: %w", cerr)
+		}
+	}
+	if q.getGatewayEnvelopeByIDStmt != nil {
+		if cerr := q.getGatewayEnvelopeByIDStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getGatewayEnvelopeByIDStmt: %w", cerr)
+		}
+	}
+	if q.getLastEventStmt != nil {
+		if cerr := q.getLastEventStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getLastEventStmt: %w", cerr)
+		}
+	}
+	if q.getLastSequenceIDForOriginatorMinuteStmt != nil {
+		if cerr := q.getLastSequenceIDForOriginatorMinuteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getLastSequenceIDForOriginatorMinuteStmt: %w", cerr)
+		}
+	}
+	if q.getLatestBlockStmt != nil {
+		if cerr := q.getLatestBlockStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getLatestBlockStmt: %w", cerr)
+		}
+	}
+	if q.getLatestSequenceIdStmt != nil {
+		if cerr := q.getLatestSequenceIdStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getLatestSequenceIdStmt: %w", cerr)
+		}
+	}
+	if q.getMigrationProgressStmt != nil {
+		if cerr := q.getMigrationProgressStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getMigrationProgressStmt: %w", cerr)
+		}
+	}
+	if q.getNextAvailableNonceStmt != nil {
+		if cerr := q.getNextAvailableNonceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getNextAvailableNonceStmt: %w", cerr)
+		}
+	}
+	if q.getPayerBalanceStmt != nil {
+		if cerr := q.getPayerBalanceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getPayerBalanceStmt: %w", cerr)
+		}
+	}
+	if q.getPayerByAddressStmt != nil {
+		if cerr := q.getPayerByAddressStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getPayerByAddressStmt: %w", cerr)
+		}
+	}
+	if q.getPayerInfoReportStmt != nil {
+		if cerr := q.getPayerInfoReportStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getPayerInfoReportStmt: %w", cerr)
+		}
+	}
+	if q.getPayerUnsettledUsageStmt != nil {
+		if cerr := q.getPayerUnsettledUsageStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getPayerUnsettledUsageStmt: %w", cerr)
+		}
+	}
+	if q.getPrunableCeilingStmt != nil {
+		if cerr := q.getPrunableCeilingStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getPrunableCeilingStmt: %w", cerr)
+		}
+	}
+	if q.getRecentOriginatorCongestionStmt != nil {
+		if cerr := q.getRecentOriginatorCongestionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getRecentOriginatorCongestionStmt: %w", cerr)
+		}
+	}
+	if q.getRetryableMigrationDeadLetterBoxesStmt != nil {
+		if cerr := q.getRetryableMigrationDeadLetterBoxesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getRetryableMigrationDeadLetterBoxesStmt: %w", cerr)
+		}
+	}
+	if q.getSecondNewestMinuteStmt != nil {
+		if cerr := q.getSecondNewestMinuteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getSecondNewestMinuteStmt: %w", cerr)
+		}
+	}
+	if q.incrementOriginatorCongestionStmt != nil {
+		if cerr := q.incrementOriginatorCongestionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing incrementOriginatorCongestionStmt: %w", cerr)
+		}
+	}
+	if q.incrementUnsettledUsageStmt != nil {
+		if cerr := q.incrementUnsettledUsageStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing incrementUnsettledUsageStmt: %w", cerr)
+		}
+	}
+	if q.insertAddressLogStmt != nil {
+		if cerr := q.insertAddressLogStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertAddressLogStmt: %w", cerr)
+		}
+	}
+	if q.insertAddressLogsBatchStmt != nil {
+		if cerr := q.insertAddressLogsBatchStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertAddressLogsBatchStmt: %w", cerr)
+		}
+	}
+	if q.insertGatewayEnvelopeStmt != nil {
+		if cerr := q.insertGatewayEnvelopeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertGatewayEnvelopeStmt: %w", cerr)
+		}
+	}
+	if q.insertGatewayEnvelopeBatchV2Stmt != nil {
+		if cerr := q.insertGatewayEnvelopeBatchV2Stmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertGatewayEnvelopeBatchV2Stmt: %w", cerr)
+		}
+	}
+	if q.insertMigrationDeadLetterBoxStmt != nil {
+		if cerr := q.insertMigrationDeadLetterBoxStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertMigrationDeadLetterBoxStmt: %w", cerr)
+		}
+	}
+	if q.insertNodeInfoStmt != nil {
+		if cerr := q.insertNodeInfoStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertNodeInfoStmt: %w", cerr)
+		}
+	}
+	if q.insertOrIgnorePayerReportStmt != nil {
+		if cerr := q.insertOrIgnorePayerReportStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertOrIgnorePayerReportStmt: %w", cerr)
+		}
+	}
+	if q.insertOrIgnorePayerReportAttestationStmt != nil {
+		if cerr := q.insertOrIgnorePayerReportAttestationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertOrIgnorePayerReportAttestationStmt: %w", cerr)
+		}
+	}
+	if q.insertPayerLedgerEventStmt != nil {
+		if cerr := q.insertPayerLedgerEventStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertPayerLedgerEventStmt: %w", cerr)
+		}
+	}
+	if q.insertSavePointStmt != nil {
+		if cerr := q.insertSavePointStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertSavePointStmt: %w", cerr)
+		}
+	}
+	if q.insertSavePointReleaseStmt != nil {
+		if cerr := q.insertSavePointReleaseStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertSavePointReleaseStmt: %w", cerr)
+		}
+	}
+	if q.insertSavePointRollbackStmt != nil {
+		if cerr := q.insertSavePointRollbackStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertSavePointRollbackStmt: %w", cerr)
+		}
+	}
+	if q.insertStagedOriginatorEnvelopeStmt != nil {
+		if cerr := q.insertStagedOriginatorEnvelopeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertStagedOriginatorEnvelopeStmt: %w", cerr)
+		}
+	}
+	if q.insertStagedOriginatorEnvelopeBatchStmt != nil {
+		if cerr := q.insertStagedOriginatorEnvelopeBatchStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertStagedOriginatorEnvelopeBatchStmt: %w", cerr)
+		}
+	}
+	if q.makeBlobOriginatorPartStmt != nil {
+		if cerr := q.makeBlobOriginatorPartStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing makeBlobOriginatorPartStmt: %w", cerr)
+		}
+	}
+	if q.makeBlobSeqBandStmt != nil {
+		if cerr := q.makeBlobSeqBandStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing makeBlobSeqBandStmt: %w", cerr)
+		}
+	}
+	if q.makeMetaOriginatorPartStmt != nil {
+		if cerr := q.makeMetaOriginatorPartStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing makeMetaOriginatorPartStmt: %w", cerr)
+		}
+	}
+	if q.makeMetaSeqBandStmt != nil {
+		if cerr := q.makeMetaSeqBandStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing makeMetaSeqBandStmt: %w", cerr)
+		}
+	}
+	if q.revokeAddressFromLogStmt != nil {
+		if cerr := q.revokeAddressFromLogStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing revokeAddressFromLogStmt: %w", cerr)
+		}
+	}
+	if q.revokeAddressFromLogBatchStmt != nil {
+		if cerr := q.revokeAddressFromLogBatchStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing revokeAddressFromLogBatchStmt: %w", cerr)
+		}
+	}
+	if q.selectAndLockStagedEnvelopesStmt != nil {
+		if cerr := q.selectAndLockStagedEnvelopesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectAndLockStagedEnvelopesStmt: %w", cerr)
+		}
+	}
+	if q.selectGatewayEnvelopesByOriginatorsStmt != nil {
+		if cerr := q.selectGatewayEnvelopesByOriginatorsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectGatewayEnvelopesByOriginatorsStmt: %w", cerr)
+		}
+	}
+	if q.selectGatewayEnvelopesByPerTopicCursorsStmt != nil {
+		if cerr := q.selectGatewayEnvelopesByPerTopicCursorsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectGatewayEnvelopesByPerTopicCursorsStmt: %w", cerr)
+		}
+	}
+	if q.selectGatewayEnvelopesBySingleOriginatorStmt != nil {
+		if cerr := q.selectGatewayEnvelopesBySingleOriginatorStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectGatewayEnvelopesBySingleOriginatorStmt: %w", cerr)
+		}
+	}
+	if q.selectGatewayEnvelopesByTopicsStmt != nil {
+		if cerr := q.selectGatewayEnvelopesByTopicsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectGatewayEnvelopesByTopicsStmt: %w", cerr)
+		}
+	}
+	if q.selectGatewayEnvelopesUnfilteredStmt != nil {
+		if cerr := q.selectGatewayEnvelopesUnfilteredStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectGatewayEnvelopesUnfilteredStmt: %w", cerr)
+		}
+	}
+	if q.selectNewestFromTopicsStmt != nil {
+		if cerr := q.selectNewestFromTopicsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectNewestFromTopicsStmt: %w", cerr)
+		}
+	}
+	if q.selectNodeInfoStmt != nil {
+		if cerr := q.selectNodeInfoStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectNodeInfoStmt: %w", cerr)
+		}
+	}
+	if q.selectOriginatorNodeIDsStmt != nil {
+		if cerr := q.selectOriginatorNodeIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectOriginatorNodeIDsStmt: %w", cerr)
+		}
+	}
+	if q.selectStagedOriginatorEnvelopesStmt != nil {
+		if cerr := q.selectStagedOriginatorEnvelopesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectStagedOriginatorEnvelopesStmt: %w", cerr)
+		}
+	}
+	if q.selectVectorClockStmt != nil {
+		if cerr := q.selectVectorClockStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing selectVectorClockStmt: %w", cerr)
+		}
+	}
+	if q.setLatestBlockStmt != nil {
+		if cerr := q.setLatestBlockStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setLatestBlockStmt: %w", cerr)
+		}
+	}
+	if q.setLocalWorkMemStmt != nil {
+		if cerr := q.setLocalWorkMemStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setLocalWorkMemStmt: %w", cerr)
+		}
+	}
+	if q.setReportAttestationStatusStmt != nil {
+		if cerr := q.setReportAttestationStatusStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setReportAttestationStatusStmt: %w", cerr)
+		}
+	}
+	if q.setReportSubmissionStatusStmt != nil {
+		if cerr := q.setReportSubmissionStatusStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setReportSubmissionStatusStmt: %w", cerr)
+		}
+	}
+	if q.setReportSubmittedStmt != nil {
+		if cerr := q.setReportSubmittedStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setReportSubmittedStmt: %w", cerr)
+		}
+	}
+	if q.sumOriginatorCongestionStmt != nil {
+		if cerr := q.sumOriginatorCongestionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing sumOriginatorCongestionStmt: %w", cerr)
+		}
+	}
+	if q.tryAdvisoryLockWithKeyStmt != nil {
+		if cerr := q.tryAdvisoryLockWithKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing tryAdvisoryLockWithKeyStmt: %w", cerr)
+		}
+	}
+	if q.updateMigrationProgressStmt != nil {
+		if cerr := q.updateMigrationProgressStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing updateMigrationProgressStmt: %w", cerr)
+		}
+	}
+	return err
+}
+
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+	switch {
+	case stmt != nil && q.tx != nil:
+		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
+	case stmt != nil:
+		return stmt.ExecContext(ctx, args...)
+	default:
+		return q.db.ExecContext(ctx, query, args...)
+	}
+}
+
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+	switch {
+	case stmt != nil && q.tx != nil:
+		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
+	case stmt != nil:
+		return stmt.QueryContext(ctx, args...)
+	default:
+		return q.db.QueryContext(ctx, query, args...)
+	}
+}
+
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+	switch {
+	case stmt != nil && q.tx != nil:
+		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)
+	case stmt != nil:
+		return stmt.QueryRowContext(ctx, args...)
+	default:
+		return q.db.QueryRowContext(ctx, query, args...)
+	}
+}
+
 type Queries struct {
-	db DBTX
+	db                                           DBTX
+	tx                                           *sql.Tx
+	advisoryLockWithKeyStmt                      *sql.Stmt
+	buildPayerReportStmt                         *sql.Stmt
+	bulkDeleteStagedOriginatorEnvelopesStmt      *sql.Stmt
+	bulkFindOrCreatePayersStmt                   *sql.Stmt
+	clearUnsettledUsageStmt                      *sql.Stmt
+	countExpiredEnvelopesStmt                    *sql.Stmt
+	deleteAvailableNonceStmt                     *sql.Stmt
+	deleteMigrationDeadLetterBoxStmt             *sql.Stmt
+	deleteObsoleteNoncesStmt                     *sql.Stmt
+	ensureGatewayPartsStmt                       *sql.Stmt
+	fetchPayerReportStmt                         *sql.Stmt
+	fetchPayerReportLockedStmt                   *sql.Stmt
+	fetchPayerReportsStmt                        *sql.Stmt
+	fillNonceSequenceStmt                        *sql.Stmt
+	findOrCreatePayerStmt                        *sql.Stmt
+	getAddressLogsStmt                           *sql.Stmt
+	getGatewayEnvelopeByIDStmt                   *sql.Stmt
+	getLastEventStmt                             *sql.Stmt
+	getLastSequenceIDForOriginatorMinuteStmt     *sql.Stmt
+	getLatestBlockStmt                           *sql.Stmt
+	getLatestSequenceIdStmt                      *sql.Stmt
+	getMigrationProgressStmt                     *sql.Stmt
+	getNextAvailableNonceStmt                    *sql.Stmt
+	getPayerBalanceStmt                          *sql.Stmt
+	getPayerByAddressStmt                        *sql.Stmt
+	getPayerInfoReportStmt                       *sql.Stmt
+	getPayerUnsettledUsageStmt                   *sql.Stmt
+	getPrunableCeilingStmt                       *sql.Stmt
+	getRecentOriginatorCongestionStmt            *sql.Stmt
+	getRetryableMigrationDeadLetterBoxesStmt     *sql.Stmt
+	getSecondNewestMinuteStmt                    *sql.Stmt
+	incrementOriginatorCongestionStmt            *sql.Stmt
+	incrementUnsettledUsageStmt                  *sql.Stmt
+	insertAddressLogStmt                         *sql.Stmt
+	insertAddressLogsBatchStmt                   *sql.Stmt
+	insertGatewayEnvelopeStmt                    *sql.Stmt
+	insertGatewayEnvelopeBatchV2Stmt             *sql.Stmt
+	insertMigrationDeadLetterBoxStmt             *sql.Stmt
+	insertNodeInfoStmt                           *sql.Stmt
+	insertOrIgnorePayerReportStmt                *sql.Stmt
+	insertOrIgnorePayerReportAttestationStmt     *sql.Stmt
+	insertPayerLedgerEventStmt                   *sql.Stmt
+	insertSavePointStmt                          *sql.Stmt
+	insertSavePointReleaseStmt                   *sql.Stmt
+	insertSavePointRollbackStmt                  *sql.Stmt
+	insertStagedOriginatorEnvelopeStmt           *sql.Stmt
+	insertStagedOriginatorEnvelopeBatchStmt      *sql.Stmt
+	makeBlobOriginatorPartStmt                   *sql.Stmt
+	makeBlobSeqBandStmt                          *sql.Stmt
+	makeMetaOriginatorPartStmt                   *sql.Stmt
+	makeMetaSeqBandStmt                          *sql.Stmt
+	revokeAddressFromLogStmt                     *sql.Stmt
+	revokeAddressFromLogBatchStmt                *sql.Stmt
+	selectAndLockStagedEnvelopesStmt             *sql.Stmt
+	selectGatewayEnvelopesByOriginatorsStmt      *sql.Stmt
+	selectGatewayEnvelopesByPerTopicCursorsStmt  *sql.Stmt
+	selectGatewayEnvelopesBySingleOriginatorStmt *sql.Stmt
+	selectGatewayEnvelopesByTopicsStmt           *sql.Stmt
+	selectGatewayEnvelopesUnfilteredStmt         *sql.Stmt
+	selectNewestFromTopicsStmt                   *sql.Stmt
+	selectNodeInfoStmt                           *sql.Stmt
+	selectOriginatorNodeIDsStmt                  *sql.Stmt
+	selectStagedOriginatorEnvelopesStmt          *sql.Stmt
+	selectVectorClockStmt                        *sql.Stmt
+	setLatestBlockStmt                           *sql.Stmt
+	setLocalWorkMemStmt                          *sql.Stmt
+	setReportAttestationStatusStmt               *sql.Stmt
+	setReportSubmissionStatusStmt                *sql.Stmt
+	setReportSubmittedStmt                       *sql.Stmt
+	sumOriginatorCongestionStmt                  *sql.Stmt
+	tryAdvisoryLockWithKeyStmt                   *sql.Stmt
+	updateMigrationProgressStmt                  *sql.Stmt
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
-		db: tx,
+		db:                                           tx,
+		tx:                                           tx,
+		advisoryLockWithKeyStmt:                      q.advisoryLockWithKeyStmt,
+		buildPayerReportStmt:                         q.buildPayerReportStmt,
+		bulkDeleteStagedOriginatorEnvelopesStmt:      q.bulkDeleteStagedOriginatorEnvelopesStmt,
+		bulkFindOrCreatePayersStmt:                   q.bulkFindOrCreatePayersStmt,
+		clearUnsettledUsageStmt:                      q.clearUnsettledUsageStmt,
+		countExpiredEnvelopesStmt:                    q.countExpiredEnvelopesStmt,
+		deleteAvailableNonceStmt:                     q.deleteAvailableNonceStmt,
+		deleteMigrationDeadLetterBoxStmt:             q.deleteMigrationDeadLetterBoxStmt,
+		deleteObsoleteNoncesStmt:                     q.deleteObsoleteNoncesStmt,
+		ensureGatewayPartsStmt:                       q.ensureGatewayPartsStmt,
+		fetchPayerReportStmt:                         q.fetchPayerReportStmt,
+		fetchPayerReportLockedStmt:                   q.fetchPayerReportLockedStmt,
+		fetchPayerReportsStmt:                        q.fetchPayerReportsStmt,
+		fillNonceSequenceStmt:                        q.fillNonceSequenceStmt,
+		findOrCreatePayerStmt:                        q.findOrCreatePayerStmt,
+		getAddressLogsStmt:                           q.getAddressLogsStmt,
+		getGatewayEnvelopeByIDStmt:                   q.getGatewayEnvelopeByIDStmt,
+		getLastEventStmt:                             q.getLastEventStmt,
+		getLastSequenceIDForOriginatorMinuteStmt:     q.getLastSequenceIDForOriginatorMinuteStmt,
+		getLatestBlockStmt:                           q.getLatestBlockStmt,
+		getLatestSequenceIdStmt:                      q.getLatestSequenceIdStmt,
+		getMigrationProgressStmt:                     q.getMigrationProgressStmt,
+		getNextAvailableNonceStmt:                    q.getNextAvailableNonceStmt,
+		getPayerBalanceStmt:                          q.getPayerBalanceStmt,
+		getPayerByAddressStmt:                        q.getPayerByAddressStmt,
+		getPayerInfoReportStmt:                       q.getPayerInfoReportStmt,
+		getPayerUnsettledUsageStmt:                   q.getPayerUnsettledUsageStmt,
+		getPrunableCeilingStmt:                       q.getPrunableCeilingStmt,
+		getRecentOriginatorCongestionStmt:            q.getRecentOriginatorCongestionStmt,
+		getRetryableMigrationDeadLetterBoxesStmt:     q.getRetryableMigrationDeadLetterBoxesStmt,
+		getSecondNewestMinuteStmt:                    q.getSecondNewestMinuteStmt,
+		incrementOriginatorCongestionStmt:            q.incrementOriginatorCongestionStmt,
+		incrementUnsettledUsageStmt:                  q.incrementUnsettledUsageStmt,
+		insertAddressLogStmt:                         q.insertAddressLogStmt,
+		insertAddressLogsBatchStmt:                   q.insertAddressLogsBatchStmt,
+		insertGatewayEnvelopeStmt:                    q.insertGatewayEnvelopeStmt,
+		insertGatewayEnvelopeBatchV2Stmt:             q.insertGatewayEnvelopeBatchV2Stmt,
+		insertMigrationDeadLetterBoxStmt:             q.insertMigrationDeadLetterBoxStmt,
+		insertNodeInfoStmt:                           q.insertNodeInfoStmt,
+		insertOrIgnorePayerReportStmt:                q.insertOrIgnorePayerReportStmt,
+		insertOrIgnorePayerReportAttestationStmt:     q.insertOrIgnorePayerReportAttestationStmt,
+		insertPayerLedgerEventStmt:                   q.insertPayerLedgerEventStmt,
+		insertSavePointStmt:                          q.insertSavePointStmt,
+		insertSavePointReleaseStmt:                   q.insertSavePointReleaseStmt,
+		insertSavePointRollbackStmt:                  q.insertSavePointRollbackStmt,
+		insertStagedOriginatorEnvelopeStmt:           q.insertStagedOriginatorEnvelopeStmt,
+		insertStagedOriginatorEnvelopeBatchStmt:      q.insertStagedOriginatorEnvelopeBatchStmt,
+		makeBlobOriginatorPartStmt:                   q.makeBlobOriginatorPartStmt,
+		makeBlobSeqBandStmt:                          q.makeBlobSeqBandStmt,
+		makeMetaOriginatorPartStmt:                   q.makeMetaOriginatorPartStmt,
+		makeMetaSeqBandStmt:                          q.makeMetaSeqBandStmt,
+		revokeAddressFromLogStmt:                     q.revokeAddressFromLogStmt,
+		revokeAddressFromLogBatchStmt:                q.revokeAddressFromLogBatchStmt,
+		selectAndLockStagedEnvelopesStmt:             q.selectAndLockStagedEnvelopesStmt,
+		selectGatewayEnvelopesByOriginatorsStmt:      q.selectGatewayEnvelopesByOriginatorsStmt,
+		selectGatewayEnvelopesByPerTopicCursorsStmt:  q.selectGatewayEnvelopesByPerTopicCursorsStmt,
+		selectGatewayEnvelopesBySingleOriginatorStmt: q.selectGatewayEnvelopesBySingleOriginatorStmt,
+		selectGatewayEnvelopesByTopicsStmt:           q.selectGatewayEnvelopesByTopicsStmt,
+		selectGatewayEnvelopesUnfilteredStmt:         q.selectGatewayEnvelopesUnfilteredStmt,
+		selectNewestFromTopicsStmt:                   q.selectNewestFromTopicsStmt,
+		selectNodeInfoStmt:                           q.selectNodeInfoStmt,
+		selectOriginatorNodeIDsStmt:                  q.selectOriginatorNodeIDsStmt,
+		selectStagedOriginatorEnvelopesStmt:          q.selectStagedOriginatorEnvelopesStmt,
+		selectVectorClockStmt:                        q.selectVectorClockStmt,
+		setLatestBlockStmt:                           q.setLatestBlockStmt,
+		setLocalWorkMemStmt:                          q.setLocalWorkMemStmt,
+		setReportAttestationStatusStmt:               q.setReportAttestationStatusStmt,
+		setReportSubmissionStatusStmt:                q.setReportSubmissionStatusStmt,
+		setReportSubmittedStmt:                       q.setReportSubmittedStmt,
+		sumOriginatorCongestionStmt:                  q.sumOriginatorCongestionStmt,
+		tryAdvisoryLockWithKeyStmt:                   q.tryAdvisoryLockWithKeyStmt,
+		updateMigrationProgressStmt:                  q.updateMigrationProgressStmt,
 	}
 }

--- a/pkg/db/queries/envelopes.sql.go
+++ b/pkg/db/queries/envelopes.sql.go
@@ -17,7 +17,7 @@ DELETE FROM staged_originator_envelopes WHERE id = ANY($1::BIGINT[])
 `
 
 func (q *Queries) BulkDeleteStagedOriginatorEnvelopes(ctx context.Context, ids []int64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, bulkDeleteStagedOriginatorEnvelopes, pq.Array(ids))
+	result, err := q.exec(ctx, q.bulkDeleteStagedOriginatorEnvelopesStmt, bulkDeleteStagedOriginatorEnvelopes, pq.Array(ids))
 	if err != nil {
 		return 0, err
 	}
@@ -33,7 +33,7 @@ SELECT COALESCE((
 `
 
 func (q *Queries) GetLatestSequenceId(ctx context.Context, originatorNodeID int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getLatestSequenceId, originatorNodeID)
+	row := q.queryRow(ctx, q.getLatestSequenceIdStmt, getLatestSequenceId, originatorNodeID)
 	var originator_sequence_id int64
 	err := row.Scan(&originator_sequence_id)
 	return originator_sequence_id, err
@@ -50,7 +50,7 @@ type InsertStagedOriginatorEnvelopeParams struct {
 }
 
 func (q *Queries) InsertStagedOriginatorEnvelope(ctx context.Context, arg InsertStagedOriginatorEnvelopeParams) (StagedOriginatorEnvelope, error) {
-	row := q.db.QueryRowContext(ctx, insertStagedOriginatorEnvelope, arg.Topic, arg.PayerEnvelope)
+	row := q.queryRow(ctx, q.insertStagedOriginatorEnvelopeStmt, insertStagedOriginatorEnvelope, arg.Topic, arg.PayerEnvelope)
 	var i StagedOriginatorEnvelope
 	err := row.Scan(
 		&i.ID,
@@ -86,7 +86,7 @@ type InsertStagedOriginatorEnvelopeBatchRow struct {
 }
 
 func (q *Queries) InsertStagedOriginatorEnvelopeBatch(ctx context.Context, arg InsertStagedOriginatorEnvelopeBatchParams) ([]InsertStagedOriginatorEnvelopeBatchRow, error) {
-	rows, err := q.db.QueryContext(ctx, insertStagedOriginatorEnvelopeBatch, pq.Array(arg.Topics), pq.Array(arg.PayerEnvelopes))
+	rows, err := q.query(ctx, q.insertStagedOriginatorEnvelopeBatchStmt, insertStagedOriginatorEnvelopeBatch, pq.Array(arg.Topics), pq.Array(arg.PayerEnvelopes))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ FOR UPDATE
 `
 
 func (q *Queries) SelectAndLockStagedEnvelopes(ctx context.Context, numRows int32) ([]StagedOriginatorEnvelope, error) {
-	rows, err := q.db.QueryContext(ctx, selectAndLockStagedEnvelopes, numRows)
+	rows, err := q.query(ctx, q.selectAndLockStagedEnvelopesStmt, selectAndLockStagedEnvelopes, numRows)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ ORDER BY originator_node_id
 `
 
 func (q *Queries) SelectOriginatorNodeIDs(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, selectOriginatorNodeIDs)
+	rows, err := q.query(ctx, q.selectOriginatorNodeIDsStmt, selectOriginatorNodeIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ type SelectStagedOriginatorEnvelopesParams struct {
 }
 
 func (q *Queries) SelectStagedOriginatorEnvelopes(ctx context.Context, arg SelectStagedOriginatorEnvelopesParams) ([]StagedOriginatorEnvelope, error) {
-	rows, err := q.db.QueryContext(ctx, selectStagedOriginatorEnvelopes, arg.LastSeenID, arg.NumRows)
+	rows, err := q.query(ctx, q.selectStagedOriginatorEnvelopesStmt, selectStagedOriginatorEnvelopes, arg.LastSeenID, arg.NumRows)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ ORDER BY originator_node_id
 `
 
 func (q *Queries) SelectVectorClock(ctx context.Context) ([]GatewayEnvelopesLatest, error) {
-	rows, err := q.db.QueryContext(ctx, selectVectorClock)
+	rows, err := q.query(ctx, q.selectVectorClockStmt, selectVectorClock)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/queries/envelopes_v2.sql.go
+++ b/pkg/db/queries/envelopes_v2.sql.go
@@ -64,7 +64,7 @@ type InsertGatewayEnvelopeRow struct {
 }
 
 func (q *Queries) InsertGatewayEnvelope(ctx context.Context, arg InsertGatewayEnvelopeParams) (InsertGatewayEnvelopeRow, error) {
-	row := q.db.QueryRowContext(ctx, insertGatewayEnvelope,
+	row := q.queryRow(ctx, q.insertGatewayEnvelopeStmt, insertGatewayEnvelope,
 		arg.OriginatorNodeID,
 		arg.OriginatorSequenceID,
 		arg.Topic,
@@ -119,7 +119,7 @@ type InsertGatewayEnvelopeBatchV2Row struct {
 }
 
 func (q *Queries) InsertGatewayEnvelopeBatchV2(ctx context.Context, arg InsertGatewayEnvelopeBatchV2Params) (InsertGatewayEnvelopeBatchV2Row, error) {
-	row := q.db.QueryRowContext(ctx, insertGatewayEnvelopeBatchV2,
+	row := q.queryRow(ctx, q.insertGatewayEnvelopeBatchV2Stmt, insertGatewayEnvelopeBatchV2,
 		pq.Array(arg.OriginatorNodeIds),
 		pq.Array(arg.OriginatorSequenceIds),
 		pq.Array(arg.Topics),
@@ -209,7 +209,7 @@ type SelectGatewayEnvelopesByOriginatorsRow struct {
 // LATERAL per originator with per-originator blob join.
 // Requires callers to include all desired originators in cursor arrays (use seq_id=0 for unseen).
 func (q *Queries) SelectGatewayEnvelopesByOriginators(ctx context.Context, arg SelectGatewayEnvelopesByOriginatorsParams) ([]SelectGatewayEnvelopesByOriginatorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, selectGatewayEnvelopesByOriginators, pq.Array(arg.CursorNodeIds), pq.Array(arg.CursorSequenceIds), arg.RowLimit)
+	rows, err := q.query(ctx, q.selectGatewayEnvelopesByOriginatorsStmt, selectGatewayEnvelopesByOriginators, pq.Array(arg.CursorNodeIds), pq.Array(arg.CursorSequenceIds), arg.RowLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ type SelectGatewayEnvelopesByPerTopicCursorsRow struct {
 // instead of CROSS JOINing topics × cursors.
 // Uses gem_topic_orig_seq_idx for index-only scans.
 func (q *Queries) SelectGatewayEnvelopesByPerTopicCursors(ctx context.Context, arg SelectGatewayEnvelopesByPerTopicCursorsParams) ([]SelectGatewayEnvelopesByPerTopicCursorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, selectGatewayEnvelopesByPerTopicCursors,
+	rows, err := q.query(ctx, q.selectGatewayEnvelopesByPerTopicCursorsStmt, selectGatewayEnvelopesByPerTopicCursors,
 		pq.Array(arg.CursorTopics),
 		pq.Array(arg.CursorNodeIds),
 		pq.Array(arg.CursorSequenceIds),
@@ -376,7 +376,7 @@ type SelectGatewayEnvelopesBySingleOriginatorRow struct {
 
 // Optimized query for a single originator - uses direct index scan
 func (q *Queries) SelectGatewayEnvelopesBySingleOriginator(ctx context.Context, arg SelectGatewayEnvelopesBySingleOriginatorParams) ([]SelectGatewayEnvelopesBySingleOriginatorRow, error) {
-	rows, err := q.db.QueryContext(ctx, selectGatewayEnvelopesBySingleOriginator, arg.OriginatorNodeID, arg.CursorSequenceID, arg.RowLimit)
+	rows, err := q.query(ctx, q.selectGatewayEnvelopesBySingleOriginatorStmt, selectGatewayEnvelopesBySingleOriginator, arg.OriginatorNodeID, arg.CursorSequenceID, arg.RowLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ type SelectGatewayEnvelopesByTopicsRow struct {
 // Uses gem_topic_orig_seq_idx for index-only scans.
 // row_limit is required and caps total rows returned.
 func (q *Queries) SelectGatewayEnvelopesByTopics(ctx context.Context, arg SelectGatewayEnvelopesByTopicsParams) ([]SelectGatewayEnvelopesByTopicsRow, error) {
-	rows, err := q.db.QueryContext(ctx, selectGatewayEnvelopesByTopics,
+	rows, err := q.query(ctx, q.selectGatewayEnvelopesByTopicsStmt, selectGatewayEnvelopesByTopics,
 		pq.Array(arg.CursorNodeIds),
 		pq.Array(arg.CursorSequenceIds),
 		pq.Array(arg.Topics),
@@ -540,7 +540,7 @@ type SelectGatewayEnvelopesUnfilteredParams struct {
 }
 
 func (q *Queries) SelectGatewayEnvelopesUnfiltered(ctx context.Context, arg SelectGatewayEnvelopesUnfilteredParams) ([]GatewayEnvelopesView, error) {
-	rows, err := q.db.QueryContext(ctx, selectGatewayEnvelopesUnfiltered, arg.RowLimit, pq.Array(arg.CursorNodeIds), pq.Array(arg.CursorSequenceIds))
+	rows, err := q.query(ctx, q.selectGatewayEnvelopesUnfilteredStmt, selectGatewayEnvelopesUnfiltered, arg.RowLimit, pq.Array(arg.CursorNodeIds), pq.Array(arg.CursorSequenceIds))
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +598,7 @@ type SelectNewestFromTopicsRow struct {
 
 // TODO(mkysel) -- sorting by gateway time can lead to wrong results, this query needs to be redone
 func (q *Queries) SelectNewestFromTopics(ctx context.Context, topics [][]byte) ([]SelectNewestFromTopicsRow, error) {
-	rows, err := q.db.QueryContext(ctx, selectNewestFromTopics, pq.Array(topics))
+	rows, err := q.query(ctx, q.selectNewestFromTopicsStmt, selectNewestFromTopics, pq.Array(topics))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/queries/identity_updates.sql.go
+++ b/pkg/db/queries/identity_updates.sql.go
@@ -40,7 +40,7 @@ type GetAddressLogsRow struct {
 }
 
 func (q *Queries) GetAddressLogs(ctx context.Context, addresses []string) ([]GetAddressLogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAddressLogs, pq.Array(addresses))
+	rows, err := q.query(ctx, q.getAddressLogsStmt, getAddressLogs, pq.Array(addresses))
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ type InsertAddressLogParams struct {
 }
 
 func (q *Queries) InsertAddressLog(ctx context.Context, arg InsertAddressLogParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, insertAddressLog, arg.Address, arg.InboxID, arg.AssociationSequenceID)
+	result, err := q.exec(ctx, q.insertAddressLogStmt, insertAddressLog, arg.Address, arg.InboxID, arg.AssociationSequenceID)
 	if err != nil {
 		return 0, err
 	}
@@ -112,7 +112,7 @@ type InsertAddressLogsBatchParams struct {
 }
 
 func (q *Queries) InsertAddressLogsBatch(ctx context.Context, arg InsertAddressLogsBatchParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, insertAddressLogsBatch, pq.Array(arg.Addresses), arg.InboxID, arg.AssociationSequenceID)
+	result, err := q.exec(ctx, q.insertAddressLogsBatchStmt, insertAddressLogsBatch, pq.Array(arg.Addresses), arg.InboxID, arg.AssociationSequenceID)
 	if err != nil {
 		return 0, err
 	}
@@ -136,7 +136,7 @@ type RevokeAddressFromLogParams struct {
 }
 
 func (q *Queries) RevokeAddressFromLog(ctx context.Context, arg RevokeAddressFromLogParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, revokeAddressFromLog, arg.RevocationSequenceID, arg.Address, arg.InboxID)
+	result, err := q.exec(ctx, q.revokeAddressFromLogStmt, revokeAddressFromLog, arg.RevocationSequenceID, arg.Address, arg.InboxID)
 	if err != nil {
 		return 0, err
 	}
@@ -163,7 +163,7 @@ type RevokeAddressFromLogBatchParams struct {
 }
 
 func (q *Queries) RevokeAddressFromLogBatch(ctx context.Context, arg RevokeAddressFromLogBatchParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, revokeAddressFromLogBatch, pq.Array(arg.Addresses), arg.InboxID, arg.RevocationSequenceID)
+	result, err := q.exec(ctx, q.revokeAddressFromLogBatchStmt, revokeAddressFromLogBatch, pq.Array(arg.Addresses), arg.InboxID, arg.RevocationSequenceID)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/db/queries/indexer.sql.go
+++ b/pkg/db/queries/indexer.sql.go
@@ -25,7 +25,7 @@ type GetLatestBlockRow struct {
 }
 
 func (q *Queries) GetLatestBlock(ctx context.Context, contractAddress string) (GetLatestBlockRow, error) {
-	row := q.db.QueryRowContext(ctx, getLatestBlock, contractAddress)
+	row := q.queryRow(ctx, q.getLatestBlockStmt, getLatestBlock, contractAddress)
 	var i GetLatestBlockRow
 	err := row.Scan(&i.BlockNumber, &i.BlockHash)
 	return i, err
@@ -49,6 +49,6 @@ type SetLatestBlockParams struct {
 }
 
 func (q *Queries) SetLatestBlock(ctx context.Context, arg SetLatestBlockParams) error {
-	_, err := q.db.ExecContext(ctx, setLatestBlock, arg.ContractAddress, arg.BlockNumber, arg.BlockHash)
+	_, err := q.exec(ctx, q.setLatestBlockStmt, setLatestBlock, arg.ContractAddress, arg.BlockNumber, arg.BlockHash)
 	return err
 }

--- a/pkg/db/queries/ledger.sql.go
+++ b/pkg/db/queries/ledger.sql.go
@@ -24,7 +24,7 @@ type GetLastEventParams struct {
 }
 
 func (q *Queries) GetLastEvent(ctx context.Context, arg GetLastEventParams) (PayerLedgerEvent, error) {
-	row := q.db.QueryRowContext(ctx, getLastEvent, arg.PayerID, arg.EventType)
+	row := q.queryRow(ctx, q.getLastEventStmt, getLastEvent, arg.PayerID, arg.EventType)
 	var i PayerLedgerEvent
 	err := row.Scan(
 		&i.EventID,
@@ -43,7 +43,7 @@ WHERE payer_id = $1
 `
 
 func (q *Queries) GetPayerBalance(ctx context.Context, payerID int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getPayerBalance, payerID)
+	row := q.queryRow(ctx, q.getPayerBalanceStmt, getPayerBalance, payerID)
 	var balance int64
 	err := row.Scan(&balance)
 	return balance, err
@@ -72,7 +72,7 @@ type InsertPayerLedgerEventParams struct {
 }
 
 func (q *Queries) InsertPayerLedgerEvent(ctx context.Context, arg InsertPayerLedgerEventParams) error {
-	_, err := q.db.ExecContext(ctx, insertPayerLedgerEvent,
+	_, err := q.exec(ctx, q.insertPayerLedgerEventStmt, insertPayerLedgerEvent,
 		arg.EventID,
 		arg.PayerID,
 		arg.AmountPicodollars,

--- a/pkg/db/queries/migrator.sql.go
+++ b/pkg/db/queries/migrator.sql.go
@@ -19,7 +19,7 @@ type DeleteMigrationDeadLetterBoxParams struct {
 }
 
 func (q *Queries) DeleteMigrationDeadLetterBox(ctx context.Context, arg DeleteMigrationDeadLetterBoxParams) (bool, error) {
-	row := q.db.QueryRowContext(ctx, deleteMigrationDeadLetterBox, arg.SourceTable, arg.SequenceID)
+	row := q.queryRow(ctx, q.deleteMigrationDeadLetterBoxStmt, deleteMigrationDeadLetterBox, arg.SourceTable, arg.SequenceID)
 	var delete_migration_dead_letter_box bool
 	err := row.Scan(&delete_migration_dead_letter_box)
 	return delete_migration_dead_letter_box, err
@@ -34,7 +34,7 @@ WHERE source_table = $1
 
 // Migration Tracker Operations
 func (q *Queries) GetMigrationProgress(ctx context.Context, sourceTable string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getMigrationProgress, sourceTable)
+	row := q.queryRow(ctx, q.getMigrationProgressStmt, getMigrationProgress, sourceTable)
 	var last_migrated_id int64
 	err := row.Scan(&last_migrated_id)
 	return last_migrated_id, err
@@ -49,7 +49,7 @@ LIMIT $1
 `
 
 func (q *Queries) GetRetryableMigrationDeadLetterBoxes(ctx context.Context, rowLimit int32) ([]MigrationDeadLetterBox, error) {
-	rows, err := q.db.QueryContext(ctx, getRetryableMigrationDeadLetterBoxes, rowLimit)
+	rows, err := q.query(ctx, q.getRetryableMigrationDeadLetterBoxesStmt, getRetryableMigrationDeadLetterBoxes, rowLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ type InsertMigrationDeadLetterBoxParams struct {
 }
 
 func (q *Queries) InsertMigrationDeadLetterBox(ctx context.Context, arg InsertMigrationDeadLetterBoxParams) (MigrationDeadLetterBox, error) {
-	row := q.db.QueryRowContext(ctx, insertMigrationDeadLetterBox,
+	row := q.queryRow(ctx, q.insertMigrationDeadLetterBoxStmt, insertMigrationDeadLetterBox,
 		arg.SourceTable,
 		arg.SequenceID,
 		arg.Payload,
@@ -126,6 +126,6 @@ type UpdateMigrationProgressParams struct {
 }
 
 func (q *Queries) UpdateMigrationProgress(ctx context.Context, arg UpdateMigrationProgressParams) error {
-	_, err := q.db.ExecContext(ctx, updateMigrationProgress, arg.LastMigratedID, arg.SourceTable)
+	_, err := q.exec(ctx, q.updateMigrationProgressStmt, updateMigrationProgress, arg.LastMigratedID, arg.SourceTable)
 	return err
 }

--- a/pkg/db/queries/node.sql.go
+++ b/pkg/db/queries/node.sql.go
@@ -22,7 +22,7 @@ type InsertNodeInfoParams struct {
 }
 
 func (q *Queries) InsertNodeInfo(ctx context.Context, arg InsertNodeInfoParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, insertNodeInfo, arg.NodeID, arg.PublicKey)
+	result, err := q.exec(ctx, q.insertNodeInfoStmt, insertNodeInfo, arg.NodeID, arg.PublicKey)
 	if err != nil {
 		return 0, err
 	}
@@ -39,7 +39,7 @@ WHERE
 `
 
 func (q *Queries) SelectNodeInfo(ctx context.Context) (NodeInfo, error) {
-	row := q.db.QueryRowContext(ctx, selectNodeInfo)
+	row := q.queryRow(ctx, q.selectNodeInfoStmt, selectNodeInfo)
 	var i NodeInfo
 	err := row.Scan(&i.NodeID, &i.PublicKey, &i.SingletonID)
 	return i, err

--- a/pkg/db/queries/nonce_manager.sql.go
+++ b/pkg/db/queries/nonce_manager.sql.go
@@ -15,7 +15,7 @@ WHERE nonce = $1
 `
 
 func (q *Queries) DeleteAvailableNonce(ctx context.Context, nonce int64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteAvailableNonce, nonce)
+	result, err := q.exec(ctx, q.deleteAvailableNonceStmt, deleteAvailableNonce, nonce)
 	if err != nil {
 		return 0, err
 	}
@@ -37,7 +37,7 @@ WHERE nonce_table.nonce = deletable.nonce
 `
 
 func (q *Queries) DeleteObsoleteNonces(ctx context.Context, nonce int64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteObsoleteNonces, nonce)
+	result, err := q.exec(ctx, q.deleteObsoleteNoncesStmt, deleteObsoleteNonces, nonce)
 	if err != nil {
 		return 0, err
 	}
@@ -57,7 +57,7 @@ type FillNonceSequenceParams struct {
 }
 
 func (q *Queries) FillNonceSequence(ctx context.Context, arg FillNonceSequenceParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, fillNonceSequence, arg.PendingNonce, arg.NumElements)
+	row := q.queryRow(ctx, q.fillNonceSequenceStmt, fillNonceSequence, arg.PendingNonce, arg.NumElements)
 	var inserted_rows int32
 	err := row.Scan(&inserted_rows)
 	return inserted_rows, err
@@ -72,7 +72,7 @@ UPDATE SKIP LOCKED
 `
 
 func (q *Queries) GetNextAvailableNonce(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getNextAvailableNonce)
+	row := q.queryRow(ctx, q.getNextAvailableNonceStmt, getNextAvailableNonce)
 	var nonce int64
 	err := row.Scan(&nonce)
 	return nonce, err

--- a/pkg/db/queries/partitions.sql.go
+++ b/pkg/db/queries/partitions.sql.go
@@ -24,7 +24,7 @@ type EnsureGatewayPartsParams struct {
 }
 
 func (q *Queries) EnsureGatewayParts(ctx context.Context, arg EnsureGatewayPartsParams) error {
-	_, err := q.db.ExecContext(ctx, ensureGatewayParts, arg.OriginatorNodeID, arg.OriginatorSequenceID, arg.BandWidth)
+	_, err := q.exec(ctx, q.ensureGatewayPartsStmt, ensureGatewayParts, arg.OriginatorNodeID, arg.OriginatorSequenceID, arg.BandWidth)
 	return err
 }
 
@@ -33,7 +33,7 @@ SAVEPOINT sp_part
 `
 
 func (q *Queries) InsertSavePoint(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, insertSavePoint)
+	_, err := q.exec(ctx, q.insertSavePointStmt, insertSavePoint)
 	return err
 }
 
@@ -42,7 +42,7 @@ RELEASE SAVEPOINT sp_part
 `
 
 func (q *Queries) InsertSavePointRelease(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, insertSavePointRelease)
+	_, err := q.exec(ctx, q.insertSavePointReleaseStmt, insertSavePointRelease)
 	return err
 }
 
@@ -51,7 +51,7 @@ ROLLBACK TO SAVEPOINT sp_part
 `
 
 func (q *Queries) InsertSavePointRollback(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, insertSavePointRollback)
+	_, err := q.exec(ctx, q.insertSavePointRollbackStmt, insertSavePointRollback)
 	return err
 }
 
@@ -60,7 +60,7 @@ SELECT make_blob_originator_part_v2($1)
 `
 
 func (q *Queries) MakeBlobOriginatorPart(ctx context.Context, originatorNodeID int32) error {
-	_, err := q.db.ExecContext(ctx, makeBlobOriginatorPart, originatorNodeID)
+	_, err := q.exec(ctx, q.makeBlobOriginatorPartStmt, makeBlobOriginatorPart, originatorNodeID)
 	return err
 }
 
@@ -75,7 +75,7 @@ type MakeBlobSeqBandParams struct {
 }
 
 func (q *Queries) MakeBlobSeqBand(ctx context.Context, arg MakeBlobSeqBandParams) error {
-	_, err := q.db.ExecContext(ctx, makeBlobSeqBand, arg.OriginatorNodeID, arg.BandStart, arg.BandEnd)
+	_, err := q.exec(ctx, q.makeBlobSeqBandStmt, makeBlobSeqBand, arg.OriginatorNodeID, arg.BandStart, arg.BandEnd)
 	return err
 }
 
@@ -84,7 +84,7 @@ SELECT make_meta_originator_part_v2($1)
 `
 
 func (q *Queries) MakeMetaOriginatorPart(ctx context.Context, originatorNodeID int32) error {
-	_, err := q.db.ExecContext(ctx, makeMetaOriginatorPart, originatorNodeID)
+	_, err := q.exec(ctx, q.makeMetaOriginatorPartStmt, makeMetaOriginatorPart, originatorNodeID)
 	return err
 }
 
@@ -99,6 +99,6 @@ type MakeMetaSeqBandParams struct {
 }
 
 func (q *Queries) MakeMetaSeqBand(ctx context.Context, arg MakeMetaSeqBandParams) error {
-	_, err := q.db.ExecContext(ctx, makeMetaSeqBand, arg.OriginatorNodeID, arg.BandStart, arg.BandEnd)
+	_, err := q.exec(ctx, q.makeMetaSeqBandStmt, makeMetaSeqBand, arg.OriginatorNodeID, arg.BandStart, arg.BandEnd)
 	return err
 }

--- a/pkg/db/queries/payer_reports.sql.go
+++ b/pkg/db/queries/payer_reports.sql.go
@@ -35,7 +35,7 @@ type BuildPayerReportRow struct {
 }
 
 func (q *Queries) BuildPayerReport(ctx context.Context, arg BuildPayerReportParams) ([]BuildPayerReportRow, error) {
-	rows, err := q.db.QueryContext(ctx, buildPayerReport, arg.OriginatorID, arg.StartMinutesSinceEpoch, arg.EndMinutesSinceEpoch)
+	rows, err := q.query(ctx, q.buildPayerReportStmt, buildPayerReport, arg.OriginatorID, arg.StartMinutesSinceEpoch, arg.EndMinutesSinceEpoch)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ type BulkFindOrCreatePayersRow struct {
 }
 
 func (q *Queries) BulkFindOrCreatePayers(ctx context.Context, addresses []string) ([]BulkFindOrCreatePayersRow, error) {
-	rows, err := q.db.QueryContext(ctx, bulkFindOrCreatePayers, pq.Array(addresses))
+	rows, err := q.query(ctx, q.bulkFindOrCreatePayersStmt, bulkFindOrCreatePayers, pq.Array(addresses))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ type ClearUnsettledUsageParams struct {
 }
 
 func (q *Queries) ClearUnsettledUsage(ctx context.Context, arg ClearUnsettledUsageParams) error {
-	_, err := q.db.ExecContext(ctx, clearUnsettledUsage, arg.OriginatorID, arg.PrevReportEndMinuteSinceEpoch, arg.EndMinuteSinceEpoch)
+	_, err := q.exec(ctx, q.clearUnsettledUsageStmt, clearUnsettledUsage, arg.OriginatorID, arg.PrevReportEndMinuteSinceEpoch, arg.EndMinuteSinceEpoch)
 	return err
 }
 
@@ -129,7 +129,7 @@ WHERE id = $1
 `
 
 func (q *Queries) FetchPayerReport(ctx context.Context, id []byte) (PayerReport, error) {
-	row := q.db.QueryRowContext(ctx, fetchPayerReport, id)
+	row := q.queryRow(ctx, q.fetchPayerReportStmt, fetchPayerReport, id)
 	var i PayerReport
 	err := row.Scan(
 		&i.ID,
@@ -155,7 +155,7 @@ FOR UPDATE
 `
 
 func (q *Queries) FetchPayerReportLocked(ctx context.Context, id []byte) (PayerReport, error) {
-	row := q.db.QueryRowContext(ctx, fetchPayerReportLocked, id)
+	row := q.queryRow(ctx, q.fetchPayerReportLockedStmt, fetchPayerReportLocked, id)
 	var i PayerReport
 	err := row.Scan(
 		&i.ID,
@@ -246,7 +246,7 @@ type FetchPayerReportsRow struct {
 }
 
 func (q *Queries) FetchPayerReports(ctx context.Context, arg FetchPayerReportsParams) ([]FetchPayerReportsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchPayerReports,
+	rows, err := q.query(ctx, q.fetchPayerReportsStmt, fetchPayerReports,
 		arg.MinAttestations,
 		pq.Array(arg.AttestationStatusIn),
 		pq.Array(arg.SubmissionStatusIn),
@@ -309,7 +309,7 @@ LIMIT 1
 `
 
 func (q *Queries) FindOrCreatePayer(ctx context.Context, address string) (int32, error) {
-	row := q.db.QueryRowContext(ctx, findOrCreatePayer, address)
+	row := q.queryRow(ctx, q.findOrCreatePayerStmt, findOrCreatePayer, address)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -328,7 +328,7 @@ type GetGatewayEnvelopeByIDParams struct {
 }
 
 func (q *Queries) GetGatewayEnvelopeByID(ctx context.Context, arg GetGatewayEnvelopeByIDParams) (GatewayEnvelopesView, error) {
-	row := q.db.QueryRowContext(ctx, getGatewayEnvelopeByID, arg.OriginatorSequenceID, arg.OriginatorNodeID)
+	row := q.queryRow(ctx, q.getGatewayEnvelopeByIDStmt, getGatewayEnvelopeByID, arg.OriginatorSequenceID, arg.OriginatorNodeID)
 	var i GatewayEnvelopesView
 	err := row.Scan(
 		&i.OriginatorNodeID,
@@ -353,7 +353,7 @@ type GetLastSequenceIDForOriginatorMinuteParams struct {
 }
 
 func (q *Queries) GetLastSequenceIDForOriginatorMinute(ctx context.Context, arg GetLastSequenceIDForOriginatorMinuteParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getLastSequenceIDForOriginatorMinute, arg.OriginatorID, arg.MinutesSinceEpoch)
+	row := q.queryRow(ctx, q.getLastSequenceIDForOriginatorMinuteStmt, getLastSequenceIDForOriginatorMinute, arg.OriginatorID, arg.MinutesSinceEpoch)
 	var last_sequence_id int64
 	err := row.Scan(&last_sequence_id)
 	return last_sequence_id, err
@@ -366,7 +366,7 @@ WHERE address = $1
 `
 
 func (q *Queries) GetPayerByAddress(ctx context.Context, address string) (int32, error) {
-	row := q.db.QueryRowContext(ctx, getPayerByAddress, address)
+	row := q.queryRow(ctx, q.getPayerByAddressStmt, getPayerByAddress, address)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -403,7 +403,7 @@ type GetPayerInfoReportRow struct {
 }
 
 func (q *Queries) GetPayerInfoReport(ctx context.Context, arg GetPayerInfoReportParams) ([]GetPayerInfoReportRow, error) {
-	rows, err := q.db.QueryContext(ctx, getPayerInfoReport, arg.GroupBy, arg.PayerID)
+	rows, err := q.query(ctx, q.getPayerInfoReportStmt, getPayerInfoReport, arg.GroupBy, arg.PayerID)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +452,7 @@ type GetPayerUnsettledUsageRow struct {
 }
 
 func (q *Queries) GetPayerUnsettledUsage(ctx context.Context, arg GetPayerUnsettledUsageParams) (GetPayerUnsettledUsageRow, error) {
-	row := q.db.QueryRowContext(ctx, getPayerUnsettledUsage, arg.PayerID, arg.MinutesSinceEpochGt, arg.MinutesSinceEpochLt)
+	row := q.queryRow(ctx, q.getPayerUnsettledUsageStmt, getPayerUnsettledUsage, arg.PayerID, arg.MinutesSinceEpochGt, arg.MinutesSinceEpochLt)
 	var i GetPayerUnsettledUsageRow
 	err := row.Scan(&i.TotalSpendPicodollars, &i.LastSequenceID)
 	return i, err
@@ -486,7 +486,7 @@ type GetSecondNewestMinuteRow struct {
 }
 
 func (q *Queries) GetSecondNewestMinute(ctx context.Context, arg GetSecondNewestMinuteParams) (GetSecondNewestMinuteRow, error) {
-	row := q.db.QueryRowContext(ctx, getSecondNewestMinute, arg.OriginatorID, arg.MinimumMinutesSinceEpoch)
+	row := q.queryRow(ctx, q.getSecondNewestMinuteStmt, getSecondNewestMinute, arg.OriginatorID, arg.MinimumMinutesSinceEpoch)
 	var i GetSecondNewestMinuteRow
 	err := row.Scan(&i.MaxSequenceID, &i.MinutesSinceEpoch)
 	return i, err
@@ -525,7 +525,7 @@ type IncrementUnsettledUsageParams struct {
 }
 
 func (q *Queries) IncrementUnsettledUsage(ctx context.Context, arg IncrementUnsettledUsageParams) error {
-	_, err := q.db.ExecContext(ctx, incrementUnsettledUsage,
+	_, err := q.exec(ctx, q.incrementUnsettledUsageStmt, incrementUnsettledUsage,
 		arg.PayerID,
 		arg.OriginatorID,
 		arg.MinutesSinceEpoch,
@@ -568,7 +568,7 @@ type InsertOrIgnorePayerReportParams struct {
 }
 
 func (q *Queries) InsertOrIgnorePayerReport(ctx context.Context, arg InsertOrIgnorePayerReportParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, insertOrIgnorePayerReport,
+	result, err := q.exec(ctx, q.insertOrIgnorePayerReportStmt, insertOrIgnorePayerReport,
 		arg.ID,
 		arg.OriginatorNodeID,
 		arg.StartSequenceID,
@@ -595,7 +595,7 @@ type InsertOrIgnorePayerReportAttestationParams struct {
 }
 
 func (q *Queries) InsertOrIgnorePayerReportAttestation(ctx context.Context, arg InsertOrIgnorePayerReportAttestationParams) error {
-	_, err := q.db.ExecContext(ctx, insertOrIgnorePayerReportAttestation, arg.PayerReportID, arg.NodeID, arg.Signature)
+	_, err := q.exec(ctx, q.insertOrIgnorePayerReportAttestationStmt, insertOrIgnorePayerReportAttestation, arg.PayerReportID, arg.NodeID, arg.Signature)
 	return err
 }
 
@@ -613,7 +613,7 @@ type SetReportAttestationStatusParams struct {
 }
 
 func (q *Queries) SetReportAttestationStatus(ctx context.Context, arg SetReportAttestationStatusParams) error {
-	_, err := q.db.ExecContext(ctx, setReportAttestationStatus, arg.NewStatus, arg.ReportID, pq.Array(arg.PrevStatus))
+	_, err := q.exec(ctx, q.setReportAttestationStatusStmt, setReportAttestationStatus, arg.NewStatus, arg.ReportID, pq.Array(arg.PrevStatus))
 	return err
 }
 
@@ -631,7 +631,7 @@ type SetReportSubmissionStatusParams struct {
 }
 
 func (q *Queries) SetReportSubmissionStatus(ctx context.Context, arg SetReportSubmissionStatusParams) error {
-	_, err := q.db.ExecContext(ctx, setReportSubmissionStatus, arg.NewStatus, arg.ReportID, pq.Array(arg.PrevStatus))
+	_, err := q.exec(ctx, q.setReportSubmissionStatusStmt, setReportSubmissionStatus, arg.NewStatus, arg.ReportID, pq.Array(arg.PrevStatus))
 	return err
 }
 
@@ -651,7 +651,7 @@ type SetReportSubmittedParams struct {
 }
 
 func (q *Queries) SetReportSubmitted(ctx context.Context, arg SetReportSubmittedParams) error {
-	_, err := q.db.ExecContext(ctx, setReportSubmitted,
+	_, err := q.exec(ctx, q.setReportSubmittedStmt, setReportSubmitted,
 		arg.NewStatus,
 		arg.SubmittedReportIndex,
 		arg.ReportID,

--- a/pkg/db/queries/prune.sql.go
+++ b/pkg/db/queries/prune.sql.go
@@ -26,7 +26,7 @@ WHERE ge.expiry IS NOT NULL
 `
 
 func (q *Queries) CountExpiredEnvelopes(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countExpiredEnvelopes)
+	row := q.queryRow(ctx, q.countExpiredEnvelopesStmt, countExpiredEnvelopes)
 	var expired_count int64
 	err := row.Scan(&expired_count)
 	return expired_count, err
@@ -47,7 +47,7 @@ type GetPrunableCeilingRow struct {
 }
 
 func (q *Queries) GetPrunableCeiling(ctx context.Context) ([]GetPrunableCeilingRow, error) {
-	rows, err := q.db.QueryContext(ctx, getPrunableCeiling)
+	rows, err := q.query(ctx, q.getPrunableCeilingStmt, getPrunableCeiling)
 	if err != nil {
 		return nil, err
 	}

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -7,6 +7,7 @@ sql:
       go:
         package: "queries"
         out: "pkg/db/queries"
+        emit_prepared_queries: true
         overrides:
           - column: "blockchain_messages.block_number"
             go_type: "uint64"


### PR DESCRIPTION
TLDR
--
Total benchmarks: 25
Consistent gains: 13
Consistent regressions: 3
Mixed/noisy: 9

Consistent gains
--
BenchmarkSelectGatewayEnvelopesByTopics/rows=1M-14 (avg ~-30.8%)
BenchmarkSelectGatewayEnvelopesBySingleOriginator/rows=1M-14 (avg ~-23.6%)
BenchmarkInsertGatewayEnvelopeBatch/rows=1M-14 (avg ~-20.8%)
BenchmarkGetLastEvent-14 (avg ~-14.9%)
BenchmarkIncrementUnsettledUsage-14 (avg ~-12.6%)
BenchmarkHotPathFullCycle-14 (avg ~-12.5%)
BenchmarkHotPathSelectStaged-14 (avg ~-11.9%)
BenchmarkHotPathInsertStaged-14 (avg ~-9.5%)
BenchmarkHotPathDeleteStaged-14 (avg ~-8.0%)
BenchmarkSelectGatewayEnvelopesUnfiltered/rows=1M-14 (avg ~-7.7%)
BenchmarkSelectNewestFromTopics/rows=1M-14 (avg ~-7.4%)
BenchmarkSelectGatewayEnvelopesByOriginators/rows=1M-14 (avg ~-7.4%)
BenchmarkGetRecentOriginatorCongestion-14 (avg ~-6.9%)

Consistent regressions
--
BenchmarkHotPathBatchCycle/batch=100-14 (avg ~+26.2%)
BenchmarkHotPathBatchCycle/batch=1-14 (avg ~+9.9%)
BenchmarkInsertPayerLedgerEvent-14 (avg ~+44.0%, but driven by a large outlier in POST4)

Mixed/noisy
--
BenchmarkSetLatestBlock-14
BenchmarkSumOriginatorCongestion-14
BenchmarkGetPayerBalance-14
BenchmarkIncrementOriginatorCongestion-14
BenchmarkInsertGatewayEnvelope/rows=1M-14
BenchmarkHotPathBatchCycle/batch=10-14
BenchmarkHotPathInsertGatewayWithUsage-14
BenchmarkHotPathBatchCycle/batch=500-14
BenchmarkGetLatestBlock-14

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prepared query support to database benchmarks via `BENCH_USE_PREPARED` flag
> - Enables `sqlc` prepared query emission (`emit_prepared_queries: true`) and generates `Prepare`, `Close`, and routing helpers (`exec`, `query`, `queryRow`) in [`pkg/db/queries/db.go`](https://github.com/xmtp/xmtpd/pull/1815/files#diff-6f01214a3b19a1a0ac22c30a57abde78d928dc4c2fb8df0a6700c10db665b11e).
> - Adds `BENCH_USE_PREPARED` env var (default `true`) to [`dev/bench`](https://github.com/xmtp/xmtpd/pull/1815/files#diff-603422e67071703f6398e1a82d60eeac5c4b8a23cc6390712121b1007a1977e9) and [`pkg/db/bench/main_test.go`](https://github.com/xmtp/xmtpd/pull/1815/files#diff-f2095268e0de543c1047d2d89076b72d8fe8a13fc5c60d8f02385a11c4e0b3da) to toggle prepared statements at benchmark runtime.
> - Refactors all bench test files to use shared, package-level `*queries.Queries` instances (e.g. `congestionQueries`, `hotPathQueries`) instead of constructing local query objects per benchmark.
> - Behavioral Change: benchmarks now default to prepared statements; set `BENCH_USE_PREPARED=false` to revert to unprepared queries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c40719.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->