### PR TITLE
Fix issue with inconsistent fee calculation

### DIFF
--- a/pkg/db/queries/db.go
+++ b/pkg/db/queries/db.go
@@ -108,6 +108,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getPrunableCeilingStmt, err = db.PrepareContext(ctx, getPrunableCeiling); err != nil {
 		return nil, fmt.Errorf("error preparing query GetPrunableCeiling: %w", err)
 	}
+	if q.getPrunableMetaPartitionsStmt, err = db.PrepareContext(ctx, getPrunableMetaPartitions); err != nil {
+		return nil, fmt.Errorf("error preparing query GetPrunableMetaPartitions: %w", err)
+	}
 	if q.getRecentOriginatorCongestionStmt, err = db.PrepareContext(ctx, getRecentOriginatorCongestion); err != nil {
 		return nil, fmt.Errorf("error preparing query GetRecentOriginatorCongestion: %w", err)
 	}
@@ -383,6 +386,11 @@ func (q *Queries) Close() error {
 	if q.getPrunableCeilingStmt != nil {
 		if cerr := q.getPrunableCeilingStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getPrunableCeilingStmt: %w", cerr)
+		}
+	}
+	if q.getPrunableMetaPartitionsStmt != nil {
+		if cerr := q.getPrunableMetaPartitionsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getPrunableMetaPartitionsStmt: %w", cerr)
 		}
 	}
 	if q.getRecentOriginatorCongestionStmt != nil {
@@ -672,6 +680,7 @@ type Queries struct {
 	getPayerInfoReportStmt                       *sql.Stmt
 	getPayerUnsettledUsageStmt                   *sql.Stmt
 	getPrunableCeilingStmt                       *sql.Stmt
+	getPrunableMetaPartitionsStmt                *sql.Stmt
 	getRecentOriginatorCongestionStmt            *sql.Stmt
 	getRetryableMigrationDeadLetterBoxesStmt     *sql.Stmt
 	getSecondNewestMinuteStmt                    *sql.Stmt
@@ -750,6 +759,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getPayerInfoReportStmt:                       q.getPayerInfoReportStmt,
 		getPayerUnsettledUsageStmt:                   q.getPayerUnsettledUsageStmt,
 		getPrunableCeilingStmt:                       q.getPrunableCeilingStmt,
+		getPrunableMetaPartitionsStmt:                q.getPrunableMetaPartitionsStmt,
 		getRecentOriginatorCongestionStmt:            q.getRecentOriginatorCongestionStmt,
 		getRetryableMigrationDeadLetterBoxesStmt:     q.getRetryableMigrationDeadLetterBoxesStmt,
 		getSecondNewestMinuteStmt:                    q.getSecondNewestMinuteStmt,

--- a/pkg/db/queries/prune.sql.go
+++ b/pkg/db/queries/prune.sql.go
@@ -95,7 +95,7 @@ type GetPrunableMetaPartitionsRow struct {
 }
 
 func (q *Queries) GetPrunableMetaPartitions(ctx context.Context) ([]GetPrunableMetaPartitionsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getPrunableMetaPartitions)
+	rows, err := q.query(ctx, q.getPrunableMetaPartitionsStmt, getPrunableMetaPartitions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sync/envelope_sink.go
+++ b/pkg/sync/envelope_sink.go
@@ -300,12 +300,12 @@ func (s *EnvelopeSink) calculateFees(
 		return baseFee + 0, nil
 	}
 
-	// NOTE: This is code smell IMO. We have a function that is (by name) a reader function,
-	// but it feels wrong to IMPOSE read limitation on it this way. However, if the goal is to
-	// have read queries work on a db read replica, then this should operate on the read db.
+	// Use WriteQuery so congestion reads come from the primary DB, the same database
+	// that receives IncrementOriginatorCongestion writes.
+	// (see: https://github.com/xmtp/xmtpd/issues/1818).
 	congestionFee, err = s.feeCalculator.CalculateCongestionFee(
 		s.ctx,
-		s.db.ReadQuery(),
+		s.db.WriteQuery(),
 		messageTime,
 		env.OriginatorNodeID(),
 	)


### PR DESCRIPTION
### TL;DR

Fixed fee calculation divergence between local and remote nodes by ensuring congestion data is read from the primary database instead of potentially stale read replicas.

### What changed?

- Modified `EnvelopeSink.calculateFees()` to use `WriteQuery()` instead of `ReadQuery()` when calculating congestion fees
- Added comprehensive test `TestCongestionFeeParity_StaleReadReplicaCausesDivergence` that demonstrates the bug and validates the fix using separate primary and stale database instances

### How to test?

Run the new test `TestCongestionFeeParity_StaleReadReplicaCausesDivergence` which:
1. Simulates a stale read replica scenario with two separate database instances
2. Verifies that stale replicas cause fee calculation divergence (bug reproduction)
3. Confirms that reading from the primary database maintains fee parity between local and remote nodes (fix validation)

### Why make this change?

When remote nodes read congestion data from stale read replicas, they see outdated message counts and calculate lower fees than the originating node's BatchFeeCalculator. This creates fee inconsistencies between nodes. By reading congestion data from the primary database, both local and remote fee calculation paths see the same committed state, ensuring fee parity across the network.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inconsistent congestion fee calculation by reading from the primary database
> - `EnvelopeSink.calculateFees` now passes the write/primary DB connection to `feeCalculator.CalculateCongestionFee` instead of a read replica, ensuring fee calculations see the latest committed data.
> - Adds a `getPrunableMetaPartitions` prepared statement to [pkg/db/queries/db.go](https://github.com/xmtp/xmtpd/pull/1820/files#diff-6f01214a3b19a1a0ac22c30a57abde78d928dc4c2fb8df0a6700c10db665b11e), including proper lifecycle management in `Prepare`, `Close`, and `WithTx`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a42ca3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->