### PR TITLE
Fix chain-watcher reporting time since restart instead of last on-chain submission

### DIFF
--- a/pkg/chainwatcher/watcher.go
+++ b/pkg/chainwatcher/watcher.go
@@ -327,7 +327,8 @@ func (w *Watcher) handlePayerReportSubmitted(log types.Log) {
 
 	nodeID := parsed.OriginatorNodeId
 	nodeLabel := nodeIDLabel(nodeID)
-	now := w.blockTimeForLog(log)
+	now := time.Now()
+	blockTime := w.blockTimeForLog(log)
 
 	// Core counter
 	reportSubmittedTotal.WithLabelValues(nodeLabel).Inc()
@@ -352,13 +353,14 @@ func (w *Watcher) handlePayerReportSubmitted(log types.Log) {
 	}
 	w.lastEndSeqByNode[nodeID] = parsed.EndSequenceId
 
-	// Track submission time for settlement latency
+	// Track submission time for settlement latency (wall clock for relative timing).
 	key := submissionKey(nodeID, parsed.PayerReportIndex)
 	w.submissionTimeByKey[key] = now
 
-	// Active originator tracking
+	// Active originator tracking (wall clock for sliding window comparisons).
 	w.activeOriginators[nodeID] = now
-	w.lastSubmissionTime = now
+	// Block timestamp so the lag metric reflects actual on-chain time, not restart time.
+	w.lastSubmissionTime = blockTime
 	w.mu.Unlock()
 
 	// Attesting node count


### PR DESCRIPTION
## Summary

`xmtp_chain_time_since_last_submission_seconds` was showing **time since last chain-watcher restart** instead of **time since the last on-chain `PayerReportSubmitted` event**.

### Root cause

`handlePayerReportSubmitted` used `time.Now()` to record `lastSubmissionTime`. During backfill on startup, historical events (e.g. from 14 days ago) were all stamped with the current wall clock. The lag ticker then computed `time.Since(restart_time)`, making the metric grow from zero on every restart.

### Fix

Replace `time.Now()` with the block timestamp fetched via `HeaderByNumber`, with a fallback to wall clock if the RPC call fails. This correctly reflects when the event actually occurred on-chain, regardless of when the chain-watcher processed it.

### Evidence

Observed on testnet-staging: dashboard showed 4.24 days (time since last restart) when the actual gap was 14 days with no on-chain submissions.

## Test plan

- [ ] Deploy to an environment with a known submission gap — metric should reflect the actual on-chain gap, not restart age
- [ ] Restart chain-watcher — metric should not reset to ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chain-watcher `lastSubmissionTime` to use on-chain block timestamp instead of wall clock
> - Adds `Watcher.blockTimeForLog` in [watcher.go](https://github.com/xmtp/xmtpd/pull/1923/files#diff-5d55a4b0376cd6b64755e600c3c7cf5554efab2ac96120fa0d76a1f240be0d1b) to fetch the block header via `rpcClient.HeaderByNumber` and return the block's timestamp.
> - Updates `handlePayerReportSubmitted` to assign `w.lastSubmissionTime` from the block timestamp rather than the current wall-clock time, fixing the reported time since last on-chain submission.
> - Falls back to wall-clock time and emits a warning log if the header fetch fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be351a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->