### PR TITLE
Enable prepared statements via pgx for improved query plan caching

### DIFF
--- a/cmd/replication/main.go
+++ b/cmd/replication/main.go
@@ -165,7 +165,10 @@ func main() {
 				dbopts = append(dbopts, db.WithReadReplica(readDB))
 			}
 
-			dbh = db.NewDBHandler(writeDB, dbopts...)
+			dbh, err = db.NewDBHandler(ctx, writeDB, dbopts...)
+			if err != nil {
+				logger.Fatal("preparing database statements", zap.Error(err))
+			}
 
 			// Start a database worker in the background.
 			err = worker.NewWorker(logger, dbh).Start(ctx)

--- a/pkg/api/message/publish_test.go
+++ b/pkg/api/message/publish_test.go
@@ -655,9 +655,11 @@ func TestPublishEnvelopeBalanceEnforcement(t *testing.T) {
 				payerAddr, err := payerEnv.RecoverSigner()
 				require.NoError(t, err)
 
+				dbHandler, err := dbPkg.NewDBHandler(t.Context(), suite.DB)
+				require.NoError(t, err)
 				payerLedger := ledger.NewLedger(
 					testutils.NewLog(t),
-					dbPkg.NewDBHandler(suite.DB),
+					dbHandler,
 				)
 				payerID, err := payerLedger.FindOrCreatePayer(
 					context.Background(),
@@ -735,7 +737,9 @@ func TestPublishEnvelopeMultiEnvelopeBatchBalance(t *testing.T) {
 
 	// Deposit enough for 1 envelope but not 3
 	payerAddr := crypto.PubkeyToAddress(signerKey.PublicKey)
-	payerLedger := ledger.NewLedger(testutils.NewLog(t), dbPkg.NewDBHandler(suite.DB))
+	payerDBHandler, err := dbPkg.NewDBHandler(t.Context(), suite.DB)
+	require.NoError(t, err)
+	payerLedger := ledger.NewLedger(testutils.NewLog(t), payerDBHandler)
 	payerID, err := payerLedger.FindOrCreatePayer(context.Background(), payerAddr)
 	require.NoError(t, err)
 

--- a/pkg/api/message/publish_worker.go
+++ b/pkg/api/message/publish_worker.go
@@ -175,8 +175,8 @@ func (p *publishWorker) processBatch() (int32, error) {
 
 	var spans []tracing.Span
 
-	result, err := db.RunInTxWithResult(
-		p.ctx, p.store.DB(), &sql.TxOptions{},
+	result, err := db.HandlerRunInTxWithResult(
+		p.ctx, p.store, &sql.TxOptions{},
 		func(ctx context.Context, txQueries *queries.Queries) (batchResult, error) {
 			staged, err := txQueries.SelectAndLockStagedEnvelopes(
 				ctx, numRowsPerBatch,

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 
@@ -30,30 +31,39 @@ type Handler struct {
 	// Handle to read-only DB. Preferred for reads, if available.
 	read *sql.DB
 
-	// NOTE: This is potentially just overhead since it's trivial to create queries in other places.
 	query     *queries.Queries
 	readQuery *queries.Queries
 }
 
 // NewDBHandler creates a new database handler with two database connections - a read-write and a read one.
 // If there's no exclusive read replica it can be omitted and the write replica will be used.
-func NewDBHandler(db *sql.DB, options ...HandlerOption) *Handler {
+// Prepared statements are registered on startup so the PostgreSQL server can cache query plans.
+func NewDBHandler(ctx context.Context, db *sql.DB, options ...HandlerOption) (*Handler, error) {
 	var cfg handlerConfig
 	for _, opt := range options {
 		opt(&cfg)
 	}
 
+	q, err := queries.Prepare(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
 	handler := &Handler{
 		write: db,
-		query: queries.New(db),
+		query: q,
 	}
 
 	if cfg.readReplica != nil {
+		rq, err := queries.Prepare(ctx, cfg.readReplica)
+		if err != nil {
+			return nil, err
+		}
 		handler.read = cfg.readReplica
-		handler.readQuery = queries.New(cfg.readReplica)
+		handler.readQuery = rq
 	}
 
-	return handler
+	return handler, nil
 }
 
 func (h *Handler) DB() *sql.DB {

--- a/pkg/db/tx.go
+++ b/pkg/db/tx.go
@@ -62,7 +62,60 @@ func RunInTxWithResult[T any](
 		}
 	}()
 
-	result, err = fn(ctx, queries.New(db).WithTx(tx))
+	result, err = fn(ctx, queries.New(tx))
+	if err != nil {
+		return result, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+// RunInTxRaw runs fn inside a transaction using the handler's write DB.
+func (h *Handler) RunInTxRaw(
+	ctx context.Context,
+	opts *sql.TxOptions,
+	fn func(ctx context.Context, tx *sql.Tx) error,
+) error {
+	return RunInTxRaw(ctx, h.write, opts, fn)
+}
+
+// RunInTx runs fn inside a transaction, providing prepared queries bound to the transaction.
+// This allows PostgreSQL to reuse cached query plans for all statements in the transaction.
+func (h *Handler) RunInTx(
+	ctx context.Context,
+	opts *sql.TxOptions,
+	fn func(ctx context.Context, txQueries *queries.Queries) error,
+) error {
+	return RunInTxRaw(ctx, h.write, opts, func(ctx context.Context, tx *sql.Tx) error {
+		return fn(ctx, h.query.WithTx(tx))
+	})
+}
+
+// HandlerRunInTxWithResult runs fn inside a transaction on h and returns a result.
+// It provides prepared queries bound to the transaction so PostgreSQL can reuse cached query plans.
+// Note: Go does not allow generic methods on non-generic types, so this is a package-level function.
+func HandlerRunInTxWithResult[T any](
+	ctx context.Context,
+	h *Handler,
+	opts *sql.TxOptions,
+	fn func(ctx context.Context, txQueries *queries.Queries) (T, error),
+) (result T, err error) {
+	tx, err := h.write.BeginTx(ctx, opts)
+	if err != nil {
+		return result, err
+	}
+
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	result, err = fn(ctx, h.query.WithTx(tx))
 	if err != nil {
 		return result, err
 	}

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -15,6 +15,7 @@ package migrator
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -103,7 +104,7 @@ type Migrator struct {
 
 	// Data management.
 	target              *db.Handler
-	source              *db.Handler
+	source              *sql.DB
 	readers             map[string]ISourceReader
 	transformer         IDataTransformer
 	blockchainPublisher blockchain.IBlockchainPublisher
@@ -182,8 +183,6 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 		return nil, err
 	}
 
-	readDB := db.NewDBHandler(reader, db.WithReadReplica(reader))
-
 	logger.Info(
 		"running migration service with lower limits configured as",
 		zap.Int64(
@@ -210,19 +209,19 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 
 	readers := map[string]ISourceReader{
 		groupMessagesTableName: NewGroupMessageReader(
-			readDB.DB(),
+			reader,
 			cfg.options.LowerLimits.Get(config.MigrationSourceGroupMessages),
 		),
-		inboxLogTableName: NewInboxLogReader(readDB.DB()),
+		inboxLogTableName: NewInboxLogReader(reader),
 		keyPackagesTableName: NewKeyPackageReader(
-			readDB.DB(),
+			reader,
 			cfg.options.LowerLimits.Get(config.MigrationSourceKeyPackages),
 		),
 		welcomeMessagesTableName: NewWelcomeMessageReader(
-			readDB.DB(),
+			reader,
 			cfg.options.LowerLimits.Get(config.MigrationSourceWelcomeMessages),
 		),
-		commitMessagesTableName: NewCommitMessageReader(readDB.DB()),
+		commitMessagesTableName: NewCommitMessageReader(reader),
 	}
 
 	transformer := NewTransformer(cfg.feeCalculator, payerPrivateKey, nodeSigningKey)
@@ -247,7 +246,7 @@ func NewMigrationService(opts ...DBMigratorOption) (*Migrator, error) {
 		mu:                  sync.RWMutex{},
 		logger:              logger,
 		target:              cfg.db,
-		source:              readDB,
+		source:              reader,
 		readers:             readers,
 		transformer:         transformer,
 		blockchainPublisher: blockchainPublisher,

--- a/pkg/migrator/writer.go
+++ b/pkg/migrator/writer.go
@@ -34,9 +34,8 @@ func (w *Worker) insertOriginatorEnvelopeDatabaseBatch(
 		return re.NewNonRecoverableError("", errors.New("batch is nil"))
 	}
 
-	err := db.RunInTx(
+	err := w.writer.RunInTx(
 		ctx,
-		w.writer.Write(),
 		nil,
 		func(ctx context.Context, querier *queries.Queries) error {
 			_, err := querier.SetLocalWorkMem(ctx, batchWorkMem)

--- a/pkg/payerreport/store.go
+++ b/pkg/payerreport/store.go
@@ -165,9 +165,8 @@ func (s *Store) ForceSetReportSubmitted(ctx context.Context, id ReportID, report
 }
 
 func (s *Store) SetReportSettled(ctx context.Context, id ReportID) error {
-	return db.RunInTx(
+	return s.db.RunInTx(
 		ctx,
-		s.db.DB(),
 		&sql.TxOptions{},
 		func(ctx context.Context, txQueries *queries.Queries) error {
 			var (
@@ -289,9 +288,8 @@ func (s *Store) CreatePayerReport(
 		return nil, err
 	}
 
-	if err = db.RunInTx(
+	if err = s.db.RunInTx(
 		ctx,
-		s.db.DB(),
 		&sql.TxOptions{},
 		func(ctx context.Context, tx *queries.Queries) error {
 			var (
@@ -346,9 +344,8 @@ func (s *Store) CreateAttestation(
 		return ErrReportNil
 	}
 
-	return db.RunInTx(
+	return s.db.RunInTx(
 		ctx,
-		s.db.DB(),
 		&sql.TxOptions{},
 		func(ctx context.Context, tx *queries.Queries) error {
 			report, err := tx.FetchPayerReportLocked(ctx, reportID)
@@ -450,9 +447,8 @@ func (s *Store) StoreSyncedReport(
 		return err
 	}
 
-	return db.RunInTx(
+	return s.db.RunInTx(
 		ctx,
-		s.db.DB(),
 		&sql.TxOptions{},
 		func(ctx context.Context, txQueries *queries.Queries) error {
 			_, err := db.InsertGatewayEnvelopeWithChecksTransactional(ctx, txQueries,
@@ -496,9 +492,8 @@ func (s *Store) StoreSyncedAttestation(
 
 	attestationProto := attestationProtoWrapper.PayerReportAttestation
 
-	return db.RunInTx(
+	return s.db.RunInTx(
 		ctx,
-		s.db.DB(),
 		&sql.TxOptions{},
 		func(ctx context.Context, txQueries *queries.Queries) error {
 			_, err := db.InsertGatewayEnvelopeWithChecksTransactional(ctx, txQueries,

--- a/pkg/payerreport/workers/integration_test.go
+++ b/pkg/payerreport/workers/integration_test.go
@@ -220,8 +220,12 @@ func setupMultiNodeTest(t *testing.T) multiNodeTestScaffold {
 	)
 	require.NoError(t, err)
 
-	payerReportStore1 := payerreport.NewStore(log, db.NewDBHandler(dbs[0]))
-	payerReportStore2 := payerreport.NewStore(log, db.NewDBHandler(dbs[1]))
+	dbHandler1, err := db.NewDBHandler(t.Context(), dbs[0])
+	require.NoError(t, err)
+	dbHandler2, err := db.NewDBHandler(t.Context(), dbs[1])
+	require.NoError(t, err)
+	payerReportStore1 := payerreport.NewStore(log, dbHandler1)
+	payerReportStore2 := payerreport.NewStore(log, dbHandler2)
 	reportGenerator1 := workers.NewGeneratorWorker(
 		t.Context(),
 		log.With(zap.Uint32("node_id", server1NodeID)),

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -171,10 +171,12 @@ func NewTestAPIServer(
 		ctx, cancel           = context.WithCancel(context.Background())
 		log                   = testutils.NewLog(t)
 		sqlDB, _              = testutils.NewRawDB(t, ctx)
-		db                    = dbPkg.NewDBHandler(sqlDB)
 		mockMessagePublisher  = blockchainMocks.NewMockIBlockchainPublisher(t)
 		mockValidationService = mlsvalidateMocks.NewMockMLSValidationService(t)
 	)
+
+	db, err := dbPkg.NewDBHandler(ctx, sqlDB)
+	require.NoError(t, err)
 
 	privKey, err := crypto.GenerateKey()
 	require.NoError(t, err)

--- a/pkg/testutils/server/server.go
+++ b/pkg/testutils/server/server.go
@@ -44,10 +44,13 @@ func NewTestBaseServer(
 ) *s.BaseServer {
 	log := testutils.NewLog(t)
 
+	dbHandler, err := db.NewDBHandler(t.Context(), cfg.DB)
+	require.NoError(t, err)
+
 	opts := []s.BaseServerOption{
 		s.WithContext(t.Context()),
 		s.WithLogger(log),
-		s.WithDB(db.NewDBHandler(cfg.DB)),
+		s.WithDB(dbHandler),
 		s.WithNodeRegistry(cfg.Registry),
 		s.WithServerVersion(testutils.GetLatestVersion(t)),
 		s.WithFeeCalculator(fees.NewTestFeeCalculator()),

--- a/pkg/testutils/store.go
+++ b/pkg/testutils/store.go
@@ -75,7 +75,9 @@ func NewDB(t *testing.T, ctx context.Context) (*xmtpdb.Handler, string) {
 	t.Helper()
 
 	dbh, dsn := NewRawDB(t, ctx)
-	return xmtpdb.NewDBHandler(dbh), dsn
+	handler, err := xmtpdb.NewDBHandler(ctx, dbh)
+	require.NoError(t, err)
+	return handler, dsn
 }
 
 func NewDBs(t *testing.T, ctx context.Context, count int) []*sql.DB {


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1726

## Summary

This spike investigated whether performance could be improved by using prepared plans via pgx. **Conclusion: no need to bypass the `*sql.DB` wrapper** — pgx's `stdlib` adapter fully supports prepared statements through the standard interface. The issue was that `queries.Prepare()` was never being called even though `emit_prepared_queries: true` was set in `sqlc.yaml`.

### What changed

- **`NewDBHandler`** now accepts `context.Context` and calls `queries.Prepare(ctx, db)` to send `Parse` messages for all queries to PostgreSQL at startup, enabling server-side plan caching. Returns `(*Handler, error)`.

- **New handler transaction methods** (`Handler.RunInTx`, `Handler.RunInTxRaw`, `HandlerRunInTxWithResult`) propagate the prepared `*sql.Stmt` objects into transactions via `sql.Tx.StmtContext()`. This lets PostgreSQL reuse the cached plan inside transactions.

- **Hot-path callers migrated** to use handler transaction methods: `publish_worker`, `payerreport/store` (5 call sites), `migrator/writer`.

- **Minor bugfix**: `RunInTxWithResult` free function was using `queries.New(db).WithTx(tx)` — changed to `queries.New(tx)` which is equivalent but cleaner.

- **Migrator source DB**: The migrator reads from a legacy database schema that doesn't have all current tables. Changed `source` field from `*db.Handler` to `*sql.DB` to avoid failing prepared-statement registration against an incomplete schema.

### How prepared statements work with pgx/stdlib

The `pgx/stdlib` adapter implements `PrepareContext` by sending PostgreSQL's extended protocol `Parse` message. The resulting `*sql.Stmt` is pool-aware — each connection in the pool gets the statement prepared lazily on first use. Inside transactions, `tx.StmtContext(stmt)` binds the already-parsed statement to the transaction, avoiding re-parsing per query.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `dev/lint-fix` reports 0 issues
- [x] All affected packages pass tests individually: `pkg/db`, `pkg/migrator`, `pkg/payerreport`, `pkg/payerreport/workers`, `pkg/server`, `pkg/sync`, `pkg/ledger`, `pkg/indexer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable prepared statements in `db.Handler` for query plan caching
> - Changes `db.NewDBHandler` to accept a context and return `(*Handler, error)`, preparing SQL statements for both the write DB and optional read replica on construction via `queries.Prepare`.
> - Adds `Handler.RunInTx`, `Handler.RunInTxRaw`, and `HandlerRunInTxWithResult` methods to bind prepared queries to transactions, replacing standalone `db.RunInTx` calls across the codebase.
> - Updates all call sites — including migrator, payer report store, publish worker, and test utilities — to use the new constructor signature and handler-scoped transaction helpers.
> - Risk: `NewDBHandler` can now fail at startup; callers that do not handle the error will panic or log fatal, changing prior behavior where construction was infallible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5379314.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->