### PR TITLE
Migrator: remove redundant check

### DIFF
--- a/pkg/migrator/transformer.go
+++ b/pkg/migrator/transformer.go
@@ -399,17 +399,13 @@ func transformGroupMessage(groupMessage *GroupMessage) (*proto.ClientEnvelope, e
 		return nil, errors.New("groupMessage is nil")
 	}
 
-	if groupMessage.GroupID == nil {
-		return nil, errors.New("groupID is nil")
+	if len(groupMessage.Data) <= 0 {
+		return nil, errors.New("data is empty")
 	}
 
 	_, err := utils.ParseGroupID(groupMessage.GroupID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse group ID: %w", err)
-	}
-
-	if len(groupMessage.Data) <= 0 {
-		return nil, errors.New("data is empty")
 	}
 
 	return &proto.ClientEnvelope{


### PR DESCRIPTION
The null check is redundant as ParseGroupID checks len(groupMessage.GroupID) 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant nil check in `transformGroupMessage`
> Reorders validation in [transformer.go](https://github.com/xmtp/xmtpd/pull/1850/files#diff-c76d70079716ba42e22c5b5031c1960504cccbca874aadb118385ca67341cf62) so that empty data is checked before `ParseGroupID` is called. The explicit nil check on `groupID` is removed since `ParseGroupID` already handles that case. Behavioral Change: a nil or invalid group ID now returns a "failed to parse group ID" error instead of "groupID is nil".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9b195e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->