### PR TITLE
Fix bridging backfill gap in RPC log streamer

### DIFF
--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -212,7 +212,9 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 					case errors.Is(err, ErrEndOfBackfill):
 						if response.NextBlockNumber != nil {
 							backfillFromBlockNumber = *response.NextBlockNumber
-							backfillFromBlockHash = response.NextBlockHash
+							if response.NextBlockHash != nil {
+								backfillFromBlockHash = response.NextBlockHash
+							}
 						}
 						if len(response.Logs) > 0 {
 							for _, log := range response.Logs {
@@ -280,7 +282,9 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 					case errors.Is(err, ErrEndOfBackfill):
 						if response.NextBlockNumber != nil {
 							backfillFromBlockNumber = *response.NextBlockNumber
-							backfillFromBlockHash = response.NextBlockHash
+							if response.NextBlockHash != nil {
+								backfillFromBlockHash = response.NextBlockHash
+							}
 						}
 						if len(response.Logs) > 0 {
 							for _, log := range response.Logs {

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -267,13 +267,6 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 
 		// Bridging backfill: cover any gap between HTTP head (where backfill ended) and
 		// the WS head (where the subscription starts delivering logs).
-		if backfillFromBlockNumber <= subFromBlock {
-			logger.Info(
-				"bridging backfill gap",
-				zap.Uint64("from_block", backfillFromBlockNumber),
-				zap.Uint64("sub_from_block", subFromBlock),
-			)
-		}
 	bridgingLoop:
 		for backfillFromBlockNumber <= subFromBlock {
 			select {
@@ -464,9 +457,10 @@ func (r *RPCLogStreamer) GetNextPage(
 	metrics.EmitIndexerLogBytesIndexed(cfg.Address.Hex(), dataSize)
 
 	if toBlock+1 > highestBlock {
+		nextBlock := toBlock + 1
 		return GetNextPageResponse{
 			Logs:            logs,
-			NextBlockNumber: nil,
+			NextBlockNumber: &nextBlock,
 			NextBlockHash:   nil,
 		}, ErrEndOfBackfill
 	}

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer.go
@@ -180,7 +180,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 
 	defer close(cfg.eventChannel)
 
-	sub, err := r.buildSubscription(cfg, innerSubCh)
+	sub, subFromBlock, err := r.buildSubscription(cfg, innerSubCh)
 	if err != nil {
 		logger.Error("failed to subscribe to contract", zap.Error(err))
 		return
@@ -200,7 +200,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 				}
 
 				logger.Warn("subscription error, rebuilding", zap.Error(err))
-				sub, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
+				sub, subFromBlock, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
 				if err != nil {
 					logger.Fatal("failed rebuilding subscription after max disconnect time", zap.Error(err), zap.String("max_disconnect_time", cfg.MaxDisconnectTime.String()))
 				}
@@ -265,6 +265,58 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 			}
 		}
 
+		// Bridging backfill: cover any gap between HTTP head (where backfill ended) and
+		// the WS head (where the subscription starts delivering logs).
+		if backfillFromBlockNumber <= subFromBlock {
+			logger.Info(
+				"bridging backfill gap",
+				zap.Uint64("from_block", backfillFromBlockNumber),
+				zap.Uint64("sub_from_block", subFromBlock),
+			)
+		}
+	bridgingLoop:
+		for backfillFromBlockNumber <= subFromBlock {
+			select {
+			case <-r.ctx.Done():
+				logger.Info("context cancelled during bridging backfill")
+				return
+			default:
+				response, err := r.GetNextPage(r.ctx, cfg, backfillFromBlockNumber, backfillFromBlockHash)
+				if err != nil {
+					switch {
+					case errors.Is(err, ErrEndOfBackfill):
+						if response.NextBlockNumber != nil {
+							backfillFromBlockNumber = *response.NextBlockNumber
+							backfillFromBlockHash = response.NextBlockHash
+						}
+						if len(response.Logs) > 0 {
+							for _, log := range response.Logs {
+								cfg.eventChannel <- log
+							}
+						} else {
+							cfg.eventChannel <- c.NewUpdateProgressLog(backfillFromBlockNumber, backfillFromBlockHash)
+						}
+						break bridgingLoop
+					case errors.Is(err, ErrReorg):
+						logger.Warn("reorg detected during bridging backfill", utils.BlockNumberField(*response.NextBlockNumber))
+					default:
+						logger.Error("error during bridging backfill", utils.BlockNumberField(backfillFromBlockNumber), zap.Error(err))
+						time.Sleep(sleepTimeOnError)
+						continue
+					}
+				}
+
+				if response.NextBlockNumber != nil {
+					backfillFromBlockNumber = *response.NextBlockNumber
+					backfillFromBlockHash = response.NextBlockHash
+				}
+
+				for _, log := range response.Logs {
+					cfg.eventChannel <- log
+				}
+			}
+		}
+
 		// From now on we are operating on the subscription, and we no longer check what the highest block is.
 		metrics.EmitIndexerCurrentBlockLag(cfg.Address.Hex(), 0)
 
@@ -281,7 +333,7 @@ func (r *RPCLogStreamer) watchContract(cfg *ContractConfig) {
 				}
 
 				logger.Warn("subscription error, rebuilding", zap.Error(err))
-				sub, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
+				sub, subFromBlock, err = r.buildSubscriptionWithBackoff(cfg, innerSubCh)
 				if err != nil {
 					logger.Fatal("failed rebuilding subscription after max disconnect time", zap.Error(err), zap.String("max_disconnect_time", cfg.MaxDisconnectTime.String()))
 				}
@@ -435,12 +487,12 @@ func (r *RPCLogStreamer) GetNextPage(
 func (r *RPCLogStreamer) buildSubscription(
 	cfg *ContractConfig,
 	innerSubCh chan types.Log,
-) (sub ethereum.Subscription, err error) {
+) (sub ethereum.Subscription, fromBlock uint64, err error) {
 	query := buildBaseFilterQuery(*cfg)
 
 	highestBlock, err := r.wsClient.BlockNumber(r.ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// In most implementations, FromBlock is ignored by the RPC nodes when subscribing to logs.
@@ -455,10 +507,10 @@ func (r *RPCLogStreamer) buildSubscription(
 		innerSubCh,
 	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return sub, nil
+	return sub, highestBlock, nil
 }
 
 // buildSubscriptionWithBackoff builds a subscription with backoff.
@@ -467,16 +519,21 @@ func (r *RPCLogStreamer) buildSubscription(
 func (r *RPCLogStreamer) buildSubscriptionWithBackoff(
 	cfg *ContractConfig,
 	innerSubCh chan types.Log,
-) (sub ethereum.Subscription, err error) {
-	rebuildOperation := func() (ethereum.Subscription, error) {
-		sub, err = r.buildSubscription(cfg, innerSubCh)
-		return sub, err
+) (sub ethereum.Subscription, fromBlock uint64, err error) {
+	type subResult struct {
+		sub       ethereum.Subscription
+		fromBlock uint64
+	}
+
+	rebuildOperation := func() (subResult, error) {
+		sub, fromBlock, err := r.buildSubscription(cfg, innerSubCh)
+		return subResult{sub: sub, fromBlock: fromBlock}, err
 	}
 
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.InitialInterval = 1 * time.Second
 
-	sub, err = backoff.Retry(
+	result, err := backoff.Retry(
 		r.ctx,
 		rebuildOperation,
 		backoff.WithBackOff(expBackoff),
@@ -488,12 +545,12 @@ func (r *RPCLogStreamer) buildSubscriptionWithBackoff(
 			"failed to rebuild subscription, closing",
 			zap.Error(err),
 		)
-		return nil, err
+		return nil, 0, err
 	}
 
 	r.logger.Info("subscription rebuilt")
 
-	return sub, nil
+	return result.sub, result.fromBlock, nil
 }
 
 func (r *RPCLogStreamer) validateWatcher(cfg *ContractConfig) error {
@@ -508,7 +565,7 @@ func (r *RPCLogStreamer) validateWatcher(cfg *ContractConfig) error {
 	testCh := make(chan types.Log, 100)
 	defer close(testCh)
 
-	sub, err := r.buildSubscription(cfg, testCh)
+	sub, _, err := r.buildSubscription(cfg, testCh)
 	if err != nil {
 		return fmt.Errorf("failed to validate watcher %s: %w", cfg.Address.Hex(), err)
 	}

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer_test.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer_test.go
@@ -138,19 +138,24 @@ func TestBridgingBackfill(t *testing.T) {
 		Topics:    [][]common.Hash{{topic}},
 	}).Return([]types.Log{initialLog}, nil).Once()
 
-	// After initial backfill ends (ErrEndOfBackfill with nil NextBlockNumber),
-	// backfillFromBlockNumber stays at 1. The bridging loop re-fetches from block 1
-	// but now the HTTP client reports wsHead as the highest block.
+	// After initial backfill ends, backfillFromBlockNumber advances to httpHead+1 (11).
+	// The bridging loop fetches from block 11 to wsHead (15) to cover the gap.
 	httpClient.On("BlockNumber", mock.Anything).Return(wsHead, nil)
 
-	// Bridging backfill: re-fetches from block 1 to wsHead (15), returns both logs.
-	// The gapLog at block 12 would have been missed without bridging.
+	// Reorg check in bridging calls HeaderByNumber(fromBlockNumber+1) = HeaderByNumber(12).
+	mockBlock12 := types.NewBlockWithHeader(&types.Header{
+		Number: big.NewInt(12),
+	})
+	httpClient.On("HeaderByNumber", mock.Anything, big.NewInt(int64(httpHead+2))).
+		Return(mockBlock12.Header(), nil)
+
+	// Bridging backfill: fetches only the gap (blocks 11-15), returns gapLog.
 	httpClient.On("FilterLogs", mock.Anything, ethereum.FilterQuery{
-		FromBlock: big.NewInt(1),
+		FromBlock: big.NewInt(int64(httpHead + 1)),
 		ToBlock:   big.NewInt(int64(wsHead)),
 		Addresses: []common.Address{address},
 		Topics:    [][]common.Hash{{topic}},
-	}).Return([]types.Log{initialLog, gapLog}, nil)
+	}).Return([]types.Log{gapLog}, nil)
 
 	// WS client returns wsHead. Called multiple times: validate + watch.
 	wsClient := blockchainMocks.NewMockChainClient(t)
@@ -193,35 +198,19 @@ func TestBridgingBackfill(t *testing.T) {
 	ch := streamer.GetEventChannel("testContract")
 	require.NotNil(t, ch)
 
-	// Collect logs from the channel. We expect to see the gapLog, which proves
-	// that the bridging backfill fetched logs beyond the initial HTTP head.
-	var receivedLogs []types.Log
+	// Wait for the gap log, proving the bridging backfill covered the gap.
 	timeout := time.After(5 * time.Second)
-	for {
+	found := false
+	for !found {
 		select {
 		case log := <-ch:
-			if len(log.Data) > 0 {
-				receivedLogs = append(receivedLogs, log)
-				// Once we see the gap log, we know bridging worked.
-				if string(log.Data) == "gap" {
-					goto done
-				}
+			if string(log.Data) == "gap" {
+				found = true
 			}
 		case <-timeout:
-			t.Fatalf("timed out waiting for gap log, got %d logs", len(receivedLogs))
+			t.Fatal("timed out waiting for gap log from bridging backfill")
 		}
 	}
-done:
-
-	// The gap log must be present, proving the bridging backfill covered the gap.
-	var foundGap bool
-	for _, l := range receivedLogs {
-		if string(l.Data) == "gap" {
-			foundGap = true
-			break
-		}
-	}
-	require.True(t, foundGap, "expected gap log from bridging backfill")
 
 	cancel()
 	streamer.Stop()

--- a/pkg/indexer/rpc_streamer/rpc_log_streamer_test.go
+++ b/pkg/indexer/rpc_streamer/rpc_log_streamer_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO: Add more test coverage.
-
 func TestRpcLogStreamer(t *testing.T) {
 	address := testutils.RandomAddress()
 	topic := testutils.RandomLogTopic()
@@ -84,4 +82,147 @@ func TestRpcLogStreamer(t *testing.T) {
 	require.Equal(t, mockBlock11.NumberU64(), *response.NextBlockNumber)
 	require.Len(t, response.Logs, 1)
 	require.Equal(t, response.Logs[0].Address, address)
+}
+
+// testSubscription is a minimal ethereum.Subscription for testing.
+type testSubscription struct {
+	errCh chan error
+}
+
+func (s *testSubscription) Err() <-chan error { return s.errCh }
+func (s *testSubscription) Unsubscribe()      { close(s.errCh) }
+
+// TestBridgingBackfill verifies that the streamer fetches logs in the gap
+// between the HTTP head (where initial backfill ends) and the WS head
+// (where the subscription starts delivering).
+func TestBridgingBackfill(t *testing.T) {
+	address := testutils.RandomAddress()
+	topic := testutils.RandomLogTopic()
+
+	// HTTP head is at block 10, WS head is at block 15.
+	// Backfill starts at block 1 with page size 20, so initial backfill ends at HTTP head (10).
+	// Bridging backfill should fetch blocks 11-15 to cover the gap.
+	httpHead := uint64(10)
+	wsHead := uint64(15)
+
+	initialLog := types.Log{
+		Address:     address,
+		Topics:      []common.Hash{topic},
+		Data:        []byte("initial"),
+		BlockNumber: 5,
+	}
+	gapLog := types.Log{
+		Address:     address,
+		Topics:      []common.Hash{topic},
+		Data:        []byte("gap"),
+		BlockNumber: 12,
+	}
+
+	mockBlock2 := types.NewBlockWithHeader(&types.Header{
+		Number:     big.NewInt(2),
+		ParentHash: common.Hash{},
+	})
+
+	// HTTP client: first call returns httpHead, subsequent calls return wsHead.
+	httpClient := blockchainMocks.NewMockChainClient(t)
+	httpClient.On("BlockNumber", mock.Anything).Return(httpHead, nil).Once()
+
+	httpClient.On("HeaderByNumber", mock.Anything, big.NewInt(int64(2))).
+		Return(mockBlock2.Header(), nil)
+
+	// Initial backfill: blocks 1-10, returns initialLog.
+	httpClient.On("FilterLogs", mock.Anything, ethereum.FilterQuery{
+		FromBlock: big.NewInt(1),
+		ToBlock:   big.NewInt(int64(httpHead)),
+		Addresses: []common.Address{address},
+		Topics:    [][]common.Hash{{topic}},
+	}).Return([]types.Log{initialLog}, nil).Once()
+
+	// After initial backfill ends (ErrEndOfBackfill with nil NextBlockNumber),
+	// backfillFromBlockNumber stays at 1. The bridging loop re-fetches from block 1
+	// but now the HTTP client reports wsHead as the highest block.
+	httpClient.On("BlockNumber", mock.Anything).Return(wsHead, nil)
+
+	// Bridging backfill: re-fetches from block 1 to wsHead (15), returns both logs.
+	// The gapLog at block 12 would have been missed without bridging.
+	httpClient.On("FilterLogs", mock.Anything, ethereum.FilterQuery{
+		FromBlock: big.NewInt(1),
+		ToBlock:   big.NewInt(int64(wsHead)),
+		Addresses: []common.Address{address},
+		Topics:    [][]common.Hash{{topic}},
+	}).Return([]types.Log{initialLog, gapLog}, nil)
+
+	// WS client returns wsHead. Called multiple times: validate + watch.
+	wsClient := blockchainMocks.NewMockChainClient(t)
+	wsClient.On("BlockNumber", mock.Anything).Return(wsHead, nil)
+
+	// SubscribeFilterLogs is called twice: once in validateWatcher, once in watchContract.
+	// Each needs its own subscription since validateWatcher unsubscribes.
+	validationSub := &testSubscription{errCh: make(chan error, 1)}
+	watchSub := &testSubscription{errCh: make(chan error, 1)}
+	wsClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
+		Return(validationSub, nil).Once()
+	wsClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
+		Return(watchSub, nil).Once()
+
+	cfg := &rpcstreamer.ContractConfig{
+		ID:                "testContract",
+		FromBlockNumber:   1,
+		FromBlockHash:     []byte{},
+		Address:           address,
+		Topics:            []common.Hash{topic},
+		MaxDisconnectTime: 5 * time.Minute,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	streamer, err := rpcstreamer.NewRPCLogStreamer(
+		ctx,
+		httpClient,
+		wsClient,
+		testutils.NewLog(t),
+		rpcstreamer.WithContractConfig(cfg),
+		rpcstreamer.WithBackfillBlockPageSize(20),
+	)
+	require.NoError(t, err)
+
+	err = streamer.Start()
+	require.NoError(t, err)
+
+	ch := streamer.GetEventChannel("testContract")
+	require.NotNil(t, ch)
+
+	// Collect logs from the channel. We expect to see the gapLog, which proves
+	// that the bridging backfill fetched logs beyond the initial HTTP head.
+	var receivedLogs []types.Log
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case log := <-ch:
+			if len(log.Data) > 0 {
+				receivedLogs = append(receivedLogs, log)
+				// Once we see the gap log, we know bridging worked.
+				if string(log.Data) == "gap" {
+					goto done
+				}
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for gap log, got %d logs", len(receivedLogs))
+		}
+	}
+done:
+
+	// The gap log must be present, proving the bridging backfill covered the gap.
+	var foundGap bool
+	for _, l := range receivedLogs {
+		if string(l.Data) == "gap" {
+			foundGap = true
+			break
+		}
+	}
+	require.True(t, foundGap, "expected gap log from bridging backfill")
+
+	cancel()
+	streamer.Stop()
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/xmtp/xmtpd/issues/1889

- Modified `buildSubscription` and `buildSubscriptionWithBackoff` to return the WS head block number used as the subscription's `FromBlock`
- Added a bridging backfill loop in `watchContract` that runs after the initial backfill completes, fetching any logs between the HTTP head and the WS subscription start block
- Added test verifying the bridging backfill fetches logs in the gap

## Test plan

- [x] Existing `TestRpcLogStreamer` passes
- [x] New `TestBridgingBackfill` validates gap coverage: HTTP head=10, WS head=15, verifies logs at block 12 are fetched via bridging
- [x] `dev/lint-fix` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bridging backfill gap between HTTP head and WS head in RPC log streamer
> - When transitioning from HTTP backfill to a WS subscription in [`watchContract`](https://github.com/xmtp/xmtpd/pull/1903/files#diff-10e2ad066301e371b4055118a8d04f20723857f2c6158609bf3c33b5237e5b4d), a bridging backfill loop now fetches logs for any blocks between the HTTP head and the WS subscription start block before processing subscription events.
> - `buildSubscription` and `buildSubscriptionWithBackoff` now return the WS head block number used to initialize the subscription, so `watchContract` knows where to stop the bridging loop.
> - `GetNextPage` now sets `NextBlockNumber` to `toBlock+1` (previously `nil`) when returning `ErrEndOfBackfill`, which the bridging loop relies on to advance correctly.
> - A new `TestBridgingBackfill` test simulates an HTTP head at block 10 and WS head at block 15, asserting logs at block 12 are emitted during bridging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0470a5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->