### PR TITLE
Fix TestCreateServer

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -170,7 +170,9 @@ func TestCreateServer(t *testing.T) {
 				Limit: 10,
 			},
 		})
-		require.NoError(t, err)
+		if err != nil {
+			return false
+		}
 
 		for _, e := range q1.Msg.GetEnvelopes() {
 			if reflect.DeepEqual(e, p2.Msg.GetOriginatorEnvelopes()[0]) {
@@ -178,7 +180,7 @@ func TestCreateServer(t *testing.T) {
 			}
 		}
 		return false
-	}, 10*time.Second, 200*time.Millisecond)
+	}, 20*time.Second, 500*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		q2, err := client2.QueryEnvelopes(ctx, &connect.Request[message_api.QueryEnvelopesRequest]{
@@ -190,7 +192,9 @@ func TestCreateServer(t *testing.T) {
 				Limit: 10,
 			},
 		})
-		require.NoError(t, err)
+		if err != nil {
+			return false
+		}
 
 		for _, e := range q2.Msg.GetEnvelopes() {
 			if reflect.DeepEqual(e, p1.Msg.GetOriginatorEnvelopes()[0]) {


### PR DESCRIPTION
Change `require.NoError` inside Eventually to return false so Postgres deadlocks retry instead of failing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TestCreateServer` to retry on transient errors instead of failing immediately
> In [server_test.go](https://github.com/xmtp/xmtpd/pull/1910/files#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4e), the two `require.Eventually` polling blocks previously called `require.NoError` on `QueryEnvelopes` errors, causing immediate test failure on transient errors. They now return `false` on error, allowing retries to continue. The first polling block also has its timeout increased from 10s to 20s and polling interval from 200ms to 500ms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 970e82f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->