### PR TITLE
Stable hashing return first node >= topicHash

### DIFF
--- a/pkg/api/payer/selectors/stable.go
+++ b/pkg/api/payer/selectors/stable.go
@@ -67,7 +67,7 @@ func (s *StableHashingNodeSelectorAlgorithm) GetNode(
 
 	// Binary search to find the first node with a virtual position >= topicHash
 	idx := sort.Search(len(nodeLocations), func(i int) bool {
-		return topicHash < nodeLocations[i]
+		return topicHash >= nodeLocations[i]
 	})
 
 	// Flatten banlist


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix binary search predicate in `StableHashingNodeSelectorAlgorithm.GetNode` to return first node >= topicHash
Fixes an inverted predicate in the binary search in [stable.go](https://github.com/xmtp/xmtpd/pull/1972/files#diff-f990a0220de02181148faed747c79db973555c8995276f417b3592cd66d3524b). The condition was changed from `topicHash < nodeLocations[i]` to `topicHash >= nodeLocations[i]`, so the algorithm now correctly selects the first node whose virtual position is greater than or equal to the topicHash. Risk: this changes which node is selected for every topic and banlist combination, affecting routing in production.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d02f8ee. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->