### PR TITLE
Race free funnel

### DIFF
--- a/pkg/api/message/funnel.go
+++ b/pkg/api/message/funnel.go
@@ -5,12 +5,10 @@ import (
 )
 
 type funnel[T any] struct {
-	*sync.Mutex
-
+	mu     sync.Mutex
 	in     []<-chan T
 	out    chan T
-	wg     sync.WaitGroup
-	closer sync.Once
+	active int32
 	closed bool
 }
 
@@ -18,12 +16,10 @@ type funnel[T any] struct {
 // Adding channels after the output channel has been closed is invalid.
 func newFunnel[T any](ch ...<-chan T) *funnel[T] {
 	f := &funnel[T]{
-		Mutex: &sync.Mutex{},
-		in:    make([]<-chan T, 0, len(ch)),
-		out:   make(chan T),
+		in:  make([]<-chan T, 0, len(ch)),
+		out: make(chan T),
 	}
 
-	// Function will forward entries from its channel to the common channel.
 	for _, c := range ch {
 		f.addChannel(c)
 	}
@@ -32,41 +28,30 @@ func newFunnel[T any](ch ...<-chan T) *funnel[T] {
 }
 
 func (f *funnel[T]) addChannel(ch <-chan T) {
-	f.Lock()
-	defer f.Unlock()
+	f.mu.Lock()
 
 	if f.closed {
+		f.mu.Unlock()
 		return
 	}
 
 	f.in = append(f.in, ch)
-
-	f.wg.Add(1)
-
-	f.startCloser()
+	f.active++
+	f.mu.Unlock()
 
 	go func() {
-		defer f.wg.Done()
 		for e := range ch {
 			f.out <- e
 		}
-	}()
-}
 
-func (f *funnel[T]) startCloser() {
-	// Start closer goroutine (once).
-	f.closer.Do(func() {
-		go func() {
-			// When all input channels are closed, close our channel too.
-			f.wg.Wait()
-
-			f.Lock()
-			defer f.Unlock()
-
+		f.mu.Lock()
+		f.active--
+		if f.active == 0 {
 			close(f.out)
 			f.closed = true
-		}()
-	})
+		}
+		f.mu.Unlock()
+	}()
 }
 
 func (f *funnel[T]) output() <-chan T {


### PR DESCRIPTION
In the previous version, this can happen:
- `addChannel()` invokes `wg.Add(1)` for each new input channel.
- the separate closer goroutine does `wg.Wait()` and then closes `out`channel.
- with an unlucky enough timing, `Wait()` can return just before/while another `addChannel()` is racing in.
- then, `out` closes while a new forwarder goroutine still exists and tries `f.out <- e`, which can panic (send on closed channel).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition in `funnel` by replacing WaitGroup/Once with an atomic counter
> Rewrites the closing logic in [funnel.go](https://github.com/xmtp/xmtpd/pull/1908/files#diff-1b5913c3da35c13cb00f7839e3d2a85869d69ece4556fdac54d6984e6ccf58c1) to eliminate a race condition. Replaces the `sync.WaitGroup` and `sync.Once`-based `startCloser` method with an `active int32` counter tracked under a named `mu sync.Mutex`. Each goroutine forwarding from an input channel decrements the counter on close and, when it reaches zero, closes the output channel directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c366653.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->