### PR TITLE
Deploy chain-watcher with pinned digest in CI

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -99,6 +99,7 @@ jobs:
       xmtpd_image: ${{ steps.digests.outputs.xmtpd_image }}
       prune_image: ${{ steps.digests.outputs.prune_image }}
       gateway_image: ${{ steps.digests.outputs.gateway_image }}
+      chain_watcher_image: ${{ steps.digests.outputs.chain_watcher_image }}
     steps:
       - name: Download xmtpd digest
         uses: actions/download-artifact@v4
@@ -124,6 +125,12 @@ jobs:
           name: xmtpd-gateway-digest
           path: digests
 
+      - name: Download chain-watcher digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-chain-watcher-digest
+          path: digests
+
       - name: Read and export digests
         id: digests
         run: |
@@ -133,15 +140,17 @@ jobs:
           CLI_DIGEST=$(cut -d= -f2 digests/xmtpd-cli.txt)
           PRUNE_DIGEST=$(cut -d= -f2 digests/xmtpd-prune.txt)
           GATEWAY_DIGEST=$(cut -d= -f2 digests/xmtpd-gateway.txt)
+          CHAIN_WATCHER_DIGEST=$(cut -d= -f2 digests/xmtpd-chain-watcher.txt)
 
-          if [[ -z "$XMTPD_DIGEST" || -z "$CLI_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" ]]; then
+          if [[ -z "$XMTPD_DIGEST" || -z "$CLI_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" || -z "$CHAIN_WATCHER_DIGEST" ]]; then
             echo "✖️  One or more digests are empty – aborting deploy." >&2
             exit 1
           fi
 
-          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"         >> $GITHUB_OUTPUT
-          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"   >> $GITHUB_OUTPUT
-          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST" >> $GITHUB_OUTPUT
+          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"                               >> $GITHUB_OUTPUT
+          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"                         >> $GITHUB_OUTPUT
+          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"                   >> $GITHUB_OUTPUT
+          echo "chain_watcher_image=ghcr.io/xmtp/xmtpd-chain-watcher@$CHAIN_WATCHER_DIGEST" >> $GITHUB_OUTPUT
 
   deploy_testnet_staging:
     name: Deploy to testnet-staging
@@ -158,8 +167,8 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: testnet-staging
-          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image"
-          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }}"
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"
 
   deploy_testnet:
@@ -177,6 +186,6 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: testnet
-          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image"
-          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }}"
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"


### PR DESCRIPTION
## Summary

- Downloads the `xmtpd-chain-watcher` digest artifact in the `prepare` job alongside the other images
- Exports `chain_watcher_image` output from `prepare`
- Passes `chain_watcher_image` to terraform-deployer for both `testnet-staging` and `testnet` workspaces

Requires xmtplabs/infrastructure#740 to be merged first so the Terraform workspaces accept the `chain_watcher_image` variable.

## Test plan

- [ ] CI build passes and all six images are built successfully
- [ ] `prepare` job exports a non-empty `chain_watcher_image` digest
- [ ] testnet-staging and testnet deployments pick up the pinned chain-watcher image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deploy chain-watcher with pinned digest in CI
> Extends the [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1922/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9) workflow to include the `xmtpd-chain-watcher` image alongside existing images.
>
> - Downloads the `xmtpd-chain-watcher-digest` artifact in the `prepare` job and exports it as `chain_watcher_image` to `GITHUB_OUTPUT`.
> - Passes `chain_watcher_image` as a Terraform variable in both `deploy_testnet_staging` and `deploy_testnet` jobs.
> - Risk: the `prepare` job fails if the chain-watcher digest artifact is missing or empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25f17fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->