### PR TITLE
chore: remove extra import package

### DIFF
--- a/pkg/e2e/types/types.go
+++ b/pkg/e2e/types/types.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/lib/pq"
-	_ "github.com/lib/pq"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"github.com/xmtp/xmtpd/pkg/e2e/chain"


### PR DESCRIPTION
Removing extra import package  because "github.com/lib/pq" has been imported before.  

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate blank import of `github.com/lib/pq` in `e2e/types/types.go`
> Removes a redundant blank import of `github.com/lib/pq` from [pkg/e2e/types/types.go](https://github.com/xmtp/xmtpd/pull/1822/files#diff-88b637b3a9ade33e0ef95c6b03f33bdcbacede20ef0680b8c612e6ae453ec3b2), keeping the regular import that was already present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a93f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->