### PR TITLE
fix: cancel nonce on replacement-underpriced instead of consuming it

### DIFF
--- a/pkg/blockchain/blockchain_publisher.go
+++ b/pkg/blockchain/blockchain_publisher.go
@@ -511,8 +511,7 @@ func withNonce[T any](ctx context.Context,
 				strings.Contains(
 					err.Error(),
 					"nonce too low",
-				) ||
-				strings.Contains(err.Error(), "replacement transaction underpriced") {
+				) {
 				logger.Debug(
 					"nonce already used, consume and move on",
 					utils.NonceField(nonce.Uint64()),
@@ -524,6 +523,17 @@ func withNonce[T any](ctx context.Context,
 					nonceContext.Cancel()
 					return nil, err
 				}
+				continue
+			}
+
+			if strings.Contains(err.Error(), "replacement transaction underpriced") {
+				logger.Debug(
+					"replacement transaction underpriced, cancel and back off",
+					utils.NonceField(nonce.Uint64()),
+					zap.Error(err),
+				)
+				nonceContext.Cancel()
+				utils.RandomSleep(ctx, 500*time.Millisecond)
 				continue
 			}
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/xmtp/xmtpd/issues/1884

- Separates "replacement transaction underpriced" handling from "nonce too low" in `withNonce()`
- When a replacement is underpriced, cancels the nonce reservation (returns it to the pool) and backs off instead of consuming and advancing
- This prevents creating dependent transactions at N+1 that can't mine until the pending transaction at N confirms

## Problem

When `SendTransaction` returns "replacement transaction underpriced", it means a pending transaction already exists at that nonce with a higher gas price. The original transaction is still in the mempool and will eventually be mined. Previously, the publisher treated this the same as "nonce too low" — consumed the nonce and advanced to N+1. This created transactions that couldn't be mined until N confirmed, causing cascading 2-second receipt timeouts.

## Fix

Cancel the nonce reservation and back off (matching the existing "nonce too high" pattern). The pending transaction confirms naturally, and the replenish loop (every 10s) handles nonce advancement via `PendingNonceAt`.

## Test plan

- [x] All existing blockchain publisher tests pass
- [x] Linter passes with 0 issues
- [x] Code compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel nonce on replacement-underpriced error in `withNonce` instead of consuming it
> Previously, `replacement transaction underpriced` errors were handled the same as `nonce too low`, which consumed the nonce and continued. This fix adds a dedicated branch in [`blockchain_publisher.go`](https://github.com/xmtp/xmtpd/pull/1893/files#diff-34945381e6d6c8fd46135fba01f516516618c89e7bc8908562743f1ba06df259) that cancels the nonce context and sleeps up to 500ms (via `utils.RandomSleep`) before retrying.
>
> Behavioral Change: nonce reservations are now released on replacement-underpriced errors, preventing nonce exhaustion under retry conditions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f14ddb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->