### PR TITLE
Avoid rejecting already submitted payer reports

### DIFF
--- a/pkg/payerreport/workers/submitter.go
+++ b/pkg/payerreport/workers/submitter.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -129,6 +130,7 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 		}
 
 		reportLogger.Info("submitting report")
+
 		// Submit the report to the blockchain
 		reportIndex, submitErr := w.submitReport(report)
 		if submitErr != nil {
@@ -152,10 +154,28 @@ func (w *SubmitterWorker) SubmitReports(ctx context.Context) error {
 			}
 
 			// If the on-chain protocol throws an InvalidSequenceIDs or InvalidStartSequenceID error,
-			// it means the report has invalid sequence IDs or start sequence ID.
-			// Most likely another node submitted a valid report with the same start sequence ID before the node.
-			// We set the report submission status to rejected and continue.
+			// it means the report has invalid sequence IDs or start sequence ID, or another node submitted a valid report with the same start sequence ID before the node.
+			// If the report is already marked as submitted (likely by the indexer), skip it.
+			// Otherwise, we set the report submission status to rejected and continue.
 			if submitErr.IsErrInvalidSequenceIDs() {
+				currentReport, err := w.payerReportStore.FetchReport(ctx, report.ID)
+				if err != nil && !errors.Is(err, payerreport.ErrReportNotFound) {
+					reportLogger.Error(
+						"failed to fetch report",
+						utils.PayerReportIDField(report.ID.String()),
+						zap.Error(err),
+					)
+					latestErr = err
+					continue
+				}
+
+				// If the report has already been submitted, skip it.
+				if currentReport != nil &&
+					currentReport.SubmissionStatus == payerreport.SubmissionSubmitted {
+					reportLogger.Info("report already submitted, skipping")
+					continue
+				}
+
 				reportLogger.Info("report has invalid sequence IDs, submission rejected")
 
 				err = w.payerReportStore.SetReportSubmissionRejected(ctx, report.ID)


### PR DESCRIPTION
Avoid setting a payer report to rejected if somebody else submitted it before us.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid rejecting already-submitted payer reports on `InvalidSequenceIDs` error
> When the on-chain submission returns an `InvalidSequenceIDs` error, the worker in [submitter.go](https://github.com/xmtp/xmtpd/pull/1831/files#diff-bbe168761e1f4dce803d758c9db41c508ede9eab842d93a0117aae2de4545d8f) now re-fetches the report and checks its `SubmissionStatus` before marking it as rejected. If the report is already marked as submitted, it logs and skips the rejection step. On unexpected fetch errors, it logs and sets `latestErr` to defer rejection rather than immediately rejecting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3436d40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->