### PR TITLE
feat: add concurrent stream limit for SubscribeAllEnvelopes

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -140,6 +140,11 @@ type RateLimitOptions struct {
 
 	// Trusted proxy CIDRs (comma-separated)
 	TrustedProxyCIDRs string `long:"trusted-proxy-cidrs" env:"XMTPD_RATE_LIMIT_TRUSTED_PROXY_CIDRS" description:"Comma-separated trusted proxy CIDR list for X-Forwarded-For peeling"`
+
+	// Concurrent stream limits (NotificationApi/SubscribeAllEnvelopes)
+	T1MaxConcurrentStreams int           `long:"t1-max-concurrent-streams" env:"XMTPD_RATE_LIMIT_T1_MAX_CONCURRENT_STREAMS" description:"Max concurrent SubscribeAllEnvelopes streams per IP" default:"2"`
+	StreamTTL              time.Duration `long:"stream-ttl"                env:"XMTPD_RATE_LIMIT_STREAM_TTL"                description:"Redis key TTL for stream counters (crash self-heal window)" default:"15m"`
+	StreamRefreshInterval  time.Duration `long:"stream-refresh-interval"   env:"XMTPD_RATE_LIMIT_STREAM_REFRESH_INTERVAL"   description:"How often to refresh stream counter TTL" default:"5m"`
 }
 
 type LogOptions struct {

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -142,9 +142,9 @@ type RateLimitOptions struct {
 	TrustedProxyCIDRs string `long:"trusted-proxy-cidrs" env:"XMTPD_RATE_LIMIT_TRUSTED_PROXY_CIDRS" description:"Comma-separated trusted proxy CIDR list for X-Forwarded-For peeling"`
 
 	// Concurrent stream limits (NotificationApi/SubscribeAllEnvelopes)
-	T1MaxConcurrentStreams int           `long:"t1-max-concurrent-streams" env:"XMTPD_RATE_LIMIT_T1_MAX_CONCURRENT_STREAMS" description:"Max concurrent SubscribeAllEnvelopes streams per IP"        default:"2"`
-	StreamTTL              time.Duration `long:"stream-ttl"                env:"XMTPD_RATE_LIMIT_STREAM_TTL"                description:"Redis key TTL for stream counters (crash self-heal window)" default:"15m"`
-	StreamRefreshInterval  time.Duration `long:"stream-refresh-interval"   env:"XMTPD_RATE_LIMIT_STREAM_REFRESH_INTERVAL"   description:"How often to refresh stream counter TTL"                    default:"5m"`
+	T1MaxConcurrentSubscribeAll int           `long:"t-1-max-concurrent-subscribe-all" env:"XMTPD_RATE_LIMIT_T1_MAX_CONCURRENT_SUBSCRIBE_ALL" description:"Max concurrent SubscribeAllEnvelopes streams per IP"        default:"2"`
+	StreamTTL                   time.Duration `long:"stream-ttl"                       env:"XMTPD_RATE_LIMIT_STREAM_TTL"                      description:"Redis key TTL for stream counters (crash self-heal window)" default:"15m"`
+	StreamRefreshInterval       time.Duration `long:"stream-refresh-interval"          env:"XMTPD_RATE_LIMIT_STREAM_REFRESH_INTERVAL"         description:"How often to refresh stream counter TTL"                    default:"5m"`
 }
 
 type LogOptions struct {

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -142,9 +142,9 @@ type RateLimitOptions struct {
 	TrustedProxyCIDRs string `long:"trusted-proxy-cidrs" env:"XMTPD_RATE_LIMIT_TRUSTED_PROXY_CIDRS" description:"Comma-separated trusted proxy CIDR list for X-Forwarded-For peeling"`
 
 	// Concurrent stream limits (NotificationApi/SubscribeAllEnvelopes)
-	T1MaxConcurrentStreams int           `long:"t1-max-concurrent-streams" env:"XMTPD_RATE_LIMIT_T1_MAX_CONCURRENT_STREAMS" description:"Max concurrent SubscribeAllEnvelopes streams per IP" default:"2"`
+	T1MaxConcurrentStreams int           `long:"t1-max-concurrent-streams" env:"XMTPD_RATE_LIMIT_T1_MAX_CONCURRENT_STREAMS" description:"Max concurrent SubscribeAllEnvelopes streams per IP"        default:"2"`
 	StreamTTL              time.Duration `long:"stream-ttl"                env:"XMTPD_RATE_LIMIT_STREAM_TTL"                description:"Redis key TTL for stream counters (crash self-heal window)" default:"15m"`
-	StreamRefreshInterval  time.Duration `long:"stream-refresh-interval"   env:"XMTPD_RATE_LIMIT_STREAM_REFRESH_INTERVAL"   description:"How often to refresh stream counter TTL" default:"5m"`
+	StreamRefreshInterval  time.Duration `long:"stream-refresh-interval"   env:"XMTPD_RATE_LIMIT_STREAM_REFRESH_INTERVAL"   description:"How often to refresh stream counter TTL"                    default:"5m"`
 }
 
 type LogOptions struct {

--- a/pkg/interceptors/server/stream_limit.go
+++ b/pkg/interceptors/server/stream_limit.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	"connectrpc.com/connect"
+	"go.uber.org/zap"
+
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api/message_apiconnect"
+	"github.com/xmtp/xmtpd/pkg/ratelimiter"
+	"github.com/xmtp/xmtpd/pkg/utils/clientip"
+)
+
+// StreamLimitInterceptor enforces a per-IP concurrent stream limit on
+// NotificationApi/SubscribeAllEnvelopes. Tier 0 (authenticated nodes) bypass.
+type StreamLimitInterceptor struct {
+	logger          *zap.Logger
+	limiter         ratelimiter.StreamLimiter
+	trustedCIDRs    []*net.IPNet
+	refreshInterval time.Duration
+}
+
+// NewStreamLimitInterceptor creates a StreamLimitInterceptor.
+func NewStreamLimitInterceptor(
+	logger *zap.Logger,
+	limiter ratelimiter.StreamLimiter,
+	trustedCIDRs []*net.IPNet,
+	refreshInterval time.Duration,
+) *StreamLimitInterceptor {
+	return &StreamLimitInterceptor{
+		logger:          logger.Named("xmtpd.stream-limiter"),
+		limiter:         limiter,
+		trustedCIDRs:    trustedCIDRs,
+		refreshInterval: refreshInterval,
+	}
+}
+
+// WrapUnary is a no-op — SubscribeAllEnvelopes is a streaming RPC.
+func (i *StreamLimitInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return next
+}
+
+// WrapStreamingClient is a no-op for server interceptors.
+func (i *StreamLimitInterceptor) WrapStreamingClient(
+	next connect.StreamingClientFunc,
+) connect.StreamingClientFunc {
+	return next
+}
+
+// WrapStreamingHandler enforces the concurrent stream limit on
+// NotificationApi/SubscribeAllEnvelopes.
+func (i *StreamLimitInterceptor) WrapStreamingHandler(
+	next connect.StreamingHandlerFunc,
+) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		if conn.Spec().Procedure != message_apiconnect.NotificationApiSubscribeAllEnvelopesProcedure {
+			return next(ctx, conn)
+		}
+
+		if ratelimiter.ClassifyTier(ctx) == ratelimiter.Tier0 {
+			ratelimiter.StreamDecisionsTotal.WithLabelValues(
+				"NotificationApi", "bypassed",
+			).Inc()
+			return next(ctx, conn)
+		}
+
+		subject := clientip.Extract(
+			conn.Peer().Addr,
+			conn.RequestHeader().Get("X-Forwarded-For"),
+			i.trustedCIDRs,
+		)
+
+		allowed, err := i.limiter.Acquire(ctx, subject)
+		if err != nil {
+			i.logger.Warn("stream limiter error, allowing stream",
+				zap.String("subject", subject),
+				zap.Error(err),
+			)
+			ratelimiter.StreamDecisionsTotal.WithLabelValues(
+				"NotificationApi", "failed_open",
+			).Inc()
+			return next(ctx, conn)
+		}
+
+		if !allowed {
+			ratelimiter.StreamDecisionsTotal.WithLabelValues(
+				"NotificationApi", "denied",
+			).Inc()
+			return connect.NewError(
+				connect.CodeResourceExhausted,
+				errors.New("concurrent stream limit exceeded"),
+			)
+		}
+
+		ratelimiter.StreamDecisionsTotal.WithLabelValues(
+			"NotificationApi", "allowed",
+		).Inc()
+		ratelimiter.StreamActiveStreams.Inc()
+
+		// Ensure Release fires on any exit path.
+		defer func() {
+			ratelimiter.StreamActiveStreams.Dec()
+			if releaseErr := i.limiter.Release(context.Background(), subject); releaseErr != nil {
+				i.logger.Warn("stream limiter release error",
+					zap.String("subject", subject),
+					zap.Error(releaseErr),
+				)
+			}
+		}()
+
+		// Start TTL refresh goroutine.
+		refreshCtx, cancelRefresh := context.WithCancel(ctx)
+		defer cancelRefresh()
+		go i.refreshLoop(refreshCtx, subject)
+
+		return next(ctx, conn)
+	}
+}
+
+func (i *StreamLimitInterceptor) refreshLoop(ctx context.Context, subject string) {
+	ticker := time.NewTicker(i.refreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := i.limiter.RefreshTTL(ctx, subject); err != nil {
+				i.logger.Warn("stream TTL refresh error",
+					zap.String("subject", subject),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+}

--- a/pkg/interceptors/server/stream_limit_test.go
+++ b/pkg/interceptors/server/stream_limit_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/constants"
+	"github.com/xmtp/xmtpd/pkg/proto/xmtpv4/message_api/message_apiconnect"
+	"go.uber.org/zap/zaptest"
+)
+
+// fakeStreamLimiter is a test double for ratelimiter.StreamLimiter.
+type fakeStreamLimiter struct {
+	mu           sync.Mutex
+	acquireAllow bool
+	acquireErr   error
+	releaseErr   error
+	refreshErr   error
+	acquireCount int
+	releaseCount int
+}
+
+func (f *fakeStreamLimiter) Acquire(_ context.Context, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acquireCount++
+	return f.acquireAllow, f.acquireErr
+}
+
+func (f *fakeStreamLimiter) Release(_ context.Context, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releaseCount++
+	return f.releaseErr
+}
+
+func (f *fakeStreamLimiter) RefreshTTL(_ context.Context, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.refreshErr
+}
+
+func TestStreamLimit_Tier0Bypasses(t *testing.T) {
+	limiter := &fakeStreamLimiter{acquireAllow: true}
+	interceptor := NewStreamLimitInterceptor(
+		zaptest.NewLogger(t), limiter, nil, 5*time.Minute,
+	)
+
+	ctx := context.WithValue(
+		context.Background(),
+		constants.VerifiedNodeRequestCtxKey{},
+		true,
+	)
+	conn := &mockStreamingConn{
+		spec: connect.Spec{
+			Procedure: message_apiconnect.NotificationApiSubscribeAllEnvelopesProcedure,
+		},
+		peer:   connect.Peer{Addr: "10.0.0.1:1234"},
+		header: http.Header{},
+	}
+
+	called := false
+	handler := func(_ context.Context, _ connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+
+	err := interceptor.WrapStreamingHandler(handler)(ctx, conn)
+	require.NoError(t, err)
+	assert.True(t, called, "handler should be called")
+	assert.Equal(t, 0, limiter.acquireCount, "should not call acquire for tier 0")
+}
+
+func TestStreamLimit_Tier2Allowed(t *testing.T) {
+	limiter := &fakeStreamLimiter{acquireAllow: true}
+	interceptor := NewStreamLimitInterceptor(
+		zaptest.NewLogger(t), limiter, nil, 5*time.Minute,
+	)
+
+	conn := &mockStreamingConn{
+		spec: connect.Spec{
+			Procedure: message_apiconnect.NotificationApiSubscribeAllEnvelopesProcedure,
+		},
+		peer:   connect.Peer{Addr: "10.0.0.1:1234"},
+		header: http.Header{},
+	}
+
+	called := false
+	handler := func(_ context.Context, _ connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+
+	err := interceptor.WrapStreamingHandler(handler)(context.Background(), conn)
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, 1, limiter.acquireCount)
+	assert.Equal(t, 1, limiter.releaseCount, "release should fire after handler returns")
+}
+
+func TestStreamLimit_Tier2Denied(t *testing.T) {
+	limiter := &fakeStreamLimiter{acquireAllow: false}
+	interceptor := NewStreamLimitInterceptor(
+		zaptest.NewLogger(t), limiter, nil, 5*time.Minute,
+	)
+
+	conn := &mockStreamingConn{
+		spec: connect.Spec{
+			Procedure: message_apiconnect.NotificationApiSubscribeAllEnvelopesProcedure,
+		},
+		peer:   connect.Peer{Addr: "10.0.0.1:1234"},
+		header: http.Header{},
+	}
+
+	called := false
+	handler := func(_ context.Context, _ connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+
+	err := interceptor.WrapStreamingHandler(handler)(context.Background(), conn)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	assert.False(t, called, "handler should not be called when denied")
+	assert.Equal(t, 0, limiter.releaseCount, "release should not fire when denied")
+}
+
+func TestStreamLimit_FailOpenOnRedisError(t *testing.T) {
+	limiter := &fakeStreamLimiter{
+		acquireAllow: false,
+		acquireErr:   errors.New("redis connection refused"),
+	}
+	interceptor := NewStreamLimitInterceptor(
+		zaptest.NewLogger(t), limiter, nil, 5*time.Minute,
+	)
+
+	conn := &mockStreamingConn{
+		spec: connect.Spec{
+			Procedure: message_apiconnect.NotificationApiSubscribeAllEnvelopesProcedure,
+		},
+		peer:   connect.Peer{Addr: "10.0.0.1:1234"},
+		header: http.Header{},
+	}
+
+	called := false
+	handler := func(_ context.Context, _ connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+
+	err := interceptor.WrapStreamingHandler(handler)(context.Background(), conn)
+	require.NoError(t, err)
+	assert.True(t, called, "should fail open on Redis error")
+}
+
+func TestStreamLimit_NonNotificationApiPassesThrough(t *testing.T) {
+	limiter := &fakeStreamLimiter{acquireAllow: true}
+	interceptor := NewStreamLimitInterceptor(
+		zaptest.NewLogger(t), limiter, nil, 5*time.Minute,
+	)
+
+	conn := &mockStreamingConn{
+		spec: connect.Spec{
+			Procedure: message_apiconnect.QueryApiSubscribeTopicsProcedure,
+		},
+		peer:   connect.Peer{Addr: "10.0.0.1:1234"},
+		header: http.Header{},
+	}
+
+	called := false
+	handler := func(_ context.Context, _ connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+
+	err := interceptor.WrapStreamingHandler(handler)(context.Background(), conn)
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, 0, limiter.acquireCount, "should not touch limiter for non-NotificationApi")
+}

--- a/pkg/ratelimiter/builder.go
+++ b/pkg/ratelimiter/builder.go
@@ -18,8 +18,8 @@ import (
 // key prefixes), the parsed trusted-proxy CIDRs, and is consumed by the server
 // when constructing the rate-limit interceptor.
 type BuiltLimiter struct {
-	QueryLimiter  RateLimiter // BreakerLimiter wrapping a RedisLimiter([per-minute, per-hour])
-	OpensLimiter  RateLimiter // BreakerLimiter wrapping a RedisLimiter([opens-per-minute])
+	QueryLimiter  RateLimiter   // BreakerLimiter wrapping a RedisLimiter([per-minute, per-hour])
+	OpensLimiter  RateLimiter   // BreakerLimiter wrapping a RedisLimiter([opens-per-minute])
 	StreamLimiter StreamLimiter // BreakerStreamLimiter wrapping a RedisStreamLimiter
 	TrustedCIDRs  []*net.IPNet
 }

--- a/pkg/ratelimiter/builder.go
+++ b/pkg/ratelimiter/builder.go
@@ -81,7 +81,7 @@ func Build(
 	streamInner := NewRedisStreamLimiter(
 		client,
 		redisOpts.KeyPrefix+"rl:streams:",
-		rlOpts.T1MaxConcurrentStreams,
+		rlOpts.T1MaxConcurrentSubscribeAll,
 		rlOpts.StreamTTL,
 	)
 	streamLimiter := NewBreakerStreamLimiter(
@@ -99,7 +99,7 @@ func Build(
 		zap.Int("t2_per_minute", rlOpts.T2PerMinuteCapacity),
 		zap.Int("t2_per_hour", rlOpts.T2PerHourCapacity),
 		zap.Int("t2_subscribe_opens_per_minute", rlOpts.T2SubscribeOpensPerMinute),
-		zap.Int("t1_max_concurrent_streams", rlOpts.T1MaxConcurrentStreams),
+		zap.Int("t1_max_concurrent_streams", rlOpts.T1MaxConcurrentSubscribeAll),
 		zap.Duration("stream_ttl", rlOpts.StreamTTL),
 		zap.Duration("stream_refresh_interval", rlOpts.StreamRefreshInterval),
 	)

--- a/pkg/ratelimiter/builder.go
+++ b/pkg/ratelimiter/builder.go
@@ -20,7 +20,7 @@ import (
 type BuiltLimiter struct {
 	QueryLimiter  RateLimiter // BreakerLimiter wrapping a RedisLimiter([per-minute, per-hour])
 	OpensLimiter  RateLimiter // BreakerLimiter wrapping a RedisLimiter([opens-per-minute])
-	StreamLimiter StreamLimiter
+	StreamLimiter StreamLimiter // BreakerStreamLimiter wrapping a RedisStreamLimiter
 	TrustedCIDRs  []*net.IPNet
 }
 
@@ -78,11 +78,16 @@ func Build(
 		NewCircuitBreaker(rlOpts.BreakerFailureThreshold, rlOpts.BreakerCooldown),
 	)
 
-	streamLimiter := NewRedisStreamLimiter(
+	streamInner := NewRedisStreamLimiter(
 		client,
 		redisOpts.KeyPrefix+"rl:streams:",
 		rlOpts.T1MaxConcurrentStreams,
 		rlOpts.StreamTTL,
+	)
+	streamLimiter := NewBreakerStreamLimiter(
+		streamInner,
+		NewCircuitBreaker(rlOpts.BreakerFailureThreshold, rlOpts.BreakerCooldown),
+		logger,
 	)
 
 	cidrs, err := clientip.ParseTrustedProxyCIDRs(rlOpts.TrustedProxyCIDRs)

--- a/pkg/ratelimiter/builder.go
+++ b/pkg/ratelimiter/builder.go
@@ -18,9 +18,10 @@ import (
 // key prefixes), the parsed trusted-proxy CIDRs, and is consumed by the server
 // when constructing the rate-limit interceptor.
 type BuiltLimiter struct {
-	QueryLimiter RateLimiter // BreakerLimiter wrapping a RedisLimiter([per-minute, per-hour])
-	OpensLimiter RateLimiter // BreakerLimiter wrapping a RedisLimiter([opens-per-minute])
-	TrustedCIDRs []*net.IPNet
+	QueryLimiter  RateLimiter // BreakerLimiter wrapping a RedisLimiter([per-minute, per-hour])
+	OpensLimiter  RateLimiter // BreakerLimiter wrapping a RedisLimiter([opens-per-minute])
+	StreamLimiter StreamLimiter
+	TrustedCIDRs  []*net.IPNet
 }
 
 // Build constructs the rate-limit subsystem from server configuration. If
@@ -77,6 +78,13 @@ func Build(
 		NewCircuitBreaker(rlOpts.BreakerFailureThreshold, rlOpts.BreakerCooldown),
 	)
 
+	streamLimiter := NewRedisStreamLimiter(
+		client,
+		redisOpts.KeyPrefix+"rl:streams:",
+		rlOpts.T1MaxConcurrentStreams,
+		rlOpts.StreamTTL,
+	)
+
 	cidrs, err := clientip.ParseTrustedProxyCIDRs(rlOpts.TrustedProxyCIDRs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse trusted proxy CIDRs: %w", err)
@@ -86,10 +94,14 @@ func Build(
 		zap.Int("t2_per_minute", rlOpts.T2PerMinuteCapacity),
 		zap.Int("t2_per_hour", rlOpts.T2PerHourCapacity),
 		zap.Int("t2_subscribe_opens_per_minute", rlOpts.T2SubscribeOpensPerMinute),
+		zap.Int("t1_max_concurrent_streams", rlOpts.T1MaxConcurrentStreams),
+		zap.Duration("stream_ttl", rlOpts.StreamTTL),
+		zap.Duration("stream_refresh_interval", rlOpts.StreamRefreshInterval),
 	)
 	return &BuiltLimiter{
-		QueryLimiter: queryWrapped,
-		OpensLimiter: opensWrapped,
-		TrustedCIDRs: cidrs,
+		QueryLimiter:  queryWrapped,
+		OpensLimiter:  opensWrapped,
+		StreamLimiter: streamLimiter,
+		TrustedCIDRs:  cidrs,
 	}, nil
 }

--- a/pkg/ratelimiter/metrics.go
+++ b/pkg/ratelimiter/metrics.go
@@ -29,6 +29,7 @@ var (
 func Register(reg prometheus.Registerer) {
 	for _, c := range []prometheus.Collector{
 		DecisionsTotal, BreakerStateGauge, BreakerTripsTotal,
+		StreamDecisionsTotal, StreamActiveStreams,
 	} {
 		_ = reg.Register(c)
 	}

--- a/pkg/ratelimiter/redis_stream_limiter.go
+++ b/pkg/ratelimiter/redis_stream_limiter.go
@@ -1,0 +1,84 @@
+package ratelimiter
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisStreamLimiter tracks concurrent stream counts using Redis INCR/DECR.
+// Each subject (IP) gets a single Redis key whose value is the current stream
+// count. A TTL on the key provides crash recovery: if a process dies without
+// calling Release, the key expires and the slot is freed.
+type RedisStreamLimiter struct {
+	client    redis.UniversalClient
+	keyPrefix string
+	maxCount  int64
+	ttl       time.Duration
+}
+
+// NewRedisStreamLimiter creates a RedisStreamLimiter.
+//   - keyPrefix: prepended to the subject to form the Redis key (e.g. "xmtpd:rl:streams:").
+//   - maxCount: maximum allowed concurrent streams per subject.
+//   - ttl: Redis key TTL; acts as the crash self-heal window.
+func NewRedisStreamLimiter(
+	client redis.UniversalClient,
+	keyPrefix string,
+	maxCount int,
+	ttl time.Duration,
+) *RedisStreamLimiter {
+	return &RedisStreamLimiter{
+		client:    client,
+		keyPrefix: keyPrefix,
+		maxCount:  int64(maxCount),
+		ttl:       ttl,
+	}
+}
+
+func (l *RedisStreamLimiter) key(subject string) string {
+	return l.keyPrefix + subject
+}
+
+// Acquire atomically increments the stream count for the subject. If the new
+// count exceeds maxCount, it immediately decrements and returns allowed=false.
+func (l *RedisStreamLimiter) Acquire(ctx context.Context, subject string) (bool, error) {
+	k := l.key(subject)
+
+	count, err := l.client.Incr(ctx, k).Result()
+	if err != nil {
+		return false, err
+	}
+
+	if count > l.maxCount {
+		// Over limit — roll back the increment.
+		l.client.Decr(ctx, k)
+		return false, nil
+	}
+
+	// Set/refresh TTL on successful acquire.
+	l.client.Expire(ctx, k, l.ttl)
+	return true, nil
+}
+
+// Release decrements the stream count for the subject. The count is clamped
+// at zero to prevent negative drift from orphan releases.
+func (l *RedisStreamLimiter) Release(ctx context.Context, subject string) error {
+	k := l.key(subject)
+
+	val, err := l.client.Decr(ctx, k).Result()
+	if err != nil {
+		return err
+	}
+
+	// Clamp at zero: if DECR produced a negative value, reset to 0.
+	if val < 0 {
+		l.client.Set(ctx, k, 0, l.ttl)
+	}
+	return nil
+}
+
+// RefreshTTL resets the key's TTL to keep it alive while a stream is open.
+func (l *RedisStreamLimiter) RefreshTTL(ctx context.Context, subject string) error {
+	return l.client.Expire(ctx, l.key(subject), l.ttl).Err()
+}

--- a/pkg/ratelimiter/redis_stream_limiter.go
+++ b/pkg/ratelimiter/redis_stream_limiter.go
@@ -2,20 +2,26 @@ package ratelimiter
 
 import (
 	"context"
+	_ "embed"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
-// RedisStreamLimiter tracks concurrent stream counts using Redis INCR/DECR.
-// Each subject (IP) gets a single Redis key whose value is the current stream
-// count. A TTL on the key provides crash recovery: if a process dies without
-// calling Release, the key expires and the slot is freed.
+//go:embed stream_script.lua
+var streamLuaScript string
+
+// RedisStreamLimiter tracks concurrent stream counts using a Lua script
+// for atomic acquire/release. Each subject (IP) gets a single Redis key
+// whose value is the current stream count. A TTL on the key provides crash
+// recovery: if a process dies without calling Release, the key expires and
+// the slot is freed.
 type RedisStreamLimiter struct {
 	client    redis.UniversalClient
+	script    *redis.Script
 	keyPrefix string
-	maxCount  int64
-	ttl       time.Duration
+	maxCount  int
+	ttlMs     int64
 }
 
 // NewRedisStreamLimiter creates a RedisStreamLimiter.
@@ -30,9 +36,10 @@ func NewRedisStreamLimiter(
 ) *RedisStreamLimiter {
 	return &RedisStreamLimiter{
 		client:    client,
+		script:    redis.NewScript(streamLuaScript),
 		keyPrefix: keyPrefix,
-		maxCount:  int64(maxCount),
-		ttl:       ttl,
+		maxCount:  maxCount,
+		ttlMs:     ttl.Milliseconds(),
 	}
 }
 
@@ -40,45 +47,29 @@ func (l *RedisStreamLimiter) key(subject string) string {
 	return l.keyPrefix + subject
 }
 
-// Acquire atomically increments the stream count for the subject. If the new
-// count exceeds maxCount, it immediately decrements and returns allowed=false.
+// Acquire atomically checks the current count and increments only if below
+// maxCount. Returns allowed=true if the stream was admitted.
 func (l *RedisStreamLimiter) Acquire(ctx context.Context, subject string) (bool, error) {
-	k := l.key(subject)
-
-	count, err := l.client.Incr(ctx, k).Result()
+	result, err := l.script.Run(
+		ctx, l.client, []string{l.key(subject)},
+		"acquire", l.maxCount, l.ttlMs,
+	).Int64()
 	if err != nil {
 		return false, err
 	}
-
-	if count > l.maxCount {
-		// Over limit — roll back the increment.
-		l.client.Decr(ctx, k)
-		return false, nil
-	}
-
-	// Set/refresh TTL on successful acquire.
-	l.client.Expire(ctx, k, l.ttl)
-	return true, nil
+	return result == 1, nil
 }
 
-// Release decrements the stream count for the subject. The count is clamped
-// at zero to prevent negative drift from orphan releases.
+// Release atomically decrements the stream count, clamped at zero.
 func (l *RedisStreamLimiter) Release(ctx context.Context, subject string) error {
-	k := l.key(subject)
-
-	val, err := l.client.Decr(ctx, k).Result()
-	if err != nil {
-		return err
-	}
-
-	// Clamp at zero: if DECR produced a negative value, reset to 0.
-	if val < 0 {
-		l.client.Set(ctx, k, 0, l.ttl)
-	}
-	return nil
+	_, err := l.script.Run(
+		ctx, l.client, []string{l.key(subject)},
+		"release", 0, l.ttlMs,
+	).Result()
+	return err
 }
 
 // RefreshTTL resets the key's TTL to keep it alive while a stream is open.
 func (l *RedisStreamLimiter) RefreshTTL(ctx context.Context, subject string) error {
-	return l.client.Expire(ctx, l.key(subject), l.ttl).Err()
+	return l.client.PExpire(ctx, l.key(subject), time.Duration(l.ttlMs)*time.Millisecond).Err()
 }

--- a/pkg/ratelimiter/redis_stream_limiter_test.go
+++ b/pkg/ratelimiter/redis_stream_limiter_test.go
@@ -1,0 +1,124 @@
+package ratelimiter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/ratelimiter"
+	testredis "github.com/xmtp/xmtpd/pkg/testutils/redis"
+)
+
+func TestRedisStreamLimiter_AcquireUnderLimit(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 2, 15*time.Minute)
+
+	allowed, err := limiter.Acquire(context.Background(), "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestRedisStreamLimiter_AcquireAtLimit(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 2, 15*time.Minute)
+	ctx := context.Background()
+
+	allowed1, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed1)
+
+	allowed2, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed2)
+
+	allowed3, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.False(t, allowed3, "third stream should be denied")
+}
+
+func TestRedisStreamLimiter_ReleaseFreesSlot(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 2, 15*time.Minute)
+	ctx := context.Background()
+
+	_, _ = limiter.Acquire(ctx, "10.0.0.1")
+	_, _ = limiter.Acquire(ctx, "10.0.0.1")
+
+	err := limiter.Release(ctx, "10.0.0.1")
+	require.NoError(t, err)
+
+	allowed, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed, "slot should be freed after release")
+}
+
+func TestRedisStreamLimiter_DifferentIPsIndependent(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 1, 15*time.Minute)
+	ctx := context.Background()
+
+	allowed1, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed1)
+
+	allowed2, err := limiter.Acquire(ctx, "10.0.0.2")
+	require.NoError(t, err)
+	assert.True(t, allowed2, "different IP should have independent limit")
+}
+
+func TestRedisStreamLimiter_RefreshTTL(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	ttl := 2 * time.Second
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 2, ttl)
+	ctx := context.Background()
+
+	_, _ = limiter.Acquire(ctx, "10.0.0.1")
+
+	err := limiter.RefreshTTL(ctx, "10.0.0.1")
+	require.NoError(t, err)
+
+	remaining, err := client.TTL(ctx, prefix+"streams:10.0.0.1").Result()
+	require.NoError(t, err)
+	assert.Greater(t, remaining, time.Duration(0), "TTL should be positive after refresh")
+	assert.LessOrEqual(t, remaining, ttl, "TTL should not exceed configured value")
+}
+
+func TestRedisStreamLimiter_TTLExpiryFreesSlot(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	shortTTL := 1 * time.Second
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 1, shortTTL)
+	ctx := context.Background()
+
+	allowed, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	// Wait for TTL to expire
+	time.Sleep(shortTTL + 500*time.Millisecond)
+
+	// Slot should be freed by TTL expiry
+	allowed, err = limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed, "slot should be freed after TTL expiry")
+}
+
+func TestRedisStreamLimiter_ReleaseNeverGoesNegative(t *testing.T) {
+	client, prefix := testredis.NewRedisForTest(t)
+	limiter := ratelimiter.NewRedisStreamLimiter(client, prefix+"streams:", 2, 15*time.Minute)
+	ctx := context.Background()
+
+	// Release without acquire should not make count negative
+	err := limiter.Release(ctx, "10.0.0.1")
+	require.NoError(t, err)
+
+	// Should still be able to acquire max streams
+	allowed1, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed1)
+
+	allowed2, err := limiter.Acquire(ctx, "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, allowed2)
+}

--- a/pkg/ratelimiter/stream_limiter.go
+++ b/pkg/ratelimiter/stream_limiter.go
@@ -1,0 +1,13 @@
+package ratelimiter
+
+import "context"
+
+// StreamLimiter tracks concurrent stream counts per subject.
+// Acquire increments the count and returns whether the stream is allowed.
+// Release decrements the count when the stream closes.
+// RefreshTTL extends the key's TTL while the stream is alive.
+type StreamLimiter interface {
+	Acquire(ctx context.Context, subject string) (allowed bool, err error)
+	Release(ctx context.Context, subject string) error
+	RefreshTTL(ctx context.Context, subject string) error
+}

--- a/pkg/ratelimiter/stream_limiter.go
+++ b/pkg/ratelimiter/stream_limiter.go
@@ -1,6 +1,10 @@
 package ratelimiter
 
-import "context"
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
 
 // StreamLimiter tracks concurrent stream counts per subject.
 // Acquire increments the count and returns whether the stream is allowed.
@@ -10,4 +14,65 @@ type StreamLimiter interface {
 	Acquire(ctx context.Context, subject string) (allowed bool, err error)
 	Release(ctx context.Context, subject string) error
 	RefreshTTL(ctx context.Context, subject string) error
+}
+
+// BreakerStreamLimiter wraps a StreamLimiter with a CircuitBreaker.
+// On Redis errors, Acquire fails open (allowed=true), Release and RefreshTTL
+// errors are swallowed. When the breaker is OPEN, calls bypass Redis entirely.
+type BreakerStreamLimiter struct {
+	inner   StreamLimiter
+	breaker *CircuitBreaker
+	logger  *zap.Logger
+}
+
+// NewBreakerStreamLimiter wraps inner with the provided CircuitBreaker.
+func NewBreakerStreamLimiter(
+	inner StreamLimiter,
+	breaker *CircuitBreaker,
+	logger *zap.Logger,
+) *BreakerStreamLimiter {
+	return &BreakerStreamLimiter{inner: inner, breaker: breaker, logger: logger}
+}
+
+func (b *BreakerStreamLimiter) Acquire(ctx context.Context, subject string) (bool, error) {
+	if !b.breaker.Allow() {
+		return true, nil // fail open
+	}
+	allowed, err := b.inner.Acquire(ctx, subject)
+	if err != nil {
+		b.breaker.RecordFailure()
+		return true, nil //nolint:nilerr // intentional fail-open
+	}
+	b.breaker.RecordSuccess()
+	return allowed, nil
+}
+
+func (b *BreakerStreamLimiter) Release(ctx context.Context, subject string) error {
+	if !b.breaker.Allow() {
+		return nil // breaker open, skip
+	}
+	err := b.inner.Release(ctx, subject)
+	if err != nil {
+		b.breaker.RecordFailure()
+		b.logger.Warn("stream limiter release failed (breaker)",
+			zap.String("subject", subject),
+			zap.Error(err),
+		)
+		return nil //nolint:nilerr // best-effort release
+	}
+	b.breaker.RecordSuccess()
+	return nil
+}
+
+func (b *BreakerStreamLimiter) RefreshTTL(ctx context.Context, subject string) error {
+	if !b.breaker.Allow() {
+		return nil // breaker open, skip
+	}
+	err := b.inner.RefreshTTL(ctx, subject)
+	if err != nil {
+		b.breaker.RecordFailure()
+		return nil //nolint:nilerr // best-effort refresh
+	}
+	b.breaker.RecordSuccess()
+	return nil
 }

--- a/pkg/ratelimiter/stream_metrics.go
+++ b/pkg/ratelimiter/stream_metrics.go
@@ -1,0 +1,19 @@
+package ratelimiter
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	StreamDecisionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "xmtpd_stream_limit_decisions_total",
+			Help: "Stream-limit decisions broken down by service and outcome",
+		},
+		[]string{"service", "outcome"},
+	)
+	StreamActiveStreams = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "xmtpd_stream_limit_active_streams",
+			Help: "Number of active streams tracked by this process (local count, not Redis)",
+		},
+	)
+)

--- a/pkg/ratelimiter/stream_script.lua
+++ b/pkg/ratelimiter/stream_script.lua
@@ -1,0 +1,41 @@
+-- ============================================================================
+-- Concurrent Stream Limiter
+-- ============================================================================
+-- Atomic acquire/release for a per-subject concurrent stream counter.
+-- Single-key access per call (cluster-safe).
+--
+-- INPUTS:
+--   KEYS[1] = Counter key (e.g., "xmtpd:rl:streams:10.0.0.1")
+--   ARGV[1] = Operation: "acquire" or "release"
+--   ARGV[2] = max_count (only used by acquire; ignored by release)
+--   ARGV[3] = ttl_ms (TTL in milliseconds to set on the key)
+--
+-- RETURN VALUES:
+--   acquire: 1 if allowed, 0 if denied
+--   release: current count after release (clamped at 0)
+-- ============================================================================
+
+local key     = KEYS[1]
+local op      = ARGV[1]
+local max     = tonumber(ARGV[2])
+local ttl_ms  = tonumber(ARGV[3])
+
+if op == "acquire" then
+    local count = tonumber(redis.call("GET", key) or "0")
+    if count < max then
+        count = redis.call("INCR", key)
+        redis.call("PEXPIRE", key, ttl_ms)
+        return 1
+    end
+    return 0
+elseif op == "release" then
+    local count = tonumber(redis.call("GET", key) or "0")
+    if count > 0 then
+        count = redis.call("DECR", key)
+        redis.call("PEXPIRE", key, ttl_ms)
+        return count
+    end
+    return 0
+else
+    return redis.error_reply("unknown operation: " .. tostring(op))
+end

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -559,6 +559,21 @@ func startAPIServer(
 			}
 		}
 
+		notificationHandlerOpts := handlerOpts
+		if built != nil {
+			slInterceptor := server.NewStreamLimitInterceptor(
+				cfg.Logger,
+				built.StreamLimiter,
+				built.TrustedCIDRs,
+				cfg.Options.RateLimit.StreamRefreshInterval,
+			)
+			notificationHandlerOpts = []connect.HandlerOption{
+				connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
+				connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
+				connect.WithInterceptors(append(interceptors, slInterceptor)...),
+			}
+		}
+
 		replicationPath, replicationHandler := message_apiconnect.NewReplicationApiHandler(
 			replicationService, handlerOpts...,
 		)
@@ -569,7 +584,7 @@ func startAPIServer(
 			replicationService, handlerOpts...,
 		)
 		notificationPath, notificationHandler := message_apiconnect.NewNotificationApiHandler(
-			replicationService, handlerOpts...,
+			replicationService, notificationHandlerOpts...,
 		)
 
 		mux.Handle(replicationPath, replicationHandler)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
@@ -555,7 +556,7 @@ func startAPIServer(
 			queryHandlerOpts = []connect.HandlerOption{
 				connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
 				connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
-				connect.WithInterceptors(append(interceptors, rlInterceptor)...),
+				connect.WithInterceptors(append(slices.Clone(interceptors), rlInterceptor)...),
 			}
 		}
 
@@ -570,7 +571,7 @@ func startAPIServer(
 			notificationHandlerOpts = []connect.HandlerOption{
 				connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
 				connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
-				connect.WithInterceptors(append(interceptors, slInterceptor)...),
+				connect.WithInterceptors(append(slices.Clone(interceptors), slInterceptor)...),
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Adds a Redis-backed per-IP concurrent stream limit (default 2) on `NotificationApi/SubscribeAllEnvelopes`
- Uses INCR/DECR with a 15-minute TTL (refreshed every 5 minutes) for crash self-healing
- Tier 0 (authenticated nodes) bypass the limit; Tier 2 (edge clients) are enforced
- Fails open on Redis errors (same pattern as existing QueryApi rate limiter)
- Configurable via `XMTPD_RATE_LIMIT_T1_MAX_CONCURRENT_STREAMS`, `XMTPD_RATE_LIMIT_STREAM_TTL`, `XMTPD_RATE_LIMIT_STREAM_REFRESH_INTERVAL`

Companion infrastructure PR needed to add Terraform variables (branch `feat/subscribe-all-stream-limit` on `xmtp/infrastructure`).

Ref: #366

## Test plan

- [ ] 12 unit tests across `redis_stream_limiter_test.go` and `stream_limit_test.go`
- [ ] `go build ./...` clean
- [ ] `dev/lint-fix` 0 issues
- [ ] All touched packages pass: `ratelimiter`, `interceptors/server`, `server`, `config`
- [ ] Manual smoke test with `grpcurl` against local node with Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-IP concurrent stream limit for `SubscribeAllEnvelopes` in NotificationApi
> - Introduces a Redis-backed `RedisStreamLimiter` using an atomic Lua script to track concurrent streams per IP, with configurable max count (`T1MaxConcurrentStreams`, default 2), TTL (`StreamTTL`, default 15m), and refresh interval (`StreamRefreshInterval`, default 5m).
> - Adds a `StreamLimitInterceptor` to the NotificationApi server that enforces per-IP limits, bypasses enforcement for Tier0, returns `CodeResourceExhausted` on denial, and periodically refreshes Redis TTLs while a stream is active.
> - Wraps the limiter in a `BreakerStreamLimiter` that fails open on circuit breaker trips or Redis errors, making enforcement best-effort.
> - Exposes `StreamDecisionsTotal` and `StreamActiveStreams` Prometheus metrics for stream admission outcomes.
> - Risk: fixes a bug in the QueryApi interceptor setup where the shared interceptors slice was mutated; now cloned before appending.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1962 opened
>
> - Renamed concurrent stream limit configuration for SubscribeAllEnvelopes [03b8600]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 601d050.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->