### PR TITLE
Fix flaky TestSubscribeEnvelopesByTopic

### DIFF
--- a/pkg/api/message/envelope_list.go
+++ b/pkg/api/message/envelope_list.go
@@ -13,11 +13,20 @@ import (
 )
 
 type subscriptionHandler struct {
-	mu         sync.Mutex
+	sync.Mutex
 	logger     *zap.Logger
 	store      *db.Handler
 	mergedSubs *funnel[[]queries.SelectGatewayEnvelopesBySingleOriginatorRow]
 	cursor     db.VectorClock
+	subs       map[uint32]*envelopePoller
+}
+
+type envelopePoller struct {
+	cancel context.CancelFunc
+	// TODO: Check - queries.GatewayEnvelopesView and queries.SelectGatewayEnvelopesByOriginatorsRow
+	// models are identical and they're overly verbose.
+	ch  <-chan []queries.SelectGatewayEnvelopesBySingleOriginatorRow
+	sub *db.DBSubscription[queries.SelectGatewayEnvelopesBySingleOriginatorRow, int64]
 }
 
 func newSubscriptionHandler(
@@ -30,6 +39,7 @@ func newSubscriptionHandler(
 		store:      store,
 		cursor:     cursor,
 		mergedSubs: newFunnel[[]queries.SelectGatewayEnvelopesBySingleOriginatorRow](),
+		subs:       make(map[uint32]*envelopePoller),
 	}
 }
 
@@ -99,10 +109,18 @@ func (s *subscriptionHandler) newSubscription(ctx context.Context, id uint32) (r
 		return fmt.Errorf("could not start subscription (id: %v): %w", id, err)
 	}
 
-	// Save the poller in the subscription handler.
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	// Per node/originator poller and cancellation.
+	e := &envelopePoller{
+		cancel: cancel,
+		ch:     ch,
+		sub:    sub,
+	}
 
+	// Save the poller in the subscription handler.
+	s.Lock()
+	defer s.Unlock()
+
+	s.subs[id] = e
 	s.mergedSubs.addChannel(ch)
 
 	return nil
@@ -110,7 +128,7 @@ func (s *subscriptionHandler) newSubscription(ctx context.Context, id uint32) (r
 
 // allSubscriptions returns a channel merging all individual subscription channels.
 func (s *subscriptionHandler) allSubscriptions() <-chan []queries.SelectGatewayEnvelopesBySingleOriginatorRow {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.Lock()
+	defer s.Unlock()
 	return s.mergedSubs.output()
 }

--- a/pkg/api/message/export_test.go
+++ b/pkg/api/message/export_test.go
@@ -1,0 +1,39 @@
+package message
+
+import (
+	"context"
+	"time"
+
+	"github.com/xmtp/xmtpd/pkg/db"
+)
+
+// AwaitCursor blocks until the subscribe worker has polled past all sequence IDs in vc.
+// Only compiled during testing (export_test.go pattern).
+func (s *Service) AwaitCursor(ctx context.Context, vc db.VectorClock) error {
+	const checkInterval = 5 * time.Millisecond
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for {
+		if s.subscribeWorker.subscriptions.cursorMet(vc) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *subscriptionHandler) cursorMet(vc db.VectorClock) bool {
+	s.Lock()
+	defer s.Unlock()
+	for nodeID, minSeq := range vc {
+		poller, ok := s.subs[nodeID]
+		if !ok || uint64(poller.sub.LastSeen()) < minSeq {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/api/message/subscribe_test.go
+++ b/pkg/api/message/subscribe_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/xmtp/xmtpd/pkg/migrator"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/envelopes"
 	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api"
-	message_apiconnect "github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api/message_apiconnect"
 	"github.com/xmtp/xmtpd/pkg/registry"
 	"github.com/xmtp/xmtpd/pkg/testutils"
 	testUtilsApi "github.com/xmtp/xmtpd/pkg/testutils/api"
@@ -37,9 +36,7 @@ var (
 	allRows = make([]queries.InsertGatewayEnvelopeParams, 0)
 )
 
-func setupTest(
-	t *testing.T,
-) (message_apiconnect.ReplicationApiClient, *sql.DB, testUtilsApi.APIServerMocks) {
+func setupTest(t *testing.T) *testUtilsApi.APIServerTestSuite {
 	var (
 		nodes = []registry.Node{
 			{NodeID: 100, IsCanonical: true},
@@ -104,14 +101,19 @@ func setupTest(
 		},
 	}
 
-	return suite.ClientReplication, suite.DB, suite.APIServerMocks
+	return suite
 }
 
-func insertInitialRows(t *testing.T, store *sql.DB) {
-	testutils.InsertGatewayEnvelopes(t, store, []queries.InsertGatewayEnvelopeParams{
+func insertInitialRows(t *testing.T, suite *testUtilsApi.APIServerTestSuite) {
+	t.Helper()
+	testutils.InsertGatewayEnvelopes(t, suite.DB, []queries.InsertGatewayEnvelopeParams{
 		allRows[0], allRows[1],
 	})
-	time.Sleep(message.SubscribeWorkerPollTime + 100*time.Millisecond)
+	// Wait until the subscribe worker has polled past the inserted rows so that
+	// a subsequent subscription with LastSeen=nil won't see them.
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	require.NoError(t, suite.MessageService.AwaitCursor(ctx, db.VectorClock{100: 1, 200: 1}))
 }
 
 func insertAdditionalRows(t *testing.T, store *sql.DB, notifyChan ...chan bool) {
@@ -203,11 +205,11 @@ func validateUpdates(
 }
 
 func TestSubscribeEnvelopesByTopic(t *testing.T) {
-	client, store, _ := setupTest(t)
-	insertInitialRows(t, store)
+	suite := setupTest(t)
+	insertInitialRows(t, suite)
 
 	ctx := t.Context()
-	stream, err := client.SubscribeEnvelopes(
+	stream, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
@@ -218,16 +220,16 @@ func TestSubscribeEnvelopesByTopic(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	insertAdditionalRows(t, store)
+	insertAdditionalRows(t, suite.DB)
 	validateUpdates(t, stream, []int{4})
 }
 
 func TestSubscribeEnvelopesByOriginator(t *testing.T) {
-	client, db, _ := setupTest(t)
-	insertInitialRows(t, db)
+	suite := setupTest(t)
+	insertInitialRows(t, suite)
 
 	ctx := t.Context()
-	stream, err := client.SubscribeEnvelopes(
+	stream, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
@@ -238,16 +240,16 @@ func TestSubscribeEnvelopesByOriginator(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	insertAdditionalRows(t, db)
+	insertAdditionalRows(t, suite.DB)
 	validateUpdates(t, stream, []int{2, 4})
 }
 
 func TestSimultaneousSubscriptions(t *testing.T) {
-	client, store, _ := setupTest(t)
-	insertInitialRows(t, store)
+	suite := setupTest(t)
+	insertInitialRows(t, suite)
 
 	ctx := t.Context()
-	stream1, err := client.SubscribeEnvelopes(
+	stream1, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{},
@@ -255,7 +257,7 @@ func TestSimultaneousSubscriptions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	stream2, err := client.SubscribeEnvelopes(
+	stream2, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
@@ -266,7 +268,7 @@ func TestSimultaneousSubscriptions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	stream3, err := client.SubscribeEnvelopes(
+	stream3, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
@@ -277,18 +279,18 @@ func TestSimultaneousSubscriptions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	insertAdditionalRows(t, store)
+	insertAdditionalRows(t, suite.DB)
 	validateUpdates(t, stream1, []int{})
 	validateUpdates(t, stream2, []int{2, 3})
 	validateUpdates(t, stream3, []int{3})
 }
 
 func TestSubscribeEnvelopesFromCursor(t *testing.T) {
-	client, store, _ := setupTest(t)
-	insertInitialRows(t, store)
+	suite := setupTest(t)
+	insertInitialRows(t, suite)
 
 	ctx := t.Context()
-	stream, err := client.SubscribeEnvelopes(
+	stream, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
@@ -299,16 +301,16 @@ func TestSubscribeEnvelopesFromCursor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	insertAdditionalRows(t, store)
+	insertAdditionalRows(t, suite.DB)
 	validateUpdates(t, stream, []int{1, 4})
 }
 
 func TestSubscribeEnvelopesFromEmptyCursor(t *testing.T) {
-	client, store, _ := setupTest(t)
-	insertInitialRows(t, store)
+	suite := setupTest(t)
+	insertInitialRows(t, suite)
 
 	ctx := t.Context()
-	stream, err := client.SubscribeEnvelopes(
+	stream, err := suite.ClientReplication.SubscribeEnvelopes(
 		ctx,
 		connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 			Query: &message_api.EnvelopesQuery{
@@ -319,15 +321,15 @@ func TestSubscribeEnvelopesFromEmptyCursor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	insertAdditionalRows(t, store)
+	insertAdditionalRows(t, suite.DB)
 	validateUpdates(t, stream, []int{0, 1, 4})
 }
 
 func TestSubscribeEnvelopesInvalidRequest(t *testing.T) {
 	var (
-		client, _, _ = setupTest(t)
-		ctx          = t.Context()
-		tests        = []struct {
+		suite = setupTest(t)
+		ctx   = t.Context()
+		tests = []struct {
 			name  string
 			query *message_api.EnvelopesQuery
 		}{
@@ -352,7 +354,7 @@ func TestSubscribeEnvelopesInvalidRequest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			stream, err := client.SubscribeEnvelopes(
+			stream, err := suite.ClientReplication.SubscribeEnvelopes(
 				ctx,
 				connect.NewRequest(&message_api.SubscribeEnvelopesRequest{
 					Query: test.query,

--- a/pkg/db/subscription.go
+++ b/pkg/db/subscription.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/xmtp/xmtpd/pkg/tracing"
@@ -30,10 +31,18 @@ type PollingOptions struct {
 type DBSubscription[ValueType any, CursorType any] struct {
 	ctx      context.Context
 	logger   *zap.Logger
+	mu       sync.RWMutex
 	lastSeen CursorType
 	options  PollingOptions
 	query    PollableDBQuery[ValueType, CursorType]
 	updates  chan<- []ValueType
+}
+
+// LastSeen returns the cursor position last successfully processed by the subscription.
+func (s *DBSubscription[ValueType, CursorType]) LastSeen() CursorType {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastSeen
 }
 
 func NewDBSubscription[ValueType any, CursorType any](
@@ -127,7 +136,9 @@ func (s *DBSubscription[ValueType, CursorType]) poll(trigger string) {
 		}
 
 		totalResults += len(results)
+		s.mu.Lock()
 		s.lastSeen = lastID
+		s.mu.Unlock()
 		s.updates <- results
 
 		// If we have less results than allowed, it means there's currently no more items to retrieve.

--- a/pkg/testutils/api/api.go
+++ b/pkg/testutils/api/api.go
@@ -120,6 +120,7 @@ type APIServerTestSuite struct {
 	ClientMetadata    metadata_apiconnect.MetadataApiClient
 	DB                *sql.DB
 	APIServerMocks    APIServerMocks
+	MessageService    *message.Service
 }
 
 // APIServerTestConfig allows explicitly setting some components used for tests.
@@ -207,10 +208,11 @@ func NewTestAPIServer(
 
 	authInterceptor := server.NewServerAuthInterceptor(jwtVerifier, log)
 
+	var replicationService *message.Service
 	serviceRegistrationFunc := func(mux *http.ServeMux, interceptors ...connect.Interceptor) (servicePaths []string, err error) {
 		interceptors = append(interceptors, authInterceptor)
 
-		replicationService, err := message.NewReplicationAPIService(
+		replicationService, err = message.NewReplicationAPIService(
 			ctx,
 			log,
 			registrant,
@@ -315,5 +317,6 @@ func NewTestAPIServer(
 		ClientPayer:       clientPayer,
 		ClientMetadata:    clientMetadata,
 		DB:                db.DB(),
+		MessageService:    replicationService,
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces `time.Sleep`-based synchronisation in subscribe tests with a deterministic `AwaitCursor` mechanism
- Adds `LastSeen()` getter to `DBSubscription` (thread-safe via `sync.RWMutex`) so callers can observe how far each per-originator poller has advanced
- Adds `AwaitCursor(ctx, VectorClock)` on `subscriptionHandler` → `subscribeWorker` → `Service`, polling at 5ms until all required sequence IDs are met or the context is cancelled
- `insertInitialRows` in subscribe tests now calls `AwaitCursor` with a 500ms deadline instead of sleeping, ensuring the worker has processed the pre-subscription rows before the client subscribes

## Root cause

The race in `TestSubscribeEnvelopesByTopic` (#1913): after inserting initial rows, the test slept for `SubscribeWorkerPollTime + 100ms` expecting the subscribe worker to advance its cursor past those rows. Under CI load, the unbuffered `updates` channel pipeline (`poll → funnel → worker.start() → dispatch`) could take longer than the sleep, causing the worker to consume the batch *after* the topic listener was registered — leaking pre-subscription rows into the stream.

## Test plan

- [x] All `TestSubscribe*` tests pass locally
- [x] `TestSimultaneousSubscriptions` passes
- [x] `dev/lint-fix` reports 0 issues

Closes #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `TestSubscribeEnvelopesByTopic` by adding cursor-aware synchronization
> - Introduces `envelopePoller` in [envelope_list.go](https://github.com/xmtp/xmtpd/pull/1914/files#diff-fdfe56b0ab375a73bc65fe981dc81c912fc1230a77fe08768702788bfd2e5bdc) to track per-originator poller state (cancel, channel, DB subscription), keyed in a `subs` map on `subscriptionHandler`.
> - Adds a `LastSeen` accessor to `DBSubscription` in [subscription.go](https://github.com/xmtp/xmtpd/pull/1914/files#diff-2af031639fabe8db927ae2b9d80ab346ea90e66ed03d407148a8c7c6fcb25a9a), guarded by a new `RWMutex` so concurrent reads see consistent cursor values.
> - Adds test-only helpers `AwaitCursor` and `cursorMet` in [export_test.go](https://github.com/xmtp/xmtpd/pull/1914/files#diff-45fa29c16e5a20b038e53357e8dea98bef54518822e824a406af497d1e9258d0) so tests can wait until the subscribe worker has polled past a given `VectorClock` before asserting, eliminating the race condition that caused flakiness.
> - Refactors [subscribe_test.go](https://github.com/xmtp/xmtpd/pull/1914/files#diff-da5f8b805088f6ad97e8df43ccf32b84aa3d73cf25268cfb12fa394a4eb3db3a) to use a unified `APIServerTestSuite` and calls `AwaitCursor` after inserting initial rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f962eb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->