### PR TITLE
Remove private key and contracts config from pruner and migration server

### DIFF
--- a/cmd/prune/main.go
+++ b/cmd/prune/main.go
@@ -44,11 +44,6 @@ func main() {
 
 	validator := config.NewOptionsValidator(logger)
 
-	err = validator.ParseJSONConfig(&options.Contracts)
-	if err != nil {
-		fatal("could not parse JSON contracts config: %s", err)
-	}
-
 	err = validator.ValidatePruneOptions(options)
 	if err != nil {
 		fatal("could not validate options: %s", err)

--- a/pkg/config/pruner.go
+++ b/pkg/config/pruner.go
@@ -7,9 +7,7 @@ type PruneConfig struct {
 	DryRun         bool  `long:"dry-run"          env:"XMTPD_PRUNE_DRY_RUN"         description:"Dry run mode"`
 }
 type PruneOptions struct {
-	DB          DBOptions        `group:"Database Options"  namespace:"db"`
-	Log         LogOptions       `group:"Log Options"       namespace:"log"`
-	Signer      SignerOptions    `group:"Signer Options"    namespace:"signer"`
-	Contracts   ContractsOptions `group:"Contracts Options" namespace:"contracts"`
-	PruneConfig PruneConfig      `group:"Prune Options"     namespace:"prune"`
+	DB          DBOptions   `group:"Database Options" namespace:"db"`
+	Log         LogOptions  `group:"Log Options"      namespace:"log"`
+	PruneConfig PruneConfig `group:"Prune Options"    namespace:"prune"`
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -102,14 +102,6 @@ func (v *OptionsValidator) ValidatePruneOptions(options PruneOptions) error {
 		missingSet["--DB.WriterConnectionString"] = struct{}{}
 	}
 
-	if options.Contracts.SettlementChain.NodeRegistryAddress == "" {
-		missingSet["--contracts.settlement-chain.node-registry-address"] = struct{}{}
-	}
-
-	if options.Signer.PrivateKey == "" {
-		missingSet["--signer.private-key"] = struct{}{}
-	}
-
 	if len(missingSet) > 0 {
 		var errorMessages []string
 		for err := range missingSet {
@@ -144,11 +136,6 @@ func (v *OptionsValidator) validateMigrationOptions(
 		v.validateField(
 			opts.MigrationServer.NodeSigningKey,
 			"migration-server.node-signing-key",
-			missingSet,
-		)
-		v.validateField(
-			opts.Signer.PrivateKey,
-			"signer.private-key",
 			missingSet,
 		)
 		v.validateField(


### PR DESCRIPTION
## Summary

- Remove `Signer` and `Contracts` fields from `PruneOptions` — the pruner only needs a DB connection string after Keccak256-based namespace generation was removed in #1901
- Drop `--signer.private-key` and `--contracts.settlement-chain.node-registry-address` from `ValidatePruneOptions`
- Drop `--signer.private-key` requirement from migration server validation — the migrator uses its own `payer-private-key` and `node-signing-key`

## Test plan

- [ ] Build passes: `go build ./cmd/prune/... ./pkg/config/...`
- [ ] Run pruner without `--signer.private-key` or `--contracts.*` flags and confirm it starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove private key and contracts config from pruner and migration server
> - Removes `Signer` and `Contracts` fields from [`PruneOptions`](https://github.com/xmtp/xmtpd/pull/1911/files#diff-fef04f7d186f16f834517ce92187793a16eceef8a34f1022956adb6c61de0a43), so `signer.*` and `contracts.*` CLI/env options are no longer parsed by the prune binary.
> - Removes validation checks for `--contracts.settlement-chain.node-registry-address` and `--signer.private-key` in [`ValidatePruneOptions`](https://github.com/xmtp/xmtpd/pull/1911/files#diff-3e0b3707cc5d712d06d1eeb6a67c10b45a7ba0b27e972924d71df3c8e539f23b), and removes the `signer.private-key` requirement when migration server mode is enabled.
> - Behavioral Change: The prune and migration server binaries no longer fail startup when these fields are omitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1097d74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->