### PR TITLE
fix: accept unknown originators in SubscribeTopics cursor

### DIFF
--- a/pkg/api/message/subscribe_topics.go
+++ b/pkg/api/message/subscribe_topics.go
@@ -68,16 +68,16 @@ func (s *Service) SubscribeTopics(
 		)
 	}
 
+	if err := validateTopicFilters(filters); err != nil {
+		return err
+	}
+
 	knownOriginators, err := s.originatorList.GetOriginatorNodeIDs(ctx)
 	if err != nil {
 		return connect.NewError(
 			connect.CodeInternal,
 			fmt.Errorf("could not get originator list: %w", err),
 		)
-	}
-
-	if err := validateTopicFilters(filters, knownOriginators); err != nil {
-		return err
 	}
 
 	cursors, topics, topicKeys := buildTopicCursors(filters, knownOriginators)
@@ -146,9 +146,13 @@ func (s *Service) SubscribeTopics(
 }
 
 // validateTopicFilters validates the topic filters in a SubscribeTopicsRequest.
+// Cursor entries for originators the node has not yet seen are allowed: a
+// client may learn of a new originator before this node has indexed any of
+// its messages, or may still hold cursors for originators removed long ago.
+// Unknown originators are harmless in the downstream LATERAL query — they
+// simply match no rows.
 func validateTopicFilters(
 	filters []*message_api.SubscribeTopicsRequest_TopicFilter,
-	knownOriginators []uint32,
 ) error {
 	if len(filters) == 0 {
 		return connect.NewError(
@@ -164,23 +168,9 @@ func validateTopicFilters(
 		)
 	}
 
-	known := make(map[uint32]struct{}, len(knownOriginators))
-	for _, id := range knownOriginators {
-		known[id] = struct{}{}
-	}
-
 	for _, f := range filters {
 		if err := validateTopicFilter(f); err != nil {
 			return connect.NewError(connect.CodeInvalidArgument, err)
-		}
-
-		for origID := range f.GetLastSeen().GetNodeIdToSequenceId() {
-			if _, ok := known[origID]; !ok {
-				return connect.NewError(
-					connect.CodeInvalidArgument,
-					fmt.Errorf("unknown originator node ID in cursor: %d", origID),
-				)
-			}
 		}
 	}
 

--- a/pkg/api/message/subscribe_topics_test.go
+++ b/pkg/api/message/subscribe_topics_test.go
@@ -189,7 +189,7 @@ func TestSubscribeTopics_Validation(t *testing.T) {
 	}
 }
 
-func TestSubscribeTopics_UnknownOriginatorInCursor(t *testing.T) {
+func TestSubscribeTopics_AcceptsUnknownOriginatorInCursor(t *testing.T) {
 	client, store, _ := setupTopicTest(t)
 	payerID := db.NullInt32(testutils.CreatePayer(t, store))
 
@@ -197,17 +197,87 @@ func TestSubscribeTopics_UnknownOriginatorInCursor(t *testing.T) {
 		makeEnvRow(t, 100, 1, topicA, payerID),
 	})
 
-	// Reference originator 999 which is not known.
-	stream, err := client.SubscribeTopics(
+	// Cursor references originator 999, which the node has never seen.
+	// The subscription should open normally; FillMissingOriginators seeds
+	// known originator 100 at sequence 0, so catch-up still delivers its
+	// envelope. The unknown originator is a no-op in the LATERAL query.
+	stream := subscribeTopics(
+		t,
+		client,
 		t.Context(),
-		connect.NewRequest(&message_api.SubscribeTopicsRequest{
-			Filters: []*message_api.SubscribeTopicsRequest_TopicFilter{
-				makeFilter(topicA, map[uint32]uint64{999: 0}),
-			},
-		}),
+		[]*message_api.SubscribeTopicsRequest_TopicFilter{
+			makeFilter(topicA, map[uint32]uint64{999: 0}),
+		},
 	)
-	require.NoError(t, err)
-	requireTopicStreamError(t, stream, connect.CodeInvalidArgument)
+
+	envs := collectTopicEnvelopes(t, stream, 1)
+	require.Len(t, envs, 1)
+	decoded := envelopeTestUtils.UnmarshalUnsignedOriginatorEnvelope(
+		t, envs[0].GetUnsignedOriginatorEnvelope(),
+	)
+	require.EqualValues(t, 100, decoded.GetOriginatorNodeId())
+	require.EqualValues(t, 1, decoded.GetOriginatorSequenceId())
+}
+
+func TestSubscribeTopics_MixedKnownAndUnknownOriginators(t *testing.T) {
+	client, store, _ := setupTopicTest(t)
+	payerID := db.NullInt32(testutils.CreatePayer(t, store))
+
+	insertAndWait(t, store, []queries.InsertGatewayEnvelopeV3Params{
+		makeEnvRow(t, 100, 1, topicA, payerID),
+		makeEnvRow(t, 100, 2, topicA, payerID),
+		makeEnvRow(t, 200, 1, topicA, payerID),
+	})
+
+	// Cursor: known originator 100 caught up past seq 1, plus an unknown
+	// originator 999. Expect (100, 2) and (200, 1); (100, 1) is skipped
+	// and the 999 entry contributes nothing.
+	stream := subscribeTopics(
+		t,
+		client,
+		t.Context(),
+		[]*message_api.SubscribeTopicsRequest_TopicFilter{
+			makeFilter(topicA, map[uint32]uint64{100: 1, 999: 0}),
+		},
+	)
+
+	envs := collectTopicEnvelopes(t, stream, 2)
+	require.Len(t, envs, 2)
+
+	seen := make(map[uint32]uint64)
+	for _, env := range envs {
+		decoded := envelopeTestUtils.UnmarshalUnsignedOriginatorEnvelope(
+			t, env.GetUnsignedOriginatorEnvelope(),
+		)
+		seen[decoded.GetOriginatorNodeId()] = decoded.GetOriginatorSequenceId()
+	}
+	require.Equal(t, uint64(2), seen[100])
+	require.Equal(t, uint64(1), seen[200])
+}
+
+func TestSubscribeTopics_AllUnknownOriginatorsInCursor(t *testing.T) {
+	client, store, _ := setupTopicTest(t)
+	payerID := db.NullInt32(testutils.CreatePayer(t, store))
+
+	insertAndWait(t, store, []queries.InsertGatewayEnvelopeV3Params{
+		makeEnvRow(t, 100, 1, topicA, payerID),
+		makeEnvRow(t, 200, 1, topicA, payerID),
+	})
+
+	// Cursor references only originators the node has never seen. Both
+	// known originators are absent from the cursor, so FillMissingOriginators
+	// seeds them at 0 and catch-up delivers everything.
+	stream := subscribeTopics(
+		t,
+		client,
+		t.Context(),
+		[]*message_api.SubscribeTopicsRequest_TopicFilter{
+			makeFilter(topicA, map[uint32]uint64{888: 5, 999: 10}),
+		},
+	)
+
+	envs := collectTopicEnvelopes(t, stream, 2)
+	require.Len(t, envs, 2)
 }
 
 // ---- Live-Only Tests (nil LastSeen) ----


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtpd/issues/1982

## Summary

`SubscribeTopics` rejected requests with `CodeInvalidArgument` whenever a
client's per-topic cursor referenced an originator the node had not yet
indexed (i.e. absent from `gateway_envelopes_latest`). This breaks
legitimate flows:

- `libxmtp` sends cursors containing migrator originator IDs (10, 11) even
  in environments where no migrator has been configured.
- A client may learn of a new originator before a given node has indexed
  any of its messages (new nodes, network partitions).
- A client may still hold a cursor for an originator that was removed long
  ago and has no messages on any currently-live node.

The originator set is node-local and lossy — treating a mismatch as a fatal
client error is the wrong default.

## Change

- Remove the unknown-originator rejection loop in `validateTopicFilters`.
  All other validation (filter count, topic length, vector clock length)
  stays in place.
- `buildTopicCursors` already tolerated unknown originators: the client's
  entries pass through unchanged, and `FillMissingOriginators` still seeds
  known originators at sequence 0. The downstream
  `SelectGatewayEnvelopesByPerTopicCursors` is a `CROSS JOIN LATERAL` on
  the client's `(topic, node_id, seq_id)` tuples — entries that don't
  match any row contribute nothing.
- `advanceTopicCursors` already handles previously-unknown originators
  starting to publish live, so that path needed no change.

## Test plan

- [x] Replaced `TestSubscribeTopics_UnknownOriginatorInCursor` (previously
      asserted rejection) with `TestSubscribeTopics_AcceptsUnknownOriginatorInCursor`,
      which asserts the subscription opens and delivers envelopes from
      known originators.
- [x] Added `TestSubscribeTopics_MixedKnownAndUnknownOriginators`: cursor
      mixes a partially caught-up known originator with an unknown one;
      catch-up delivers only the unseen messages for the known originator.
- [x] Added `TestSubscribeTopics_AllUnknownOriginatorsInCursor`: all cursor
      entries are unknown; catch-up still delivers messages from known
      originators via `FillMissingOriginators`.
- [x] `TestSubscribeTopics_Validation` unchanged — other validation errors
      still return `CodeInvalidArgument`.
- [x] `go test ./pkg/api/message/... -count=1`
- [x] `dev/lint-fix`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept unknown originator IDs in `SubscribeTopics` cursor without error
> Previously, `validateTopicFilters` rejected cursors containing originator IDs not known to the node. This removes that check, since unknown originators simply match no rows downstream and should not block subscription processing.
>
> - Removes the `knownOriginators` parameter from [`validateTopicFilters`](https://github.com/xmtp/xmtpd/pull/1983/files#diff-ac39f1802be2ab7789d5ffc0d2344a0d6f82d8b6a85fde0dc434a0069097bcff), dropping the loop that rejected unknown originator IDs in `LastSeen` cursors.
> - Moves `validateTopicFilters` to run before the known-originator lookup, simplifying the handler flow.
> - Behavioral Change: cursors with unknown originator IDs are now accepted; catch-up queries for those originators return no results rather than an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 426f102.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->