### PR TITLE
test(migrator): add coverage for transformer edge cases, reader lower limits, and migration mode sync

### DIFF
--- a/pkg/migrator/reader_test.go
+++ b/pkg/migrator/reader_test.go
@@ -211,6 +211,90 @@ func TestCommitMessageReader(t *testing.T) {
 	}
 }
 
+// TestGroupMessageReaderLowerLimit verifies that the lower limit correctly
+// excludes records with IDs below the threshold.
+func TestGroupMessageReaderLowerLimit(t *testing.T) {
+	ctx := t.Context()
+
+	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
+	defer cleanup()
+
+	// Set lower limit to 10; only records with id >= 10 should be returned.
+	const lowerLimit int64 = 10
+	reader := migrator.NewGroupMessageReader(db, lowerLimit)
+
+	records, err := reader.Fetch(ctx, 0, 9999)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+
+	for _, r := range records {
+		require.GreaterOrEqual(t, r.GetID(), lowerLimit,
+			"record id %d is below lower limit %d", r.GetID(), lowerLimit)
+	}
+}
+
+// TestWelcomeMessageReaderLowerLimit verifies that welcome message readers with a
+// high lower limit skip early records — this mirrors the production config where
+// welcome messages start at a large offset (e.g. 150 000 000).
+func TestWelcomeMessageReaderLowerLimit(t *testing.T) {
+	ctx := t.Context()
+
+	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
+	defer cleanup()
+
+	// The test dataset contains IDs starting at 150000001. Using a limit of
+	// 150000010 means only IDs >= 150000010 should be returned.
+	const lowerLimit int64 = 150_000_010
+	reader := migrator.NewWelcomeMessageReader(db, lowerLimit)
+
+	records, err := reader.Fetch(ctx, 0, 9999)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+
+	for _, r := range records {
+		require.GreaterOrEqual(t, r.GetID(), lowerLimit,
+			"record id %d is below lower limit %d", r.GetID(), lowerLimit)
+	}
+}
+
+// TestWelcomeMessageReaderLowerLimit_SkipsAll verifies that when the lower limit
+// is above all available records, no records are returned.
+func TestWelcomeMessageReaderLowerLimit_SkipsAll(t *testing.T) {
+	ctx := t.Context()
+
+	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
+	defer cleanup()
+
+	// lowerLimit above all data in the test set.
+	const lowerLimit int64 = 999_999_999
+	reader := migrator.NewWelcomeMessageReader(db, lowerLimit)
+
+	records, err := reader.Fetch(ctx, 0, 9999)
+	require.NoError(t, err)
+	require.Empty(t, records)
+}
+
+// TestKeyPackageReaderLowerLimit verifies that the key-package reader respects
+// the lower limit and skips records below it.
+func TestKeyPackageReaderLowerLimit(t *testing.T) {
+	ctx := t.Context()
+
+	db, _, cleanup := testdata.NewMigratorTestDB(t, ctx)
+	defer cleanup()
+
+	const lowerLimit int64 = 5
+	reader := migrator.NewKeyPackageReader(db, lowerLimit)
+
+	records, err := reader.Fetch(ctx, 0, 9999)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+
+	for _, r := range records {
+		require.GreaterOrEqual(t, r.GetID(), lowerLimit,
+			"record id %d is below lower limit %d", r.GetID(), lowerLimit)
+	}
+}
+
 func TestWelcomeMessageReader(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/migrator/transformer.go
+++ b/pkg/migrator/transformer.go
@@ -110,6 +110,10 @@ func (t *Transformer) TransformGroupMessage(
 func (t *Transformer) TransformCommitMessage(
 	commitMessage *CommitMessage,
 ) (*envelopes.OriginatorEnvelope, error) {
+	if commitMessage == nil {
+		return nil, errors.New("commitMessage is nil")
+	}
+
 	protoClientEnvelope, err := transformGroupMessage(&commitMessage.GroupMessage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform group message: %w", err)

--- a/pkg/migrator/transformer_test.go
+++ b/pkg/migrator/transformer_test.go
@@ -431,6 +431,133 @@ func TestTransformWelcomeMessage(t *testing.T) {
 	checkOriginatorSignature(t, envelope, test.nodePrivateKey, test.nodeAddress)
 }
 
+func TestTransformGroupMessage_NilInput(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformGroupMessage(nil)
+	require.Error(t, err)
+}
+
+func TestTransformGroupMessage_NilGroupID(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformGroupMessage(&migrator.GroupMessage{
+		ID:   1,
+		Data: []byte("some data"),
+	})
+	require.Error(t, err)
+}
+
+func TestTransformGroupMessage_EmptyData(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	// Use a valid-looking 16-byte group ID.
+	_, err := test.transformer.TransformGroupMessage(&migrator.GroupMessage{
+		ID:      1,
+		GroupID: make([]byte, 16),
+		Data:    []byte{},
+	})
+	require.Error(t, err)
+}
+
+func TestTransformInboxLog_NilInput(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformInboxLog(nil)
+	require.Error(t, err)
+}
+
+func TestTransformInboxLog_NilInboxID(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformInboxLog(&migrator.InboxLog{
+		SequenceID:          1,
+		IdentityUpdateProto: []byte("proto"),
+	})
+	require.Error(t, err)
+}
+
+func TestTransformInboxLog_EmptyIdentityUpdateProto(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformInboxLog(&migrator.InboxLog{
+		SequenceID:          1,
+		InboxID:             make([]byte, 32),
+		IdentityUpdateProto: []byte{},
+	})
+	require.Error(t, err)
+}
+
+func TestTransformInboxLog_InvalidProtoBytes(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	// Provide a non-empty byte slice that is not a valid proto.
+	_, err := test.transformer.TransformInboxLog(&migrator.InboxLog{
+		SequenceID:          1,
+		InboxID:             make([]byte, 32),
+		IdentityUpdateProto: []byte("not valid protobuf"),
+	})
+	require.Error(t, err)
+}
+
+func TestTransformKeyPackage_NilInput(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformKeyPackage(nil)
+	require.Error(t, err)
+}
+
+func TestTransformKeyPackage_EmptyKeyPackage(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformKeyPackage(&migrator.KeyPackage{
+		SequenceID:     1,
+		InstallationID: make([]byte, 32),
+		KeyPackage:     []byte{},
+	})
+	require.Error(t, err)
+}
+
+func TestTransformWelcomeMessage_NilInput(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformWelcomeMessage(nil)
+	require.Error(t, err)
+}
+
+func TestTransformCommitMessage_NilInput(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.TransformCommitMessage(nil)
+	require.Error(t, err)
+}
+
+// unknownRecord implements ISourceRecord with an unrecognized table name.
+type unknownRecord struct{}
+
+func (u *unknownRecord) GetID() int64           { return 1 }
+func (u *unknownRecord) TableName() string      { return "unknown_table" }
+func (u *unknownRecord) Scan(_ *sql.Rows) error { return nil }
+
+func TestTransform_UnknownTableName(t *testing.T) {
+	test := newTransformerTest(t)
+	defer test.cleanup()
+
+	_, err := test.transformer.Transform(&unknownRecord{})
+	require.Error(t, err)
+}
+
 func checkTopic(
 	t *testing.T,
 	envelope *envelopes.OriginatorEnvelope,

--- a/pkg/sync/originator_stream_test.go
+++ b/pkg/sync/originator_stream_test.go
@@ -469,6 +469,143 @@ func TestSyncWorkerOutOfOrderStillAdvancesLastSequenceId(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
+// TestSyncWorkerMigratedEnvelopesStartFromOne reproduces issue #1659:
+// When a node has existing data for migrator originator IDs (e.g. originator 10
+// at seq 220249) and the migration restarts sending envelopes from seq=1, the
+// stream must log an "out-of-order" error but still accept and forward all
+// envelopes — not silently drop them.
+func TestSyncWorkerMigratedEnvelopesStartFromOne(t *testing.T) {
+	const (
+		migratorOriginatorID = migrator.GroupMessageOriginatorID // 10
+		priorLastSeenSeq     = uint64(220249)
+	)
+
+	// Simulate the migration serving envelopes starting from seq=1
+	// (fresh migration run), while our lastSequenceIds[10] = 220249
+	// (left over from a previous migration run).
+	envs := []*envelopes.OriginatorEnvelope{
+		envelopeTestUtils.CreateOriginatorEnvelope(t, migratorOriginatorID, 1),
+		envelopeTestUtils.CreateOriginatorEnvelope(t, migratorOriginatorID, 2),
+		envelopeTestUtils.CreateOriginatorEnvelope(t, migratorOriginatorID, 3),
+	}
+
+	stream := mockSubscriptionOnePage(t, envs)
+	nodeID := uint32(200)
+	node := registryTestUtils.CreateNode(nodeID, 999, testutils.RandomPrivateKey(t))
+
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	defer close(writeQueue)
+
+	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, t.Context())
+	go dbStorerInstance.Start()
+
+	// lastSequenceIds has a high value for the migrator originator ID,
+	// simulating a node that previously processed migrations up to seq 220249.
+	lastSequenceIds := map[uint32]uint64{
+		migratorOriginatorID: priorLastSeenSeq,
+	}
+
+	core, recorded := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	permitted := map[uint32]struct{}{
+		nodeID:               {},
+		migratorOriginatorID: {},
+	}
+
+	origStream := newOriginatorStream(
+		t.Context(),
+		logger,
+		&node,
+		lastSequenceIds,
+		permitted,
+		stream,
+		writeQueue,
+	)
+
+	_ = origStream.listen()
+
+	// All three envelopes must reach the write queue despite being "out-of-order"
+	// relative to priorLastSeenSeq — the stream must not silently drop them.
+	require.Eventually(
+		t,
+		func() bool {
+			envs := getAllMessagesForOriginator(t, dbStorerInstance, migratorOriginatorID)
+			return len(envs) == 3
+		},
+		3*time.Second,
+		50*time.Millisecond,
+		"all 3 migrated envelopes must be forwarded even when received below the prior last-seen seq",
+	)
+
+	// An "out-of-order" error log must be emitted for each envelope that
+	// arrived below priorLastSeenSeq, alerting operators to the discrepancy.
+	require.Eventually(
+		t,
+		func() bool {
+			return recorded.FilterMessage("received out-of-order envelope").Len() > 0
+		},
+		3*time.Second,
+		50*time.Millisecond,
+		"out-of-order error log must be emitted when migrated envelopes arrive below the prior cursor",
+	)
+}
+
+// TestSyncWorkerMigratedEnvelopesAllOriginatorIDs verifies that all three
+// database-bound migrator originator IDs (10, 11, 13) are accepted by the
+// stream when they are listed as permitted originators.
+func TestSyncWorkerMigratedEnvelopesAllOriginatorIDs(t *testing.T) {
+	envs := []*envelopes.OriginatorEnvelope{
+		envelopeTestUtils.CreateOriginatorEnvelope(t, migrator.GroupMessageOriginatorID, 1),
+		envelopeTestUtils.CreateOriginatorEnvelope(t, migrator.WelcomeMessageOriginatorID, 1),
+		envelopeTestUtils.CreateOriginatorEnvelope(t, migrator.KeyPackagesOriginatorID, 1),
+	}
+
+	stream := mockSubscriptionOnePage(t, envs)
+	nodeID := uint32(200)
+	node := registryTestUtils.CreateNode(nodeID, 999, testutils.RandomPrivateKey(t))
+
+	writeQueue := make(chan *envUtils.OriginatorEnvelope, 10)
+	defer close(writeQueue)
+
+	dbStorerInstance := newTestEnvelopeSink(t, writeQueue, t.Context())
+	go dbStorerInstance.Start()
+
+	lastSequenceIds := make(map[uint32]uint64)
+
+	permitted := map[uint32]struct{}{
+		nodeID:                              {},
+		migrator.GroupMessageOriginatorID:   {},
+		migrator.WelcomeMessageOriginatorID: {},
+		migrator.KeyPackagesOriginatorID:    {},
+	}
+
+	core, recorded := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	origStream := newOriginatorStream(
+		t.Context(),
+		logger,
+		&node,
+		lastSequenceIds,
+		permitted,
+		stream,
+		writeQueue,
+	)
+
+	_ = origStream.listen()
+
+	require.Eventually(t, func() bool {
+		a := getAllMessagesForOriginator(t, dbStorerInstance, migrator.GroupMessageOriginatorID)
+		b := getAllMessagesForOriginator(t, dbStorerInstance, migrator.WelcomeMessageOriginatorID)
+		c := getAllMessagesForOriginator(t, dbStorerInstance, migrator.KeyPackagesOriginatorID)
+		return len(a) == 1 && len(b) == 1 && len(c) == 1
+	}, 3*time.Second, 50*time.Millisecond)
+
+	// No out-of-order errors expected — all originators start from seq=1 cleanly.
+	require.Empty(t, recorded.FilterMessage("received out-of-order envelope").All())
+}
+
 func TestSyncWorkerNoOutOfOrderErrorForMultipleOriginatorsInOrder(t *testing.T) {
 	envs := []*envelopes.OriginatorEnvelope{
 		envelopeTestUtils.CreateOriginatorEnvelope(t, 200, 1),


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1661

## Summary

This PR adds test coverage that would have caught the three production escapes referenced in #1661.

### What changed

**`pkg/migrator/transformer.go`** — Bug fix: `TransformCommitMessage(nil)` panicked with a nil-pointer dereference because the nil guard that exists on `TransformGroupMessage` and other transform functions was missing. Added the guard to match the rest of the transform functions.

**`pkg/migrator/transformer_test.go`** — 12 new error-case tests covering nil and invalid inputs for all five transform functions plus the `Transform` dispatch for unknown table names:
- `TestTransformGroupMessage_NilInput`
- `TestTransformGroupMessage_NilGroupID`
- `TestTransformGroupMessage_EmptyData`
- `TestTransformInboxLog_NilInput` / `_NilInboxID` / `_EmptyIdentityUpdateProto` / `_InvalidProtoBytes`
- `TestTransformKeyPackage_NilInput` / `_EmptyKeyPackage`
- `TestTransformWelcomeMessage_NilInput`
- `TestTransformCommitMessage_NilInput` (exposed the nil-pointer panic fixed above)
- `TestTransform_UnknownTableName`

**`pkg/migrator/reader_test.go`** — 4 new tests verifying that the `lowerLimit` parameter correctly excludes records below the configured threshold (the production use-case where welcome-message migrations start at offset ~150 000 000):
- `TestGroupMessageReaderLowerLimit`
- `TestWelcomeMessageReaderLowerLimit` / `_SkipsAll`
- `TestKeyPackageReaderLowerLimit`

**`pkg/sync/originator_stream_test.go`** — 2 new tests that reproduce issue #1659, where migrated envelopes starting from seq=1 arrived at a node whose vector clock already had a higher value for those migrator originator IDs:
- `TestSyncWorkerMigratedEnvelopesStartFromOne`: asserts that envelopes are forwarded (not dropped) AND that an `"out-of-order"` error log is emitted so operators are alerted.
- `TestSyncWorkerMigratedEnvelopesAllOriginatorIDs`: verifies all three database-bound migrator originator IDs (10, 11, 13) are accepted without spurious errors when starting cleanly from seq=1.

## Test plan

- [x] `go test ./pkg/migrator/... -count=1` — all pass
- [x] `go test ./pkg/sync/... -count=1` — all pass
- [x] `golangci-lint run ./pkg/migrator/... ./pkg/sync/...` — 0 issues

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage for transformer edge cases, reader lower limits, and migrator sync behavior
> - Adds nil/empty input tests for all `Transformer` methods (`TransformGroupMessage`, `TransformInboxLog`, `TransformKeyPackage`, `TransformWelcomeMessage`, `TransformCommitMessage`) in [transformer_test.go](https://github.com/xmtp/xmtpd/pull/1838/files#diff-4d2f9cd6dca8594127cb38e1818e608c4fcfd4fc803ffa4402afb6a6922bc29a), plus an unknown table name case.
> - Fixes `TransformCommitMessage` in [transformer.go](https://github.com/xmtp/xmtpd/pull/1838/files#diff-c76d70079716ba42e22c5b5031c1960504cccbca874aadb118385ca67341cf62) to return an error on nil input instead of potentially dereferencing a nil pointer.
> - Adds lower-limit boundary tests for `GroupMessageReader`, `WelcomeMessageReader`, and `KeyPackageReader` in [reader_test.go](https://github.com/xmtp/xmtpd/pull/1838/files#diff-e169518f1d5aa92cfd1394ad3a2cf1024c9d0803b5513d3582fe5ce71c313796), verifying records are filtered correctly.
> - Adds sync worker tests in [originator_stream_test.go](https://github.com/xmtp/xmtpd/pull/1838/files#diff-031b88e204ba2d2a9227afbb5b5bb9c0a09e0073a1dc4217fe1ee2db1990f08c) covering migrated envelope ingestion for all three migrator originator IDs (10, 11, 13) starting from sequence 1.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4064491.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->