### PR TITLE
test: stabilize TestCreateServer by aligning replication timeouts

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -202,7 +202,7 @@ func TestCreateServer(t *testing.T) {
 			}
 		}
 		return false
-	}, 10*time.Second, 200*time.Millisecond)
+	}, 20*time.Second, 500*time.Millisecond)
 }
 
 func TestReadOwnWritesGuarantee(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1970

## Summary

`TestCreateServer` in `pkg/server/server_test.go` is flaky in CI. The failure reported in #1970 was a timeout at line 185 waiting for a published envelope to replicate from server1 → server2.

The test contains two structurally identical `require.Eventually` blocks that wait for cross-node replication of a single envelope:

- Line 163 (reverse direction, server2 → server1): **20s** timeout / **500ms** poll
- Line 185 (forward direction, server1 → server2): **10s** timeout / **200ms** poll — the one that fails

The asymmetry is almost certainly an oversight — both checks do the same work and need the same budget. Under CI load the 10s window for the forward check is too tight, while the 20s reverse check is observed to pass even when the forward check fails first.

## Change

Unify both `require.Eventually` blocks on **20s / 500ms**. One-line change in `pkg/server/server_test.go`.

No production code touched; no change to the fast-path behavior (successful replication returns on the first poll in the normal case).

## Verification

- `go build ./pkg/server/...` — clean
- `go vet ./pkg/server/...` — clean
- `dev/lint-fix` — 0 issues
- `go test -run '^TestCreateServer$' -count=5 ./pkg/server/` — passes

## Test plan

- [x] Test package builds
- [x] Lint passes
- [x] `TestCreateServer` passes locally (multiple runs)
- [ ] CI confirms the test is no longer flaky after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize `TestCreateServer` by increasing replication wait timeout to 20s
> Increases the `Eventually` assertion timeout from 10s to 20s and the polling interval from 200ms to 500ms in [server_test.go](https://github.com/xmtp/xmtpd/pull/1975/files#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4e) to reduce flakiness caused by replication timing variability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a218af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->