### PR TITLE
Send proposals over the blockchain

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -934,7 +934,7 @@ func (s *Service) validateGroupMessage(
 		)
 	}
 
-	isCommit, err := deserializer.IsGroupMessageCommit(payload)
+	shouldSendToBlockchain, err := deserializer.ShouldSendToBlockchain(payload)
 	if err != nil {
 		return connect.NewError(
 			connect.CodeInvalidArgument,
@@ -942,10 +942,10 @@ func (s *Service) validateGroupMessage(
 		)
 	}
 
-	if isCommit {
+	if shouldSendToBlockchain {
 		return connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.New("commit messages must be published via the blockchain"),
+			errors.New("commit and proposal messages must be published via the blockchain"),
 		)
 	}
 

--- a/pkg/api/payer/service.go
+++ b/pkg/api/payer/service.go
@@ -615,12 +615,12 @@ func determineRetentionPolicy(clientEnvelope *envelopes.ClientEnvelope) (uint32,
 	case topic.TopicKindGroupMessagesV1:
 		switch payload := clientEnvelope.Payload().(type) {
 		case *envelopesProto.ClientEnvelope_GroupMessage:
-			isCommit, err := deserializer.IsGroupMessageCommit(payload)
+			shouldSendToBlockchain, err := deserializer.ShouldSendToBlockchain(payload)
 			if err != nil {
 				return 0, err
 			}
-			if isCommit {
-				panic("should not be called for group message commits")
+			if shouldSendToBlockchain {
+				panic("should not be called for group message commits or proposals")
 			}
 		default:
 			panic("mismatched payload type")
@@ -637,11 +637,11 @@ func shouldSendToBlockchain(clientEnvelope *envelopes.ClientEnvelope) (bool, err
 	case topic.TopicKindGroupMessagesV1:
 		switch payload := clientEnvelope.Payload().(type) {
 		case *envelopesProto.ClientEnvelope_GroupMessage:
-			isCommit, err := deserializer.IsGroupMessageCommit(payload)
+			shouldSendToBlockchain, err := deserializer.ShouldSendToBlockchain(payload)
 			if err != nil {
 				return false, err
 			}
-			return isCommit, nil
+			return shouldSendToBlockchain, nil
 		default:
 			panic("mismatched payload type")
 		}

--- a/pkg/deserializer/deserializer.go
+++ b/pkg/deserializer/deserializer.go
@@ -35,7 +35,7 @@ func DeserializeGroupMessage(
 	return &msg, nil
 }
 
-func IsGroupMessageCommit(
+func ShouldSendToBlockchain(
 	payload *envelopesProto.ClientEnvelope_GroupMessage,
 ) (bool, error) {
 	msg, err := DeserializeGroupMessage(payload)
@@ -54,5 +54,7 @@ func IsGroupMessageCommit(
 		return false, status.Errorf(codes.InvalidArgument, "invalid message type")
 	}
 
-	return ct == ContentTypeCommit, nil
+	shouldSendToBlockchain := ct == ContentTypeCommit || ct == ContentTypeProposal
+
+	return shouldSendToBlockchain, nil
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Send group proposal messages over the blockchain
- Introduces `deserializer.ShouldSendToBlockchain` (replacing `IsGroupMessageCommit`) which returns `true` for both MLS Commit and Proposal content types.
- Updates `payer.shouldSendToBlockchain` and `payer.determineRetentionPolicy` to use the new function, so proposals are routed to the blockchain alongside commits.
- Updates `message.Service.validateGroupMessage` to reject proposal messages with an `InvalidArgument` error, directing callers to publish them via the blockchain instead.
- Behavioral Change: group proposal messages are now rejected by the message API and must be published via the blockchain; previously only commit messages were subject to this restriction.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c58bb3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->