### PR TITLE
Preserve always boundary envelope

### DIFF
--- a/pkg/db/queries/prune.sql.go
+++ b/pkg/db/queries/prune.sql.go
@@ -22,7 +22,7 @@ FROM gateway_envelopes_meta ge
                    ON ge.originator_node_id = mp.originator_node_id
 WHERE ge.expiry IS NOT NULL
   AND ge.expiry < EXTRACT(EPOCH FROM now())::bigint
-  AND ge.originator_sequence_id <= COALESCE(mp.max_end_sequence_id, 0)
+  AND ge.originator_sequence_id < COALESCE(mp.max_end_sequence_id, 0)
 `
 
 func (q *Queries) CountExpiredEnvelopes(ctx context.Context) (int64, error) {

--- a/pkg/db/sqlc/prune.sql
+++ b/pkg/db/sqlc/prune.sql
@@ -11,7 +11,7 @@ FROM gateway_envelopes_meta ge
                    ON ge.originator_node_id = mp.originator_node_id
 WHERE ge.expiry IS NOT NULL
   AND ge.expiry < EXTRACT(EPOCH FROM now())::bigint
-  AND ge.originator_sequence_id <= COALESCE(mp.max_end_sequence_id, 0);
+  AND ge.originator_sequence_id < COALESCE(mp.max_end_sequence_id, 0);
 
 -- name: GetPrunableCeiling :many
 SELECT originator_node_id,

--- a/pkg/prune/prune_test.go
+++ b/pkg/prune/prune_test.go
@@ -597,6 +597,33 @@ func TestExecutor_DryRun_NoMigratedPrune(t *testing.T) {
 	)
 }
 
+func TestExecutor_PreservesBoundaryEnvelope(t *testing.T) {
+	ctx := context.Background()
+	dbs := testutils.NewDBs(t, ctx, 1)
+	db := dbs[0]
+
+	// Create 10 expired envelopes (sequence IDs 1..10) with NO valid envelopes.
+	// Set the payer report end_sequence_id to 10 — the boundary envelope.
+	setupTestData(t, ctx, db, DefaultOriginatorID, DefaultExpiredCnt, 0, 0)
+	createPrunableReport(t, ctx, db, DefaultOriginatorID, DefaultExpiredCnt)
+
+	exec := makeTestExecutor(t, ctx, db, &config.PruneConfig{
+		DryRun:    false,
+		MaxCycles: 5,
+	})
+
+	err := exec.Run()
+	require.NoError(t, err)
+
+	remainingIDs := getRemainingSequenceIds(t, ctx, db)
+	assert.Equal(
+		t,
+		[]int64{int64(DefaultExpiredCnt)},
+		remainingIDs,
+		"Only the boundary envelope (at end_sequence_id) should survive pruning",
+	)
+}
+
 func TestExecutor_PrunesExpiredMetaAndBlobs(t *testing.T) {
 	ctx := context.Background()
 	dbs := testutils.NewDBs(t, ctx, 1)

--- a/pkg/prune/query.go
+++ b/pkg/prune/query.go
@@ -16,7 +16,7 @@ WITH to_delete AS (
   SELECT ctid
   FROM %s
   WHERE expiry < EXTRACT(EPOCH FROM now())::bigint
-    AND originator_sequence_id <= %d
+    AND originator_sequence_id < %d
   ORDER BY expiry
   LIMIT %d
   FOR UPDATE SKIP LOCKED


### PR DESCRIPTION
Closes #1467 

Currently, we prune everything up to the last sequence ID that was included in the last submitted report for the specific originator, creating the ideal conditions for #1467 to happen.

With this change:

Step 1 - maybeGenerateReport(200):
  - Fetches reports → finds lastSubmittedReport with EndSequenceID=1253
  - isPastGenerationThreshold → yes (enough time passed)
  - existingReportEndSequenceID = 1253
  - No valid reports at boundary → proceeds to generateReport(200, 1253)

Step 2 - getStartMinute(ctx, 1253, 200):
  - Envelope 1253 preserved → GetGatewayEnvelopeByID succeeds
  - Parses OriginatorTime() → returns minute X

Step 3 - getEndMinute(ctx, 200, X):
  - GetSecondNewestMinute(originator=200, minimum=X)

```sql
  WITH second_newest_minute AS (
      SELECT minutes_since_epoch
      FROM unsettled_usage
      WHERE originator_id = 200
          AND minutes_since_epoch > X    -- strictly greater than start minute
      ...
      LIMIT 1 OFFSET 1
  )
```

There's nothing newer than `minutes_since_epoch`, so we return `coalesce(max(last_sequence_id), 0)`

and then hit step 4 - Back in GenerateReport:

```go
  if endSequenceID == 0 {
      p.logger.Warn("skipping report generation because there are not enough envelopes")
      return nil, nil
  }
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve boundary envelope during pruning by changing `originator_sequence_id` comparison to strict less-than
> Changes the pruning predicate from `<=` to `<` so that the envelope at `max_end_sequence_id` is never deleted. Updates both the raw SQL in [`prune.sql`](https://github.com/xmtp/xmtpd/pull/1906/files#diff-540405f1eed4e78df7e9d1fa7ae0de149323598c155ddad1f02f2b13dca8b621) and the dynamic query builder in [`query.go`](https://github.com/xmtp/xmtpd/pull/1906/files#diff-81295a4022fb81ba122a01ea208e6c7c22a07b88fc794e7b663c363e69cd4f1e), with a new test verifying only the boundary envelope survives pruning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5291777.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->