### PR TITLE
Remove funnel dead code

### DIFF
--- a/pkg/api/message/envelope_list.go
+++ b/pkg/api/message/envelope_list.go
@@ -13,22 +13,11 @@ import (
 )
 
 type subscriptionHandler struct {
-	*sync.Mutex
-
-	logger *zap.Logger
-	store  *db.Handler
-
-	subs       map[uint32]*envelopePoller
+	mu         sync.Mutex
+	logger     *zap.Logger
+	store      *db.Handler
 	mergedSubs *funnel[[]queries.SelectGatewayEnvelopesBySingleOriginatorRow]
-
-	cursor db.VectorClock
-}
-
-type envelopePoller struct {
-	cancel context.CancelFunc
-	// TODO: Check - queries.GatewayEnvelopesView and queries.SelectGatewayEnvelopesByOriginatorsRow
-	// models are identical and they're overly verbose.
-	ch <-chan []queries.SelectGatewayEnvelopesBySingleOriginatorRow
+	cursor     db.VectorClock
 }
 
 func newSubscriptionHandler(
@@ -36,16 +25,12 @@ func newSubscriptionHandler(
 	store *db.Handler,
 	cursor db.VectorClock,
 ) *subscriptionHandler {
-	s := &subscriptionHandler{
-		Mutex:      &sync.Mutex{},
-		subs:       make(map[uint32]*envelopePoller),
+	return &subscriptionHandler{
 		logger:     logger,
 		store:      store,
 		cursor:     cursor,
 		mergedSubs: newFunnel[[]queries.SelectGatewayEnvelopesBySingleOriginatorRow](),
 	}
-
-	return s
 }
 
 func (s *subscriptionHandler) newSubscription(ctx context.Context, id uint32) (retErr error) {
@@ -114,16 +99,9 @@ func (s *subscriptionHandler) newSubscription(ctx context.Context, id uint32) (r
 		return fmt.Errorf("could not start subscription (id: %v): %w", id, err)
 	}
 
-	// Per node/originator poller and cancellation.
-	e := &envelopePoller{
-		cancel: cancel,
-		ch:     ch,
-	}
-
 	// Save the poller in the subscription handler.
-	s.Lock()
-	defer s.Unlock()
-	s.subs[id] = e
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	s.mergedSubs.addChannel(ch)
 
@@ -132,8 +110,7 @@ func (s *subscriptionHandler) newSubscription(ctx context.Context, id uint32) (r
 
 // allSubscriptions returns a channel merging all individual subscription channels.
 func (s *subscriptionHandler) allSubscriptions() <-chan []queries.SelectGatewayEnvelopesBySingleOriginatorRow {
-	s.Lock()
-	defer s.Unlock()
-
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.mergedSubs.output()
 }

--- a/pkg/api/message/subscribe_worker.go
+++ b/pkg/api/message/subscribe_worker.go
@@ -3,6 +3,7 @@ package message
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -68,6 +69,10 @@ func (s *subscribeWorker) getOriginatorNodeIds() ([]uint32, error) {
 				"skipping non-canonical node",
 				utils.OriginatorIDField(node.NodeID),
 			)
+			continue
+		}
+
+		if slices.Contains(nodeIDs, node.NodeID) {
 			continue
 		}
 
@@ -176,14 +181,12 @@ func (s *subscribeWorker) monitorNodeChanges() {
 			return
 
 		case nodes, ok := <-newNodes:
-
 			if !ok {
 				s.logger.Info("registry notifier for new nodes closed")
 				return
 			}
 
 			for _, node := range nodes {
-
 				if !node.IsCanonical {
 					s.logger.Debug(
 						"skipping non-canonical node",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove dead code from funnel subscription handler and fix duplicate originator node IDs
- Removes the unused `envelopePoller` struct and the `subs` map from `subscriptionHandler` in [envelope_list.go](https://github.com/xmtp/xmtpd/pull/1907/files#diff-fdfe56b0ab375a73bc65fe981dc81c912fc1230a77fe08768702788bfd2e5bdc); per-subscription cancel functions and channels are no longer stored after startup.
- Replaces the embedded `*sync.Mutex` pointer with a named `mu sync.Mutex` field in `subscriptionHandler`.
- Fixes `getOriginatorNodeIds` in [subscribe_worker.go](https://github.com/xmtp/xmtpd/pull/1907/files#diff-6ead5de931f1e9d71c83166064bf5ca1a0d1d7bbeab213d8d26cb0781237a5ab) to skip duplicate node IDs using `slices.Contains`.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ab5c806. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->