### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xmtpd
 
-[![Github tag](https://img.shields.io/github/v/tag/xmtp/xmtpd.svg?sort=semver)](https://github.com/xmtp/xmtpd/releases/latest)
+[![GitHub tag](https://img.shields.io/github/v/tag/xmtp/xmtpd.svg?sort=semver)](https://github.com/xmtp/xmtpd/releases/latest)
 [![Test](https://github.com/xmtp/xmtpd/actions/workflows/test.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/test.yml)
 [![Lint](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/lint-go.yml)
 [![Build](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml/badge.svg)](https://github.com/xmtp/xmtpd/actions/workflows/build-xmtpd.yml)
@@ -161,7 +161,7 @@ See [Node Registry Migration](doc/node-registry-migration-v2.md).
 
 ## xmtpd OpenMetrics catalog
 
-See [xmptd OpenMetrics catalog](doc/metrics_catalog.md).
+See [xmtpd OpenMetrics catalog](doc/metrics_catalog.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Automated typo/grammar cleanup for `xmtp/xmtpd` documentation.

## Changed files
- `README.md`: 2 edit(s)

## Validation
- Reviewed only Markdown documentation files.
- Kept edits minimal and localized.

Automated typo fix. If this helps, feel free to drop a coffee tip to my Base network address: 0x1fD26F97267Ed2a5F674f8505e286271804d1046

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix typos in README.md badge alt text and section link
> Corrects two typos in [README.md](https://github.com/xmtp/xmtpd/pull/1847/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5): capitalizes 'Github' to 'GitHub' in a badge alt text, and fixes 'xmptd' to 'xmtpd' in a section link label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe46a37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->