### PR TITLE
chore: add names to iteration workflow files

### DIFF
--- a/.github/workflows/bulk-move-from-previous-iteration.yml
+++ b/.github/workflows/bulk-move-from-previous-iteration.yml
@@ -1,3 +1,5 @@
+name: "Safety net: carry over leftover tickets from last iteration"
+
 on:
   schedule:
     # Runs "at 05:00, only on Sunday" (see https://crontab.guru)

--- a/.github/workflows/bulk-move-to-next-iteration.yml
+++ b/.github/workflows/bulk-move-to-next-iteration.yml
@@ -1,3 +1,5 @@
+name: "Planning: move current tickets to next iteration"
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Added `name:` fields to both iteration-move workflow files so they display clearly in the GitHub Actions UI
- **"Safety net: carry over leftover tickets from last iteration"** — the Sunday cron (last → current)
- **"Planning: move current tickets to next iteration"** — the manual trigger (current → next)

## Test plan
- [ ] Verify workflow names render correctly in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add display names to iteration workflow files
> Adds `name` fields to [bulk-move-from-previous-iteration.yml](https://github.com/xmtp/xmtpd/pull/1961/files#diff-19b6dee2bbb4f7f481f4de4d17126db9cea089c36e3dc3d6110ee3c225d37e12) and [bulk-move-to-next-iteration.yml](https://github.com/xmtp/xmtpd/pull/1961/files#diff-49d8db6b36d54bc4bd68ead642d8dbe88084d60a95cfd595883055b200bbb7b9) so they appear with human-readable titles in the GitHub Actions UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7f02b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->