### PR TITLE
Submitter worker missing log

### DIFF
--- a/pkg/payerreport/workers/submitter.go
+++ b/pkg/payerreport/workers/submitter.go
@@ -191,6 +191,8 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 				utils.PayerReportIDField(report.ID.String()),
 			)
 		}
+
+		reportLogger.Info("report submitted")
 	}
 
 	return latestErr


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add missing "report submitted" log in `SubmitterWorker.SubmitReports`
Adds an info-level `report submitted` log in [submitter.go](https://github.com/xmtp/xmtpd/pull/1830/files#diff-bbe168761e1f4dce803d758c9db41c508ede9eab842d93a0117aae2de4545d8f) after each `SetReportSubmitted` call in the worker loop. The log was previously absent, making it hard to confirm successful submissions from logs.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6737cee.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->