### PR TITLE
Claim Protocol Fees CLI

### DIFF
--- a/cmd/xmtpd-cli/commands/settlement.go
+++ b/cmd/xmtpd-cli/commands/settlement.go
@@ -789,7 +789,11 @@ func settleDMClaimProtocolFeesHandler(
 	if err != nil {
 		return err
 	}
-	if err := admin.ClaimProtocolFeesFromDistributionManager(ctx, originatorNodeIDs, payerReportIndices); err != nil {
+	if err := admin.ClaimProtocolFeesFromDistributionManager(
+		ctx,
+		originatorNodeIDs,
+		payerReportIndices,
+	); err != nil {
 		logger.Error("dm claim protocol fees failed", zap.Error(err))
 		return err
 	}

--- a/pkg/blockchain/settlement_chain_admin.go
+++ b/pkg/blockchain/settlement_chain_admin.go
@@ -642,7 +642,11 @@ func (s settlementChainAdmin) ClaimProtocolFeesFromDistributionManager(
 		ctx,
 		s.signer, s.logger, s.client,
 		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return s.distributionManager.ClaimProtocolFees(opts, originatorNodeIDs, payerReportIndices)
+			return s.distributionManager.ClaimProtocolFees(
+				opts,
+				originatorNodeIDs,
+				payerReportIndices,
+			)
 		},
 		func(log *types.Log) (any, error) {
 			return s.distributionManager.ParseProtocolFeesClaim(*log)
@@ -692,7 +696,9 @@ func (s settlementChainAdmin) WithdrawFromDistributionManager(
 	return nil
 }
 
-func (s settlementChainAdmin) WithdrawProtocolFeesFromDistributionManager(ctx context.Context) error {
+func (s settlementChainAdmin) WithdrawProtocolFeesFromDistributionManager(
+	ctx context.Context,
+) error {
 	err := ExecuteTransaction(
 		ctx,
 		s.signer, s.logger, s.client,
@@ -705,7 +711,9 @@ func (s settlementChainAdmin) WithdrawProtocolFeesFromDistributionManager(ctx co
 		func(event any) {
 			ev, ok := event.(*dm.DistributionManagerProtocolFeesWithdrawal)
 			if !ok {
-				s.logger.Error("unexpected event type, not DistributionManagerProtocolFeesWithdrawal")
+				s.logger.Error(
+					"unexpected event type, not DistributionManagerProtocolFeesWithdrawal",
+				)
 				return
 			}
 			s.logger.Info("withdrew protocol fees from distribution manager",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `dm-claim-protocol-fees` and `dm-withdraw-protocol-fees` CLI commands to settlement
- Adds two subcommands to the `settlement` CLI: `dm-claim-protocol-fees` (requires `--originator-node-ids` and `--payer-report-indices`) and `dm-withdraw-protocol-fees` (no flags).
- Implements `ClaimProtocolFeesFromDistributionManager` and `WithdrawProtocolFeesFromDistributionManager` on `ISettlementChainAdmin` in [settlement_chain_admin.go](https://github.com/xmtp/xmtpd/pull/1833/files#diff-11ea7cf1b0e172c02219ebccf4bdb38b05ac1e3b40b07c342d22c3ff5344c466), each submitting a transaction and logging parsed event data.
- CLI handlers are wired in [settlement.go](https://github.com/xmtp/xmtpd/pull/1833/files#diff-d461e16f025fcdb3f57fd87222135ec71efb751075f850cd2a607efcf3d5b0fc) and delegate directly to the new admin methods.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e6a79e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->