### PR TITLE
ci: add flaky test watcher workflow

### DIFF
--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -9,7 +9,6 @@ on:
       - "Upgrade Tests"
       - "Lint"
       - "Lint Shellcheck"
-      - "Publish Gateway npm Package"
       - "Test"
       - "Nightly Automation"
     types: [completed]

--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -1,0 +1,143 @@
+name: Flaky Failure Watcher
+
+on:
+  workflow_run:
+    # NOTE: workflow_run requires explicit names — no wildcards.
+    # When adding a new workflow that runs on main, add it here too.
+    workflows:
+      - "Build xmtpd image"
+      - "Upgrade Tests"
+      - "Lint"
+      - "Lint Shellcheck"
+      - "Publish Gateway npm Package"
+      - "Test"
+      - "Nightly Automation"
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: flaky-failure-watcher-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  investigate:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Investigate failure
+        uses: anthropics/claude-code-action@v1.0.92
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+          claude_args: |
+            --model sonnet
+            --allowedTools "Bash(gh run view *),Bash(gh issue list *),Bash(gh issue create *),Bash(gh issue comment *),Bash(gh issue view *)"
+          prompt: |
+            A workflow has failed on the main branch. Investigate and report it.
+
+            ## Context
+
+            - **Workflow:** ${{ github.event.workflow_run.name }}
+            - **Run ID:** ${{ github.event.workflow_run.id }}
+            - **Run URL:** ${{ github.event.workflow_run.html_url }}
+            - **Commit:** ${{ github.event.workflow_run.head_sha }}
+            - **Branch:** ${{ github.event.workflow_run.head_branch }}
+            - **Repository:** ${{ github.repository }}
+
+            ## Instructions
+
+            ### Step 1: Fetch and analyze the failure
+
+            Run `gh run view ${{ github.event.workflow_run.id }} --log-failed` to get the failed job logs.
+            If the output is very large, focus on the last 200 lines of each failed step.
+
+            Identify:
+            - Which job(s) and step(s) failed
+            - The key error messages, stack traces, or assertion failures
+            - Whether this is a test/code failure or an infrastructure failure (runner OOM, network timeout, Docker pull failure, rate limit, etc.)
+
+            ### Step 2: Search for existing flaky issues
+
+            Run `gh issue list --label flaky --state open --json number,title,body,comments --limit 50` to find existing reports.
+
+            For each open issue, compare the failure signature:
+            - Same workflow?
+            - Same or similar error message / stack trace?
+            - Same failing test name?
+            - Same root cause, even if details differ?
+
+            ### Step 3: Take action
+
+            **If no existing issue matches this failure:**
+
+            Create a new issue:
+            ```
+            gh issue create \
+              --title "Flaky CI Failure: <short description of the error>" \
+              --label "flaky" \
+              --body "<body>"
+            ```
+
+            The issue body MUST follow this format:
+            ```
+            ## Flaky CI Failure: <short description>
+
+            **Workflow:** <workflow name>
+            **Failed run:** <run URL>
+            **Commit:** <sha>
+            **Failed jobs:** <job names>
+
+            ### Summary
+
+            <2-4 sentence description of the failure>
+
+            ### Error Details
+
+            <relevant log excerpts, stack traces — use code blocks>
+
+            ### Analysis
+
+            <root cause hypothesis, affected area, related code>
+            <note if this is an infrastructure failure vs. a test/code failure>
+
+            ---
+            *Reported by [Flaky Failure Watcher](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/flaky-failure-watcher.yml)*
+            ```
+
+            **If an existing issue matches AND this occurrence has new context** (different error message, new affected test, different stack trace, new reproduction conditions):
+
+            Add a comment to the existing issue:
+            ```
+            gh issue comment <issue_number> --body "<body>"
+            ```
+
+            The comment body MUST follow this format:
+            ```
+            ### Recurrence — <today's date>
+
+            **Failed run:** <run URL>
+            **Commit:** <sha>
+
+            <What is new or different about this occurrence compared to previous reports>
+            ```
+
+            **If an existing issue matches AND this is the exact same failure with no new information:**
+
+            Do nothing. Exit without creating an issue or comment. Explain your reasoning briefly in your response but take no action.
+
+            ## Important
+
+            - Do NOT create duplicate issues. If in doubt, err on the side of commenting on an existing issue.
+            - Keep error excerpts concise — include the most relevant 20-50 lines, not entire logs.
+            - Always use code blocks for error output and stack traces.

--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -5,12 +5,7 @@ on:
     # NOTE: workflow_run requires explicit names — no wildcards.
     # When adding a new workflow that runs on main, add it here too.
     workflows:
-      - "Build xmtpd image"
-      - "Upgrade Tests"
-      - "Lint"
-      - "Lint Shellcheck"
       - "Test"
-      - "Nightly Automation"
     types: [completed]
     branches: [main]
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1964

## Summary

Adapts the [flaky-failure-watcher pattern from `xmtp/libxmtp`](https://github.com/xmtp/libxmtp/blob/main/.github/workflows/flaky-failure-watcher.yml) to xmtpd. When a CI workflow fails on `main`, a `workflow_run`-triggered job dispatches `anthropics/claude-code-action` to investigate the failure and either file a new `flaky`-labelled issue or comment on an existing one.

## What's in this PR

Single file added: `.github/workflows/flaky-failure-watcher.yml`.

### Monitored workflows

`workflow_run` doesn't support name globs, so the watcher lists xmtpd's main-touching workflows explicitly. An inline comment reminds contributors to update the list when adding a new workflow that runs on `main`:

| Workflow `name:` | Source file | Trigger |
| --- | --- | --- |
| `Build xmtpd image` | `build-xmtpd.yml` | push `main` / `rel/**` / tags |
| `Upgrade Tests` | `integration-test.yml` | push `main` / `rel/**` |
| `Lint` | `lint-go.yml` | push `main` |
| `Lint Shellcheck` | `lint-shellcheck.yml` | push `main` |
| `Publish Gateway npm Package` | `publish-gateway-npm.yml` | push `main` / tags |
| `Test` | `test.yml` | push `main` / `rel/**` |
| `Nightly Automation` | `nightly.yml` | schedule |

The two iteration-bulk-move workflows and `Deploy to testnet-dev` are intentionally **not** monitored — they are administrative/manual, not CI.

### Preserved from libxmtp

Kept verbatim from the libxmtp version so future improvements there port mechanically:

- `anthropics/claude-code-action@v1.0.92` with `--model sonnet`.
- Minimal permissions (`contents: read`, `issues: write`, `actions: read`, `id-token: write`).
- Restricted allowed `Bash` invocations (`gh run view/list/create/comment/view`).
- Concurrency group keyed on `workflow_run.id`, `cancel-in-progress: false`, so overlapping failures are investigated independently.
- Investigation prompt, issue template, and recurrence-comment template.

### Adapted for xmtpd

- Monitored workflow list (above).
- "Reported by" link now points to the xmtpd copy of the file.
- The `flaky` label already exists in xmtpd, no new label needed.

## Notes

- Requires `ANTHROPIC_API_KEY` to be configured as a repo secret (same as libxmtp).
- Cannot be fully exercised until merged and a `main` workflow actually fails. Recommended post-merge smoke test: a maintainer may temporarily introduce a failing step on `main` in a throwaway workflow to confirm the watcher files an issue; revert immediately.

## Test plan

- [ ] `actionlint` passes on the new workflow file (reviewer to run if they have it locally)
- [ ] Each monitored `name:` matches exactly the `name:` field in the corresponding workflow file (verified during development)
- [ ] `ANTHROPIC_API_KEY` secret is available in the xmtpd repo settings before merging
- [ ] Post-merge smoke test: trigger a synthetic failure on `main` and confirm an issue is filed with the `flaky` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add flaky test watcher workflow that auto-files GitHub issues on CI failures
> - Adds [flaky-failure-watcher.yml](.github/workflows/flaky-failure-watcher.yml), a GitHub Actions workflow that triggers on completed `Test` workflow runs on `main` that end in failure.
> - The job uses `anthropics/claude-code-action@v1.0.92` to fetch failed run logs via `gh` CLI, analyze them, and either open a new issue labeled `flaky` or comment on an existing matching issue, skipping duplicates with no new information.
> - Concurrency is scoped per `workflow_run.id` to avoid parallel duplicate investigations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7238112.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->