### PR TITLE
feat: add optional node JWT auth enforcement for ReplicationApi

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -9,10 +9,11 @@ import (
 
 type APIOptions struct {
 	Enable                      bool          `long:"enable"                         env:"XMTPD_API_ENABLE"                         description:"Enable the client API"`
-	SendKeepAliveInterval       time.Duration `long:"send-keep-alive-interval"       env:"XMTPD_API_SEND_KEEP_ALIVE_INTERVAL"       description:"Send empty application level keepalive package interval" default:"30s"`
-	Port                        int           `long:"port"                           env:"XMTPD_API_PORT"                           description:"Port to listen on"                                       default:"5050" short:"p"`
-	OriginatorCacheTTL          time.Duration `long:"originator-cache-ttl"           env:"XMTPD_API_ORIGINATOR_CACHE_TTL"           description:"TTL for originator list cache"                           default:"5m"`
+	SendKeepAliveInterval       time.Duration `long:"send-keep-alive-interval"       env:"XMTPD_API_SEND_KEEP_ALIVE_INTERVAL"       description:"Send empty application level keepalive package interval"        default:"30s"`
+	Port                        int           `long:"port"                           env:"XMTPD_API_PORT"                           description:"Port to listen on"                                              default:"5050" short:"p"`
+	OriginatorCacheTTL          time.Duration `long:"originator-cache-ttl"           env:"XMTPD_API_ORIGINATOR_CACHE_TTL"           description:"TTL for originator list cache"                                  default:"5m"`
 	RequirePayerPositiveBalance bool          `long:"require-payer-positive-balance" env:"XMTPD_API_REQUIRE_PAYER_POSITIVE_BALANCE" description:"Reject publishes when payer balance is insufficient"`
+	RequireReplicationNodeAuth  bool          `long:"require-replication-node-auth"  env:"XMTPD_API_REQUIRE_REPLICATION_NODE_AUTH"  description:"Require node JWT authentication for all ReplicationApi methods"`
 }
 
 type ContractsOptions struct {

--- a/pkg/interceptors/server/require_node_auth.go
+++ b/pkg/interceptors/server/require_node_auth.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	"go.uber.org/zap"
+
+	"github.com/xmtp/xmtpd/pkg/constants"
+)
+
+// RequireNodeAuthInterceptor rejects requests that do not carry a verified
+// node JWT. It is intended to be wrapped around ReplicationApi only, gating
+// all methods behind Tier 0 authentication.
+//
+// The upstream ServerAuthInterceptor sets VerifiedNodeRequestCtxKey when a
+// valid node JWT is present. This interceptor checks that key and returns
+// Unauthenticated if it is missing or false.
+type RequireNodeAuthInterceptor struct {
+	logger *zap.Logger
+}
+
+var _ connect.Interceptor = (*RequireNodeAuthInterceptor)(nil)
+
+func NewRequireNodeAuthInterceptor(logger *zap.Logger) *RequireNodeAuthInterceptor {
+	return &RequireNodeAuthInterceptor{
+		logger: logger.Named("require-node-auth"),
+	}
+}
+
+func (i *RequireNodeAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if !isVerifiedNode(ctx) {
+			i.logger.Warn(
+				"unauthenticated replication request rejected",
+				zap.String("procedure", req.Spec().Procedure),
+			)
+			return nil, connect.NewError(
+				connect.CodeUnauthenticated,
+				errors.New("node authentication required"),
+			)
+		}
+		return next(ctx, req)
+	}
+}
+
+func (i *RequireNodeAuthInterceptor) WrapStreamingClient(
+	next connect.StreamingClientFunc,
+) connect.StreamingClientFunc {
+	return next
+}
+
+func (i *RequireNodeAuthInterceptor) WrapStreamingHandler(
+	next connect.StreamingHandlerFunc,
+) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		if !isVerifiedNode(ctx) {
+			i.logger.Warn(
+				"unauthenticated replication stream rejected",
+				zap.String("procedure", conn.Spec().Procedure),
+			)
+			return connect.NewError(
+				connect.CodeUnauthenticated,
+				errors.New("node authentication required"),
+			)
+		}
+		return next(ctx, conn)
+	}
+}
+
+func isVerifiedNode(ctx context.Context) bool {
+	v, ok := ctx.Value(constants.VerifiedNodeRequestCtxKey{}).(bool)
+	return ok && v
+}

--- a/pkg/interceptors/server/require_node_auth_test.go
+++ b/pkg/interceptors/server/require_node_auth_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xmtp/xmtpd/pkg/constants"
+	"go.uber.org/zap/zaptest"
+)
+
+func newRequireNodeAuthInterceptor(t *testing.T) *RequireNodeAuthInterceptor {
+	t.Helper()
+	return NewRequireNodeAuthInterceptor(zaptest.NewLogger(t))
+}
+
+func ctxWithVerifiedNode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, constants.VerifiedNodeRequestCtxKey{}, true)
+}
+
+func TestRequireNodeAuth_Unary_Authenticated(t *testing.T) {
+	interceptor := newRequireNodeAuthInterceptor(t)
+
+	called := false
+	wrapped := interceptor.WrapUnary(
+		func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			called = true
+			return nil, nil
+		},
+	)
+
+	ctx := ctxWithVerifiedNode(t.Context())
+	req := &mockConnectRequest{
+		header: http.Header{},
+		spec: connect.Spec{
+			Procedure: "/xmtp.xmtpv4.message_api.ReplicationApi/SubscribeOriginators",
+		},
+	}
+
+	_, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestRequireNodeAuth_Unary_Unauthenticated(t *testing.T) {
+	interceptor := newRequireNodeAuthInterceptor(t)
+
+	called := false
+	wrapped := interceptor.WrapUnary(
+		func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			called = true
+			return nil, nil
+		},
+	)
+
+	req := &mockConnectRequest{
+		header: http.Header{},
+		spec:   connect.Spec{Procedure: "/xmtp.xmtpv4.message_api.ReplicationApi/QueryEnvelopes"},
+	}
+
+	_, err := wrapped(t.Context(), req)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.False(t, called)
+}
+
+func TestRequireNodeAuth_Stream_Authenticated(t *testing.T) {
+	interceptor := newRequireNodeAuthInterceptor(t)
+
+	called := false
+	wrapped := interceptor.WrapStreamingHandler(
+		func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+			called = true
+			return nil
+		},
+	)
+
+	ctx := ctxWithVerifiedNode(t.Context())
+	conn := &mockStreamingConn{
+		header: http.Header{},
+		spec: connect.Spec{
+			Procedure: "/xmtp.xmtpv4.message_api.ReplicationApi/SubscribeEnvelopes",
+		},
+	}
+
+	err := wrapped(ctx, conn)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestRequireNodeAuth_Stream_Unauthenticated(t *testing.T) {
+	interceptor := newRequireNodeAuthInterceptor(t)
+
+	called := false
+	wrapped := interceptor.WrapStreamingHandler(
+		func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+			called = true
+			return nil
+		},
+	)
+
+	conn := &mockStreamingConn{
+		header: http.Header{},
+		spec: connect.Spec{
+			Procedure: "/xmtp.xmtpv4.message_api.ReplicationApi/SubscribeOriginators",
+		},
+	}
+
+	err := wrapped(t.Context(), conn)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.False(t, called)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -575,8 +575,19 @@ func startAPIServer(
 			}
 		}
 
+		replicationHandlerOpts := handlerOpts
+		if cfg.Options.API.RequireReplicationNodeAuth {
+			requireAuthInterceptor := server.NewRequireNodeAuthInterceptor(cfg.Logger)
+			replicationHandlerOpts = []connect.HandlerOption{
+				connect.WithReadMaxBytes(constants.GRPCPayloadLimit),
+				connect.WithSendMaxBytes(constants.GRPCPayloadLimit),
+				connect.WithInterceptors(
+					append(slices.Clone(interceptors), requireAuthInterceptor)...),
+			}
+		}
+
 		replicationPath, replicationHandler := message_apiconnect.NewReplicationApiHandler(
-			replicationService, handlerOpts...,
+			replicationService, replicationHandlerOpts...,
 		)
 		queryPath, queryHandler := message_apiconnect.NewQueryApiHandler(
 			replicationService, queryHandlerOpts...,


### PR DESCRIPTION
## Summary

- Adds `RequireNodeAuthInterceptor` that rejects ReplicationApi requests without a verified node JWT (`CodeUnauthenticated`)
- Gated behind `XMTPD_API_REQUIRE_REPLICATION_NODE_AUTH` env var (defaults to `false` — no behavior change until opted in)
- Follows the same pattern as `RequirePayerPositiveBalance` for config and the rate-limit/stream-limit interceptors for wiring

Part of xmtp/proto#327 Phase 2 — enforcing that all ReplicationApi requests carry an auth token.

Closes #366 (partially — ReplicationApi auth enforcement)

## Test plan

- [x] Unit tests for unary + streaming, authenticated + unauthenticated paths
- [x] All existing interceptor tests pass
- [x] Lint passes
- [ ] Staging: enable `XMTPD_API_REQUIRE_REPLICATION_NODE_AUTH=true` and verify node-to-node sync works, unauthenticated ReplicationApi calls rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional JWT auth enforcement interceptor for `ReplicationApi`
> - Adds `RequireNodeAuthInterceptor` in [`pkg/interceptors/server/require_node_auth.go`](https://github.com/xmtp/xmtpd/pull/1971/files#diff-0a2570c3583429673836ee30ddc9ffb7c6a3c5e1a6381ed40c92151dbc0344ba) that rejects unary and server-streaming RPCs with `CodeUnauthenticated` when the request context lacks a verified node flag.
> - Adds a `--require-replication-node-auth` flag (`XMTPD_API_REQUIRE_REPLICATION_NODE_AUTH` env var) to `APIOptions`; defaults to `false`.
> - When the flag is enabled, [`pkg/server/server.go`](https://github.com/xmtp/xmtpd/pull/1971/files#diff-104a11712684e520f0affa95e6a053faeb713306a10f69ee99b9729cc9dd1996) appends the new interceptor to the `ReplicationApi` handler options only, leaving other handlers unaffected.
> - Behavioral Change: enabling the flag causes all `ReplicationApi` RPCs to fail with `Unauthenticated` for any caller without a verified node context value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d8bfc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->