### PR TITLE
Fix cancellation handling gap in publish worker retry loops

### DIFF
--- a/pkg/api/message/publish_worker.go
+++ b/pkg/api/message/publish_worker.go
@@ -134,6 +134,9 @@ func (p *publishWorker) start() {
 // pollAndPublish processes batches in a loop until no more rows are available.
 func (p *publishWorker) pollAndPublish() {
 	for {
+		if p.ctx.Err() != nil {
+			return
+		}
 		count, err := p.processBatchWithRetry()
 		if err != nil {
 			p.logger.Error("failed to process batch", zap.Error(err))
@@ -149,6 +152,9 @@ func (p *publishWorker) pollAndPublish() {
 // processBatchWithRetry retries the batch on transient database errors such as deadlocks.
 func (p *publishWorker) processBatchWithRetry() (int32, error) {
 	for attempt := range maxDeadlockRetries {
+		if p.ctx.Err() != nil {
+			return 0, p.ctx.Err()
+		}
 		count, err := p.processBatch()
 		if err != nil && retryerrors.IsRetryableSQLError(err) && attempt < maxDeadlockRetries-1 {
 			p.logger.Warn("retrying batch after transient error",

--- a/pkg/api/message/publish_worker_test.go
+++ b/pkg/api/message/publish_worker_test.go
@@ -379,6 +379,55 @@ func TestPublishWorkerContextCancellation(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestPublishWorkerPollAndPublishExitsOnCancel verifies that pollAndPublish
+// returns promptly when the context is cancelled, rather than continuing to
+// retry in the inner loop.
+func TestPublishWorkerPollAndPublishExitsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Cancel the context before calling pollAndPublish
+	cancel()
+
+	worker := &publishWorker{
+		ctx:                ctx,
+		logger:             testutils.NewLog(t),
+		sleepOnFailureTime: 10 * time.Millisecond,
+		notifier:           make(chan bool, 1),
+	}
+
+	// pollAndPublish should return immediately instead of looping
+	done := make(chan struct{})
+	go func() {
+		worker.pollAndPublish()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: pollAndPublish exited promptly
+	case <-time.After(2 * time.Second):
+		t.Fatal("pollAndPublish did not exit after context cancellation")
+	}
+}
+
+// TestPublishWorkerProcessBatchWithRetryExitsOnCancel verifies that
+// processBatchWithRetry returns promptly when the context is cancelled.
+func TestPublishWorkerProcessBatchWithRetryExitsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	cancel()
+
+	worker := &publishWorker{
+		ctx:                ctx,
+		logger:             testutils.NewLog(t),
+		sleepOnFailureTime: 10 * time.Millisecond,
+	}
+
+	count, err := worker.processBatchWithRetry()
+	require.Equal(t, int32(0), count)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // TestPublishWorkerReservedTopicNoFees verifies that envelopes on reserved topics
 // (e.g., payer reports) are processed with zero base fee and zero congestion fee.
 func TestPublishWorkerReservedTopicNoFees(t *testing.T) {


### PR DESCRIPTION
## Summary

Resolves https://github.com/xmtp/xmtpd/issues/1865

- Adds `ctx.Err()` check at the top of `pollAndPublish()` loop so it exits immediately when the context is cancelled instead of calling `processBatchWithRetry()` again
- Adds `ctx.Err()` check at the top of `processBatchWithRetry()` loop so it returns early on cancellation instead of retrying
- Adds two focused unit tests verifying both loops exit promptly on context cancellation (no database required)

## Changes

**`pkg/api/message/publish_worker.go`**
- `pollAndPublish()`: Check `p.ctx.Err()` at loop start
- `processBatchWithRetry()`: Check `p.ctx.Err()` at loop start, return the context error

**`pkg/api/message/publish_worker_test.go`**
- `TestPublishWorkerPollAndPublishExitsOnCancel`: Verifies `pollAndPublish` returns promptly after cancel
- `TestPublishWorkerProcessBatchWithRetryExitsOnCancel`: Verifies `processBatchWithRetry` returns `context.Canceled`

## Test plan

- [x] New unit tests pass: `go test ./pkg/api/message/ -run "TestPublishWorkerPollAndPublishExitsOnCancel|TestPublishWorkerProcessBatchWithRetryExitsOnCancel"`
- [x] Package compiles cleanly
- [x] Linter passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cancellation handling gap in publish worker retry loops
> Adds early-exit checks at the start of each iteration in `publishWorker.pollAndPublish` and `publishWorker.processBatchWithRetry` in [publish_worker.go](https://github.com/xmtp/xmtpd/pull/1896/files#diff-a985e2d18aa8bb7ea586f77e5bc52dad0a4c4989e5a220806f737fb1c9c50415) to return immediately when the worker context is canceled, rather than continuing to process or sleep. New tests in [publish_worker_test.go](https://github.com/xmtp/xmtpd/pull/1896/files#diff-54f987d5f63cc845bd16c42fab5581c5d0dd21d0ccab057323cd2c87f49c4c65) cover both cancellation paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8b3fcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->