### PR TITLE
Add retry with exponential backoff to Redis nonce manager cancel/consume

### DIFF
--- a/pkg/blockchain/noncemanager/redis/manager.go
+++ b/pkg/blockchain/noncemanager/redis/manager.go
@@ -289,7 +289,7 @@ func (r *RedisBackedNonceManager) createNonceContext(nonce int64) *noncemanager.
 
 // cancelNonce returns a nonce to the available pool with retry on transient failures
 func (r *RedisBackedNonceManager) cancelNonce(nonce int64) {
-	attempts, err := retryWithBackoff(func() error {
+	attempts, err := utils.RetryWithBackoff(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), RedisOperationTimeout)
 		defer cancel()
 
@@ -301,7 +301,7 @@ func (r *RedisBackedNonceManager) cancelNonce(nonce int64) {
 		})
 		_, err := pipe.Exec(ctx)
 		return err
-	})
+	}, maxRetries, initialBackoff)
 	if err != nil {
 		r.logger.Error("failed to return cancelled nonce to Redis",
 			utils.NonceField(uint64(nonce)), zap.Error(err))
@@ -315,12 +315,12 @@ func (r *RedisBackedNonceManager) cancelNonce(nonce int64) {
 
 // consumeNonce removes a nonce from the reserved pool with retry on transient failures
 func (r *RedisBackedNonceManager) consumeNonce(nonce int64) {
-	attempts, err := retryWithBackoff(func() error {
+	attempts, err := utils.RetryWithBackoff(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), RedisOperationTimeout)
 		defer cancel()
 
 		return r.client.ZRem(ctx, r.reservedKey(), nonce).Err()
-	})
+	}, maxRetries, initialBackoff)
 	if err != nil {
 		r.logger.Error("failed to remove consumed nonce from reserved set",
 			utils.NonceField(uint64(nonce)), zap.Error(err))
@@ -330,23 +330,4 @@ func (r *RedisBackedNonceManager) consumeNonce(nonce int64) {
 		r.logger.Warn("consumed nonce removed from reserved set after retry",
 			utils.NonceField(uint64(nonce)), zap.Int("attempts", attempts))
 	}
-}
-
-// retryWithBackoff retries fn up to maxRetries times with exponential backoff.
-// Returns the number of attempts made and the last error (nil on success).
-func retryWithBackoff(fn func() error) (int, error) {
-	backoff := initialBackoff
-	for attempt := range maxRetries {
-		err := fn()
-		if err == nil {
-			return attempt + 1, nil
-		}
-		if attempt == maxRetries-1 {
-			return maxRetries, err
-		}
-		time.Sleep(backoff)
-		backoff *= 2
-	}
-	// unreachable, but satisfies the compiler
-	return maxRetries, nil
 }

--- a/pkg/utils/backoff.go
+++ b/pkg/utils/backoff.go
@@ -20,3 +20,28 @@ func NewBackoff(
 		backoff.WithMaxElapsedTime(maxElapsedTime),
 	)
 }
+
+// RetryWithBackoff retries fn with exponential backoff using the given parameters.
+// Returns the number of attempts made and the last error (nil on success).
+func RetryWithBackoff(
+	fn func() error,
+	maxRetries int,
+	initialInterval time.Duration,
+) (int, error) {
+	attempts := 0
+	delay := initialInterval
+	for range maxRetries {
+		attempts++
+		err := fn()
+		if err == nil {
+			return attempts, nil
+		}
+		if attempts == maxRetries {
+			return attempts, err
+		}
+		time.Sleep(delay)
+		delay *= 2
+	}
+	// unreachable, but satisfies the compiler
+	return attempts, nil
+}

--- a/pkg/utils/backoff_test.go
+++ b/pkg/utils/backoff_test.go
@@ -1,8 +1,9 @@
-package redis
+package utils
 
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,10 +11,10 @@ import (
 
 func TestRetryWithBackoff_SucceedsFirstAttempt(t *testing.T) {
 	calls := 0
-	attempts, err := retryWithBackoff(func() error {
+	attempts, err := RetryWithBackoff(func() error {
 		calls++
 		return nil
-	})
+	}, 3, 50*time.Millisecond)
 	require.NoError(t, err)
 	assert.Equal(t, 1, attempts)
 	assert.Equal(t, 1, calls)
@@ -21,13 +22,13 @@ func TestRetryWithBackoff_SucceedsFirstAttempt(t *testing.T) {
 
 func TestRetryWithBackoff_SucceedsOnRetry(t *testing.T) {
 	calls := 0
-	attempts, err := retryWithBackoff(func() error {
+	attempts, err := RetryWithBackoff(func() error {
 		calls++
 		if calls < 2 {
 			return errors.New("transient error")
 		}
 		return nil
-	})
+	}, 3, 50*time.Millisecond)
 	require.NoError(t, err)
 	assert.Equal(t, 2, attempts)
 	assert.Equal(t, 2, calls)
@@ -35,26 +36,26 @@ func TestRetryWithBackoff_SucceedsOnRetry(t *testing.T) {
 
 func TestRetryWithBackoff_ExhaustsRetries(t *testing.T) {
 	calls := 0
-	attempts, err := retryWithBackoff(func() error {
+	attempts, err := RetryWithBackoff(func() error {
 		calls++
 		return errors.New("persistent error")
-	})
+	}, 3, 50*time.Millisecond)
 	require.Error(t, err)
-	assert.Equal(t, maxRetries, attempts)
-	assert.Equal(t, maxRetries, calls)
+	assert.Equal(t, 3, attempts)
+	assert.Equal(t, 3, calls)
 	assert.Contains(t, err.Error(), "persistent error")
 }
 
 func TestRetryWithBackoff_SucceedsOnLastAttempt(t *testing.T) {
 	calls := 0
-	attempts, err := retryWithBackoff(func() error {
+	attempts, err := RetryWithBackoff(func() error {
 		calls++
-		if calls < maxRetries {
+		if calls < 3 {
 			return errors.New("transient error")
 		}
 		return nil
-	})
+	}, 3, 50*time.Millisecond)
 	require.NoError(t, err)
-	assert.Equal(t, maxRetries, attempts)
-	assert.Equal(t, maxRetries, calls)
+	assert.Equal(t, 3, attempts)
+	assert.Equal(t, 3, calls)
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/xmtp/xmtpd/issues/1875

- Add `retryWithBackoff` helper that retries up to 3 times with exponential backoff (50ms → 100ms → 200ms)
- Wrap `cancelNonce` Redis pipeline execution in retry logic
- Wrap `consumeNonce` Redis ZREM command in retry logic
- Log at Warn level on retry success, Error level on exhaustion (preserves existing behavior)
- No interface changes — purely internal improvement

This reduces the window where a nonce can be stuck in the reserved set from ~30s (stale cleanup) to the duration of a brief retry sequence for transient Redis failures.

## Test plan

- [x] Unit tests for `retryWithBackoff`: success on first attempt, success on retry, exhaustion, success on last attempt
- [x] Compilation verified
- [x] Linter passes with 0 issues
- [ ] Integration tests pass (require Redis — verified no regressions in test structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add retry with exponential backoff to `cancelNonce` and `consumeNonce` in Redis nonce manager
> - Adds a `RetryWithBackoff` helper in [`pkg/utils/backoff.go`](https://github.com/xmtp/xmtpd/pull/1900/files#diff-5fe491ef4b7467149ac96c0e25fc2583449ec4f620a52bb4343e9ce299085fab) that retries a function up to a max attempt count with a doubling delay, returning the attempt count and last error.
> - `cancelNonce` and `consumeNonce` in [`pkg/blockchain/noncemanager/redis/manager.go`](https://github.com/xmtp/xmtpd/pull/1900/files#diff-8c0a8a2a7cbaa3df924d9b9962f8bc98817194b140cf7e54b14deedcbbd63dd3) now wrap their Redis calls with this helper, logging a warning on retry and an error only after all attempts are exhausted.
> - Four unit tests cover immediate success, mid-retry success, last-attempt success, and full exhaustion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b53294.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->