### PR TITLE
Fix TestSubscribeVariableEnvelopesPerOriginator

### DIFF
--- a/pkg/api/message/subscribe_test.go
+++ b/pkg/api/message/subscribe_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -518,31 +519,41 @@ func TestSubscribeVariableEnvelopesPerOriginator(t *testing.T) {
 
 	// Receive messages and do accounting.
 	var (
-		receivedCount = 0
+		receivedCount atomic.Int64
 		received      = make(map[string]struct{})
+		streamWG      sync.WaitGroup
 	)
 
-	for receivedCount < total {
-		ok := stream.Receive()
-		if !ok {
-			break
+	streamWG.Go(func() {
+		for receivedCount.Load() < int64(total) {
+			if ok := stream.Receive(); !ok {
+				break
+			}
+
+			msg := stream.Msg()
+
+			for _, env := range msg.GetEnvelopes() {
+				receivedCount.Add(1)
+
+				decoded := envelopeTestUtils.UnmarshalUnsignedOriginatorEnvelope(
+					t,
+					env.GetUnsignedOriginatorEnvelope(),
+				)
+
+				received[keyID(int32(decoded.GetOriginatorNodeId()), int64(decoded.GetOriginatorSequenceId()))] = struct{}{}
+			}
 		}
 
-		msg := stream.Msg()
+		cancel()
+	})
 
-		for _, env := range msg.GetEnvelopes() {
-			receivedCount += 1
+	require.Eventually(t, func() bool {
+		return receivedCount.Load() >= int64(total)
+	}, 10*time.Second, 100*time.Millisecond, "not all envelopes received")
 
-			decoded := envelopeTestUtils.UnmarshalUnsignedOriginatorEnvelope(
-				t,
-				env.GetUnsignedOriginatorEnvelope(),
-			)
+	streamWG.Wait()
 
-			received[keyID(int32(decoded.GetOriginatorNodeId()), int64(decoded.GetOriginatorSequenceId()))] = struct{}{}
-		}
-	}
-
-	cancel()
+	require.Equal(t, int64(total), receivedCount.Load())
 
 	err = stream.Err()
 	require.Truef(
@@ -550,13 +561,11 @@ func TestSubscribeVariableEnvelopesPerOriginator(t *testing.T) {
 		err == nil || errors.Is(err, context.Canceled),
 		"unexpected stream error: %s, received %v/%v envelopes",
 		err,
-		receivedCount,
+		receivedCount.Load(),
 		total,
 	)
 
-	require.Equal(t, total, receivedCount)
-
-	t.Logf("processed %v envelopes", receivedCount)
+	t.Logf("processed %v envelopes", receivedCount.Load())
 
 	// Accounting - verify that query returned everything.
 	// Confirm simply that we got back all envelopes based on nodeID and seqID.


### PR DESCRIPTION
Decrease the amount of envelopes per originator so nodes can sync before cancellation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TestSubscribeVariableEnvelopesPerOriginator` to avoid flaky stream receive loop
> The test was prone to failure due to a synchronous receive loop that could miss messages or deadlock. The fix moves stream message receiving into a goroutine with an `atomic.Int64` counter, uses `require.Eventually` (up to 10s) to wait for the expected count, and cancels the context only after all envelopes are received. Envelope generation is also reduced from (50, 100) to (10, 30) per originator to keep the test faster.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b31aca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->