### PR TITLE
fix: remove peer IP from JWT validation logs, include node ID instead

### DIFF
--- a/pkg/interceptors/server/auth.go
+++ b/pkg/interceptors/server/auth.go
@@ -1,13 +1,14 @@
 // Package server implements the server authentication interceptors.
-// It validates JWT tokens from other nodes and logs the incoming address.
+// It validates JWT tokens from other nodes.
 package server
 
 import (
 	"context"
 	"errors"
-	"net"
+	"strconv"
 
 	"connectrpc.com/connect"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/xmtp/xmtpd/pkg/authn"
 	"github.com/xmtp/xmtpd/pkg/constants"
@@ -16,11 +17,6 @@ import (
 )
 
 // TODO(borja): Next PR - Fail requests if the token is not valid.
-
-const (
-	dnsNameField       = "dns_name"
-	clientAddressField = "client_address"
-)
 
 // ServerAuthInterceptor validates JWT tokens from other nodes
 type ServerAuthInterceptor struct {
@@ -52,13 +48,15 @@ func (i *ServerAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryF
 
 		nodeID, cancel, err := i.verifier.Verify(token)
 		if err != nil {
-
-			i.logger.Error("JWT verification failed",
+			logFields := []zap.Field{
 				zap.String("procedure", req.Spec().Procedure),
 				zap.String("protocol", req.Peer().Protocol),
-				zap.String("peer", req.Peer().Addr),
 				zap.Error(err),
-			)
+			}
+			if id := tryExtractNodeIDFromToken(token); id != 0 {
+				logFields = append(logFields, utils.OriginatorIDField(id))
+			}
+			i.logger.Error("JWT verification failed", logFields...)
 
 			// Do not expose too much information to the client (e.g. wrapped errors)
 			return nil, connect.NewError(
@@ -68,7 +66,7 @@ func (i *ServerAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryF
 		}
 		defer cancel()
 
-		i.connectLogIncomingAddress(req.Peer().Addr, nodeID)
+		i.connectLogIncomingAddress(nodeID)
 
 		ctx = context.WithValue(ctx, constants.VerifiedNodeRequestCtxKey{}, true)
 
@@ -98,20 +96,22 @@ func (i *ServerAuthInterceptor) WrapStreamingHandler(
 
 		nodeID, cancel, err := i.verifier.Verify(token)
 		if err != nil {
-
-			i.logger.Error("JWT verification failed",
+			logFields := []zap.Field{
 				zap.String("procedure", conn.Spec().Procedure),
 				zap.String("protocol", conn.Peer().Protocol),
-				zap.String("peer", conn.Peer().Addr),
 				zap.Error(err),
-			)
+			}
+			if id := tryExtractNodeIDFromToken(token); id != 0 {
+				logFields = append(logFields, utils.OriginatorIDField(id))
+			}
+			i.logger.Error("JWT verification failed", logFields...)
 
 			// Do not expose too much information to the client (e.g. wrapped errors)
 			return connect.NewError(connect.CodeUnauthenticated, errors.New("invalid auth token"))
 		}
 		defer cancel()
 
-		i.connectLogIncomingAddress(conn.Peer().Addr, nodeID)
+		i.connectLogIncomingAddress(nodeID)
 
 		ctx = context.WithValue(ctx, constants.VerifiedNodeRequestCtxKey{}, true)
 
@@ -121,24 +121,26 @@ func (i *ServerAuthInterceptor) WrapStreamingHandler(
 
 /* Connect-go interceptors helpers */
 
-func (i *ServerAuthInterceptor) connectLogIncomingAddress(
-	addr string,
-	nodeID uint32,
-) {
+func (i *ServerAuthInterceptor) connectLogIncomingAddress(nodeID uint32) {
 	if i.logger.Core().Enabled(zap.DebugLevel) {
-		host, _, err := net.SplitHostPort(addr)
-		if err == nil {
-			dnsName, err := net.LookupAddr(host)
-			if err != nil || len(dnsName) == 0 {
-				dnsName = []string{unknownDNSName}
-			}
-
-			i.logger.Debug(
-				"incoming connection",
-				zap.String(clientAddressField, addr),
-				zap.String(dnsNameField, dnsName[0]),
-				utils.OriginatorIDField(nodeID),
-			)
-		}
+		i.logger.Debug("incoming connection", utils.OriginatorIDField(nodeID))
 	}
+}
+
+// tryExtractNodeIDFromToken parses the JWT subject claim without signature verification.
+// Returns 0 if the subject cannot be extracted or parsed as a node ID.
+func tryExtractNodeIDFromToken(tokenString string) uint32 {
+	token, _, err := jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return 0
+	}
+	subject, err := token.Claims.GetSubject()
+	if err != nil {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(subject, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(parsed)
 }

--- a/pkg/interceptors/server/logging.go
+++ b/pkg/interceptors/server/logging.go
@@ -13,8 +13,6 @@ import (
 )
 
 const (
-	unknownDNSName = "unknown"
-
 	codeField    = "code"
 	messageField = "message"
 )


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1757

## Summary

- **Remove peer IP from JWT error logs**: The `peer` address (e.g. `req.Peer().Addr`) logged on JWT verification failure can be a load balancer IP, making it meaningless. It's now removed from both unary and streaming error log entries.
- **Optionally include originator node ID**: Added `tryExtractNodeIDFromToken` which uses `jwt.NewParser().ParseUnverified()` to extract the subject claim (node ID) from the JWT without signature verification. If present, it's included as `originator_id` in the error log — useful for identifying the node in node-to-node communication scenarios.
- **Simplify `connectLogIncomingAddress`**: Removed the `addr` parameter, DNS lookup, and related constants (`unknownDNSName`, `clientAddressField`, `dnsNameField`) on the success path for the same reason. Now only logs `originator_id`.

## Test plan

- [x] Existing unit tests pass (`go test ./pkg/interceptors/server/...`)
- [x] Lint passes (`golangci-lint run ./pkg/interceptors/server/...`)
- [x] `authn` package tests pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove peer IP from JWT validation logs and include node ID instead in `ServerAuthInterceptor`
> - Replaces peer address and DNS name logging with `originator_id` in both unary and streaming auth interceptor handlers in [server/auth.go](https://github.com/xmtp/xmtpd/pull/1837/files#diff-d05d8f7ad54ba925de6dd0e26e2b346d99ca4c65562a6dd05ec0541ba235af1d).
> - Adds `tryExtractNodeIDFromToken`, a helper that parses the JWT subject without signature verification to best-effort extract a node ID for error log context.
> - Removes `connectLogIncomingAddress` DNS lookup and address parsing; the function now only emits `originator_id` in the debug log.
> - Behavioral Change: Auth failure and incoming connection logs no longer contain client IP/DNS; they now contain `originator_id` when it can be parsed from the token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aaffe1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->