### PR TITLE
Remove unnecessary npm update step from publish workflow

### DIFF
--- a/.github/workflows/publish-gateway-npm.yml
+++ b/.github/workflows/publish-gateway-npm.yml
@@ -81,9 +81,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
-
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Removes the `npm install -g npm@latest` step from the gateway npm publish workflow
- This step is redundant since `actions/setup-node` already provides a working npm bundled with Node 22
- It was causing CI failures due to a missing `promise-retry` module on newer GitHub Actions runners ([failed run](https://github.com/xmtp/xmtpd/actions/runs/24053207269/job/70153926515))

## Test plan
- [x] Verify the workflow still runs successfully without the step (npm from setup-node is sufficient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `npm install -g npm@latest` step from publish-gateway-npm workflow
> The `publish-gateway-npm` workflow no longer upgrades npm before running `npm pack` and `npm publish`, relying instead on the version bundled with `actions/setup-node` (Node 22).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8b3957.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->