### PR TITLE
Add manual deploy-to-testnet-dev workflow

### DIFF
--- a/.github/workflows/deploy-testnet-dev.yml
+++ b/.github/workflows/deploy-testnet-dev.yml
@@ -1,0 +1,120 @@
+name: Deploy to testnet-dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "build-xmtpd.yml run ID to deploy (leave blank for latest successful run on main)"
+        required: false
+        type: string
+
+jobs:
+  resolve_run:
+    name: Resolve build run
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.resolve.outputs.run_id }}
+    steps:
+      - name: Resolve run ID
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.run_id }}" ]]; then
+            echo "run_id=${{ inputs.run_id }}" >> $GITHUB_OUTPUT
+            echo "Using provided run ID: ${{ inputs.run_id }}"
+          else
+            RUN_ID=$(gh api \
+              "/repos/${{ github.repository }}/actions/workflows/build-xmtpd.yml/runs?branch=main&status=success&per_page=1" \
+              --jq '.workflow_runs[0].id')
+            if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+              echo "✖️  No successful build-xmtpd.yml run found on main." >&2
+              exit 1
+            fi
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+            echo "Resolved latest successful run on main: $RUN_ID"
+          fi
+
+  prepare:
+    name: Aggregate digests
+    runs-on: ubuntu-latest
+    needs: resolve_run
+    permissions:
+      actions: read
+    outputs:
+      xmtpd_image: ${{ steps.digests.outputs.xmtpd_image }}
+      prune_image: ${{ steps.digests.outputs.prune_image }}
+      gateway_image: ${{ steps.digests.outputs.gateway_image }}
+      chain_watcher_image: ${{ steps.digests.outputs.chain_watcher_image }}
+    steps:
+      - name: Download xmtpd digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-digest
+          path: digests
+          run-id: ${{ needs.resolve_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download xmtpd-prune digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-prune-digest
+          path: digests
+          run-id: ${{ needs.resolve_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download xmtpd-gateway digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-gateway-digest
+          path: digests
+          run-id: ${{ needs.resolve_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download xmtpd-chain-watcher digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-chain-watcher-digest
+          path: digests
+          run-id: ${{ needs.resolve_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read and export digests
+        id: digests
+        run: |
+          set -euo pipefail
+
+          XMTPD_DIGEST=$(cut -d= -f2 digests/xmtpd.txt)
+          PRUNE_DIGEST=$(cut -d= -f2 digests/xmtpd-prune.txt)
+          GATEWAY_DIGEST=$(cut -d= -f2 digests/xmtpd-gateway.txt)
+          CHAIN_WATCHER_DIGEST=$(cut -d= -f2 digests/xmtpd-chain-watcher.txt)
+
+          if [[ -z "$XMTPD_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" || -z "$CHAIN_WATCHER_DIGEST" ]]; then
+            echo "✖️  One or more digests are empty – aborting deploy." >&2
+            exit 1
+          fi
+
+          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"                               >> $GITHUB_OUTPUT
+          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"                         >> $GITHUB_OUTPUT
+          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"                   >> $GITHUB_OUTPUT
+          echo "chain_watcher_image=ghcr.io/xmtp/xmtpd-chain-watcher@$CHAIN_WATCHER_DIGEST" >> $GITHUB_OUTPUT
+
+  deploy_testnet_dev:
+    name: Deploy to testnet-dev
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Deploy testnet-dev
+        uses: xmtp-labs/terraform-deployer@v1
+        timeout-minutes: 45
+        with:
+          timeout: 45m
+          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
+          terraform-org: xmtp
+          terraform-workspace: testnet-dev
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }}"
+          variable-value-required-prefix: "ghcr.io/xmtp/"


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch`-only workflow to deploy to `testnet-dev` without touching the automated CI/CD pipeline
- Resolves the latest successful `build-xmtpd.yml` run on `main` automatically — no inputs required for a single-click deploy
- Optionally accepts a specific `run_id` to deploy an older build or roll back
- Downloads the exact same image digests used for `testnet-staging` and `testnet` (no rebuild)

## Test plan

- [ ] Merge and verify the workflow appears in Actions → "Deploy to testnet-dev"
- [ ] Run with no inputs — confirm it resolves the latest build run and deploys to `testnet-dev`
- [ ] Run with an explicit `run_id` — confirm it uses the specified build's digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual deploy-to-testnet-dev GitHub Actions workflow
> - Adds [deploy-testnet-dev.yml](.github/workflows/deploy-testnet-dev.yml), a manually-triggered workflow that deploys to the `testnet-dev` Terraform workspace.
> - A `resolve_run` job accepts an optional `run_id` input or falls back to the latest successful `build-xmtpd.yml` run on `main`.
> - A `prepare` job downloads four image digest artifacts (`xmtpd`, `xmtpd-prune`, `xmtpd-gateway`, `xmtpd-chain-watcher`), validates them, and constructs fully qualified `ghcr.io/xmtp/` image references.
> - A `deploy_testnet_dev` job invokes `xmtp-labs/terraform-deployer@v1` with a 45-minute timeout, passing the resolved image references as Terraform variables.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8238a69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->