### PR TITLE
fix: ensure blob rows are deleted when meta rows are pruned

### DIFF
--- a/pkg/db/migrations/00023_fix-blob-orphans.down.sql
+++ b/pkg/db/migrations/00023_fix-blob-orphans.down.sql
@@ -1,0 +1,4 @@
+-- Orphan blob rows that were deleted cannot be restored.
+-- Drop the FK constraint if it was added by this migration.
+ALTER TABLE gateway_envelope_blobs
+    DROP CONSTRAINT IF EXISTS gateway_envelope_blobs_meta_fk;

--- a/pkg/db/migrations/00023_fix-blob-orphans.up.sql
+++ b/pkg/db/migrations/00023_fix-blob-orphans.up.sql
@@ -1,0 +1,113 @@
+-- Remove orphan blobs: blobs that have no matching meta row.
+-- This can happen when the ON DELETE CASCADE FK fails to propagate due to the
+-- partition attachment order in ensure_gateway_parts_v2 (meta partitions are
+-- attached before blob partitions, leaving the FK state inconsistent).
+DELETE FROM gateway_envelope_blobs b
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM gateway_envelopes_meta m
+    WHERE m.originator_node_id     = b.originator_node_id
+      AND m.originator_sequence_id = b.originator_sequence_id
+);
+
+-- Ensure the FK constraint exists on gateway_envelope_blobs.
+-- It may have been lost or never properly established during partition management.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'gateway_envelope_blobs'::regclass
+          AND contype  = 'f'
+    ) THEN
+        ALTER TABLE gateway_envelope_blobs
+            ADD CONSTRAINT gateway_envelope_blobs_meta_fk
+            FOREIGN KEY (originator_node_id, originator_sequence_id)
+            REFERENCES gateway_envelopes_meta (originator_node_id, originator_sequence_id)
+            ON DELETE CASCADE;
+    END IF;
+END$$;
+
+-- Fix argument order in make_meta_seq_subpart_v2.
+-- Previously _oid and _start were passed instead of _start and _end for the
+-- seq_id_check constraint, making it impossible to satisfy (e.g. seq_id >= 100
+-- AND seq_id < 0).  The constraint is dropped immediately after ATTACH so there
+-- was no functional impact, but correcting it avoids confusion.
+CREATE OR REPLACE FUNCTION make_meta_seq_subpart_v2(_oid int, _start bigint, _end bigint)
+    RETURNS void AS $$
+DECLARE
+    parent  text := format('gateway_envelopes_meta_o%s', _oid);
+    subname text := format('gateway_envelopes_meta_o%s_s%s_%s', _oid, _start, _end);
+BEGIN
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I (
+            LIKE gateway_envelopes_meta INCLUDING DEFAULTS INCLUDING CONSTRAINTS,
+            CONSTRAINT seq_id_check CHECK ( originator_sequence_id >= %s AND originator_sequence_id < %s )
+        )',
+        subname,
+        _start::text,
+        _end::text
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I ATTACH PARTITION %I
+            FOR VALUES FROM (%s) TO (%s)',
+        parent,
+        subname,
+        _start::text,
+        _end::text
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I DROP CONSTRAINT seq_id_check;',
+        subname
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLERRM ~ 'is already a partition' THEN
+            NULL;
+        ELSE
+            RAISE;
+        END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Fix argument order in make_blob_seq_subpart_v2 (same bug as above).
+CREATE OR REPLACE FUNCTION make_blob_seq_subpart_v2(_oid int, _start bigint, _end bigint)
+    RETURNS void AS $$
+DECLARE
+    parent  text := format('gateway_envelope_blobs_o%s', _oid);
+    subname text := format('gateway_envelope_blobs_o%s_s%s_%s', _oid, _start, _end);
+BEGIN
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I (
+            LIKE gateway_envelope_blobs INCLUDING DEFAULTS INCLUDING CONSTRAINTS,
+            CONSTRAINT seq_id_check CHECK ( originator_sequence_id >= %s AND originator_sequence_id < %s )
+        )',
+        subname,
+        _start::text,
+        _end::text
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I ATTACH PARTITION %I
+            FOR VALUES FROM (%s) TO (%s)',
+        parent,
+        subname,
+        _start::text,
+        _end::text
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I DROP CONSTRAINT seq_id_check;',
+        subname
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLERRM ~ 'is already a partition' THEN
+            NULL;
+        ELSE
+            RAISE;
+        END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/pkg/db/migrations/migrations_test.go
+++ b/pkg/db/migrations/migrations_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xmtp/xmtpd/pkg/topic"
 )
 
-const currentMigration int64 = 22
+const currentMigration int64 = 23
 
 var (
 	originatorIDs = []int32{100, 200, 300}
@@ -206,6 +206,10 @@ func TestMigrations(t *testing.T) {
 
 	t.Run("00022_prune-meta-partitions", func(t *testing.T) {
 		checkMetaPartitionSelect(t, database)
+	})
+
+	t.Run("00023_fix-blob-orphans", func(t *testing.T) {
+		checkFixBlobOrphans(t, database)
 	})
 
 	t.Run("data_verification", func(t *testing.T) {
@@ -405,6 +409,43 @@ func checkStagedInsertBatchV2(t *testing.T, database *sql.DB) {
 
 func checkMetaPartitionSelect(t *testing.T, database *sql.DB) {
 	functionExists(t, database, "get_prunable_meta_partitions")
+}
+
+func checkFixBlobOrphans(t *testing.T, database *sql.DB) {
+	// Verify updated sub-partition functions exist.
+	for _, fn := range []string{"make_meta_seq_subpart_v2", "make_blob_seq_subpart_v2"} {
+		functionExists(t, database, fn)
+	}
+
+	// Verify no orphan blobs exist after the migration.
+	var orphanCount int
+	err := database.QueryRowContext(
+		t.Context(),
+		`SELECT COUNT(*)
+		 FROM gateway_envelope_blobs b
+		 WHERE NOT EXISTS (
+		     SELECT 1
+		     FROM gateway_envelopes_meta m
+		     WHERE m.originator_node_id     = b.originator_node_id
+		       AND m.originator_sequence_id = b.originator_sequence_id
+		 )`,
+	).Scan(&orphanCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, orphanCount, "there should be no orphan blobs after migration 23")
+
+	// Verify the FK constraint is present on gateway_envelope_blobs.
+	var hasForeignKey bool
+	err = database.QueryRowContext(
+		t.Context(),
+		`SELECT EXISTS (
+		     SELECT 1
+		     FROM pg_constraint
+		     WHERE conrelid = 'gateway_envelope_blobs'::regclass
+		       AND contype  = 'f'
+		 )`,
+	).Scan(&hasForeignKey)
+	require.NoError(t, err)
+	assert.True(t, hasForeignKey, "gateway_envelope_blobs should have a FK constraint")
 }
 
 // --- Data verification after populateDatabase ---

--- a/pkg/prune/query.go
+++ b/pkg/prune/query.go
@@ -2,28 +2,55 @@ package prune
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 )
 
+// metaTableToBlobTable derives the blob partition table name from a meta partition
+// table name by replacing the "gateway_envelopes_meta" prefix with
+// "gateway_envelope_blobs".
+//
+// Example: "gateway_envelopes_meta_o100" → "gateway_envelope_blobs_o100"
+func metaTableToBlobTable(metaTable string) string {
+	return strings.Replace(metaTable, "gateway_envelopes_meta", "gateway_envelope_blobs", 1)
+}
+
+// constructVariableMetaTableQuery builds a CTE query that:
+//  1. Selects up to batchSize expired meta rows (SKIP LOCKED).
+//  2. Deletes those meta rows.
+//  3. Deletes the corresponding blob rows in the same transaction.
+//
+// It returns the number of deleted meta rows so the caller can detect when a
+// partition has been fully exhausted.
 func constructVariableMetaTableQuery(
 	tableName string,
 	batchSize int32,
 	maxSequenceId int64,
 ) string {
+	blobTable := metaTableToBlobTable(tableName)
 	return fmt.Sprintf(`
 WITH to_delete AS (
-  SELECT ctid
+  SELECT ctid, originator_sequence_id
   FROM %s
   WHERE expiry < EXTRACT(EPOCH FROM now())::bigint
     AND originator_sequence_id <= %d
   ORDER BY expiry
   LIMIT %d
   FOR UPDATE SKIP LOCKED
+),
+deleted_meta AS (
+  DELETE FROM %s
+  WHERE ctid IN (SELECT ctid FROM to_delete)
+  RETURNING originator_sequence_id
+),
+deleted_blobs AS (
+  DELETE FROM %s
+  WHERE originator_sequence_id IN (SELECT originator_sequence_id FROM deleted_meta)
 )
-DELETE FROM %s
-WHERE ctid IN (SELECT ctid FROM to_delete);
-`, pq.QuoteIdentifier(tableName), maxSequenceId, batchSize, pq.QuoteIdentifier(tableName))
+SELECT count(*) FROM deleted_meta;
+`, pq.QuoteIdentifier(tableName), maxSequenceId, batchSize,
+		pq.QuoteIdentifier(tableName), pq.QuoteIdentifier(blobTable))
 }
 
 func constructDropQuery(metaTable string, blobTable string) string {

--- a/pkg/prune/row_pruner.go
+++ b/pkg/prune/row_pruner.go
@@ -99,22 +99,14 @@ func (e *Executor) PruneRows() error {
 		var deletedThisCycle int64
 
 		for tableName, ceiling := range deletableTables {
-			result, err := e.writerDB.Exec(
+			var rows int64
+			err := e.writerDB.QueryRowContext(
+				e.ctx,
 				constructVariableMetaTableQuery(tableName, e.config.BatchSize, ceiling),
-			)
+			).Scan(&rows)
 			if err != nil {
 				e.logger.Error(
 					"error pruning envelopes",
-					zap.Error(err),
-					zap.String("table", tableName),
-				)
-				delete(deletableTables, tableName)
-				continue
-			}
-			rows, err := result.RowsAffected()
-			if err != nil {
-				e.logger.Error(
-					"Unexpected DB error: could not count envelopes",
 					zap.Error(err),
 					zap.String("table", tableName),
 				)


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1824

## Root Cause

The `ON DELETE CASCADE` FK on `gateway_envelope_blobs` referencing `gateway_envelopes_meta` was getting lost or failing to propagate when partitions were attached via `ensure_gateway_parts_v2`. This caused orphan blob rows to accumulate whenever the row pruner deleted expired meta rows.

Two contributing bugs were identified in migration 00015's partition management functions:
1. `make_meta_seq_subpart_v2` and `make_blob_seq_subpart_v2` passed `_oid` and `_start` as format args for the `seq_id_check` constraint instead of `_start` and `_end`, producing an impossible constraint (`seq_id >= {oid} AND seq_id < 0`). While cosmetic (table is empty at creation, constraint is immediately dropped), it was confusing.
2. The FK state could become inconsistent when meta partitions were attached before their corresponding blob partitions existed.

## Changes

### Migration 00023 (`pkg/db/migrations/00023_fix-blob-orphans.{up,down}.sql`)
- Deletes any existing orphan blobs (blobs with no matching meta row)
- Re-adds the FK constraint `ON DELETE CASCADE` on `gateway_envelope_blobs` if it is missing
- Fixes the `seq_id_check` argument order in `make_meta_seq_subpart_v2` and `make_blob_seq_subpart_v2`

### Pruner — explicit blob deletion (`pkg/prune/query.go`, `row_pruner.go`)
The row pruner now explicitly deletes blob rows alongside meta rows in a single atomic CTE, rather than relying solely on FK cascade. This is consistent with how `DropPrunablePartitions` already explicitly handles both tables and makes the behavior robust regardless of FK state.

The query now returns the count of deleted meta rows (via `SELECT count(*) FROM deleted_meta`) so the exhaustion check remains correct. `row_pruner.go` switches from `Exec`+`RowsAffected` to `QueryRowContext`+`Scan` to capture this count.

### Migration test (`pkg/db/migrations/migrations_test.go`)
- Bumps `currentMigration` to 23
- Adds `checkFixBlobOrphans`: verifies no orphan blobs remain and the FK constraint is present

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blob row deletion when meta rows are pruned in `gateway_envelope_blobs`
> - Adds a `ON DELETE CASCADE` foreign key from `gateway_envelope_blobs` to `gateway_envelopes_meta` via migration [00023_fix-blob-orphans.up.sql](https://github.com/xmtp/xmtpd/pull/1839/files#diff-afc4a69590a9acaca90a477225aefe8da67e309fc078525b6dc5395f9aab3252), and deletes any existing orphan blob rows.
> - Updates `constructVariableMetaTableQuery` in [query.go](https://github.com/xmtp/xmtpd/pull/1839/files#diff-81295a4022fb81ba122a01ea208e6c7c22a07b88fc794e7b663c363e69cd4f1e) to delete matching blob partition rows alongside meta rows in a single CTE-based query, returning the deleted count as a scalar.
> - Updates `PruneRows` in [row_pruner.go](https://github.com/xmtp/xmtpd/pull/1839/files#diff-8157c57b35bb98074499ab57e64cd5dcdc725d0307b7742f03d5ad8eb97cb417) to read the deleted count via `Scan` instead of `RowsAffected`.
> - Fixes argument order in `make_meta_seq_subpart_v2` and `make_blob_seq_subpart_v2` partition helper functions.
> - Behavioral Change: blob rows are now deleted atomically with meta rows during pruning; previously they were left as orphans.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c37d658.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->