### PR TITLE
Fix unbounded GetInboxIds

### DIFF
--- a/pkg/api/message/service.go
+++ b/pkg/api/message/service.go
@@ -38,11 +38,12 @@ import (
 )
 
 const (
-	maxRequestedRows     int32         = 1000
-	maxQueriesPerRequest int           = 10000
-	maxTopicLength       int           = 128
-	maxVectorClockLength int           = 100
-	pagingInterval       time.Duration = 100 * time.Millisecond
+	maxRequestedRows      int32         = 1000
+	maxInboxIdsPerRequest int           = 1000
+	maxQueriesPerRequest  int           = 10000
+	maxTopicLength        int           = 128
+	maxVectorClockLength  int           = 100
+	pagingInterval        time.Duration = 100 * time.Millisecond
 
 	requestMissingMessageError = "missing request message"
 )
@@ -1011,9 +1012,19 @@ func (s *Service) GetInboxIds(
 		logger.Debug("received request", utils.BodyField(req))
 	}
 
-	addresses := []string{}
+	if len(req.Msg.GetRequests()) > maxInboxIdsPerRequest {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("too many requests"),
+		)
+	}
 
-	for _, request := range req.Msg.GetRequests() {
+	var (
+		requests  = req.Msg.GetRequests()
+		addresses = make([]string, 0, len(requests))
+	)
+
+	for _, request := range requests {
 		addresses = append(addresses, request.GetIdentifier())
 	}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Limit `GetInboxIds` requests to 1000 per call
Adds a `maxInboxIdsPerRequest` constant (1000) in [service.go](https://github.com/xmtp/xmtpd/pull/1916/files#diff-1f687c3f8e69fec5867ded411d50bda02bef3661181fa7422b9dc66b7b57f3c2) and validates the request count before processing. Requests exceeding the limit return an `InvalidArgument` error with the message "too many requests".

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ece9b07.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->