### PR TITLE
ci: build xmtpd-network-watcher image

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -18,7 +18,7 @@ jobs:
   push_to_registry:
     strategy:
       matrix:
-        image: ["xmtpd", "xmtpd-cli", "xmtpd-prune", "xmtpd-gateway", "xmtpd-e2e", "xmtpd-chain-watcher"]
+        image: ["xmtpd", "xmtpd-cli", "xmtpd-prune", "xmtpd-gateway", "xmtpd-e2e", "xmtpd-chain-watcher", "xmtpd-network-watcher"]
     name: Push Docker Images to GitHub Packages
     runs-on: ubuntu-latest
     permissions:
@@ -65,6 +65,8 @@ jobs:
           echo "dockerfile=e2e.Dockerfile" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.image }}" == "xmtpd-chain-watcher" ]]; then
           echo "dockerfile=chain-watcher.Dockerfile" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.image }}" == "xmtpd-network-watcher" ]]; then
+          echo "dockerfile=network-watcher.Dockerfile" >> $GITHUB_OUTPUT
           else
           echo "Unknown image: ${{ matrix.image }}"
           exit 1
@@ -100,6 +102,7 @@ jobs:
       prune_image: ${{ steps.digests.outputs.prune_image }}
       gateway_image: ${{ steps.digests.outputs.gateway_image }}
       chain_watcher_image: ${{ steps.digests.outputs.chain_watcher_image }}
+      network_watcher_image: ${{ steps.digests.outputs.network_watcher_image }}
     steps:
       - name: Download xmtpd digest
         uses: actions/download-artifact@v4
@@ -131,6 +134,12 @@ jobs:
           name: xmtpd-chain-watcher-digest
           path: digests
 
+      - name: Download network-watcher digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-network-watcher-digest
+          path: digests
+
       - name: Read and export digests
         id: digests
         run: |
@@ -141,16 +150,18 @@ jobs:
           PRUNE_DIGEST=$(cut -d= -f2 digests/xmtpd-prune.txt)
           GATEWAY_DIGEST=$(cut -d= -f2 digests/xmtpd-gateway.txt)
           CHAIN_WATCHER_DIGEST=$(cut -d= -f2 digests/xmtpd-chain-watcher.txt)
+          NETWORK_WATCHER_DIGEST=$(cut -d= -f2 digests/xmtpd-network-watcher.txt)
 
-          if [[ -z "$XMTPD_DIGEST" || -z "$CLI_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" || -z "$CHAIN_WATCHER_DIGEST" ]]; then
+          if [[ -z "$XMTPD_DIGEST" || -z "$CLI_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" || -z "$CHAIN_WATCHER_DIGEST" || -z "$NETWORK_WATCHER_DIGEST" ]]; then
             echo "✖️  One or more digests are empty – aborting deploy." >&2
             exit 1
           fi
 
-          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"                               >> $GITHUB_OUTPUT
-          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"                         >> $GITHUB_OUTPUT
-          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"                   >> $GITHUB_OUTPUT
-          echo "chain_watcher_image=ghcr.io/xmtp/xmtpd-chain-watcher@$CHAIN_WATCHER_DIGEST" >> $GITHUB_OUTPUT
+          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"                                   >> $GITHUB_OUTPUT
+          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"                             >> $GITHUB_OUTPUT
+          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"                       >> $GITHUB_OUTPUT
+          echo "chain_watcher_image=ghcr.io/xmtp/xmtpd-chain-watcher@$CHAIN_WATCHER_DIGEST"     >> $GITHUB_OUTPUT
+          echo "network_watcher_image=ghcr.io/xmtp/xmtpd-network-watcher@$NETWORK_WATCHER_DIGEST" >> $GITHUB_OUTPUT
 
   deploy_testnet_staging:
     name: Deploy to testnet-staging

--- a/.github/workflows/deploy-testnet-dev.yml
+++ b/.github/workflows/deploy-testnet-dev.yml
@@ -47,6 +47,7 @@ jobs:
       prune_image: ${{ steps.digests.outputs.prune_image }}
       gateway_image: ${{ steps.digests.outputs.gateway_image }}
       chain_watcher_image: ${{ steps.digests.outputs.chain_watcher_image }}
+      network_watcher_image: ${{ steps.digests.outputs.network_watcher_image }}
     steps:
       - name: Download xmtpd digest
         uses: actions/download-artifact@v4
@@ -80,6 +81,14 @@ jobs:
           run-id: ${{ needs.resolve_run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download xmtpd-network-watcher digest
+        uses: actions/download-artifact@v4
+        with:
+          name: xmtpd-network-watcher-digest
+          path: digests
+          run-id: ${{ needs.resolve_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Read and export digests
         id: digests
         run: |
@@ -89,16 +98,18 @@ jobs:
           PRUNE_DIGEST=$(cut -d= -f2 digests/xmtpd-prune.txt)
           GATEWAY_DIGEST=$(cut -d= -f2 digests/xmtpd-gateway.txt)
           CHAIN_WATCHER_DIGEST=$(cut -d= -f2 digests/xmtpd-chain-watcher.txt)
+          NETWORK_WATCHER_DIGEST=$(cut -d= -f2 digests/xmtpd-network-watcher.txt)
 
-          if [[ -z "$XMTPD_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" || -z "$CHAIN_WATCHER_DIGEST" ]]; then
+          if [[ -z "$XMTPD_DIGEST" || -z "$PRUNE_DIGEST" || -z "$GATEWAY_DIGEST" || -z "$CHAIN_WATCHER_DIGEST" || -z "$NETWORK_WATCHER_DIGEST" ]]; then
             echo "✖️  One or more digests are empty – aborting deploy." >&2
             exit 1
           fi
 
-          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"                               >> $GITHUB_OUTPUT
-          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"                         >> $GITHUB_OUTPUT
-          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"                   >> $GITHUB_OUTPUT
-          echo "chain_watcher_image=ghcr.io/xmtp/xmtpd-chain-watcher@$CHAIN_WATCHER_DIGEST" >> $GITHUB_OUTPUT
+          echo "xmtpd_image=ghcr.io/xmtp/xmtpd@$XMTPD_DIGEST"                                   >> $GITHUB_OUTPUT
+          echo "prune_image=ghcr.io/xmtp/xmtpd-prune@$PRUNE_DIGEST"                             >> $GITHUB_OUTPUT
+          echo "gateway_image=ghcr.io/xmtp/xmtpd-gateway@$GATEWAY_DIGEST"                       >> $GITHUB_OUTPUT
+          echo "chain_watcher_image=ghcr.io/xmtp/xmtpd-chain-watcher@$CHAIN_WATCHER_DIGEST"     >> $GITHUB_OUTPUT
+          echo "network_watcher_image=ghcr.io/xmtp/xmtpd-network-watcher@$NETWORK_WATCHER_DIGEST" >> $GITHUB_OUTPUT
 
   deploy_testnet_dev:
     name: Deploy to testnet-dev
@@ -115,6 +126,6 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: testnet-dev
-          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image"
-          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }}"
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image,network_watcher_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }},${{ needs.prepare.outputs.network_watcher_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"


### PR DESCRIPTION
## Summary

Extends `build-xmtpd.yml` to build and publish the `xmtpd-network-watcher` container to ghcr.io.

- Adds `xmtpd-network-watcher` to the image matrix → built on every PR + push to main.
- Maps it to `dev/docker/network-watcher.Dockerfile`.
- Adds the digest to the `prepare` aggregator output so downstream deploy can consume it.

## Deploy wiring (out of scope here)

The `deploy_testnet_staging` and `deploy_testnet` jobs are intentionally left untouched. Adding `network_watcher_image` to their terraform-deployer variable list requires a matching variable + module definition in the terraform-deployer workspace, which lives in a separate repo. Follow-up: add a `network_watcher` module alongside `chain_watcher` in infra.

## Test plan

- [ ] CI runs the new matrix entry successfully on this PR.
- [ ] `ghcr.io/xmtp/xmtpd-network-watcher:pr-<N>` tag is pushed.
- [ ] Follow-up infra PR wires it into Terraform and the deploy jobs can append `network_watcher_image` to the variable list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build and deploy `xmtpd-network-watcher` image in CI and testnet-dev pipeline
> - Adds `xmtpd-network-watcher` to the build matrix in [build-xmtpd.yml](https://github.com/xmtp/xmtpd/pull/1984/files#diff-95afafe5dd4596d8cf6cb230db5ceef06301977a83094317aa0f85dcbd6a77d9), including Dockerfile selection, digest artifact upload, and a `network_watcher_image` output in the prepare job.
> - Updates [deploy-testnet-dev.yml](https://github.com/xmtp/xmtpd/pull/1984/files#diff-551a7cec5eda0dc75a35bfe8541588a2bf3d101f2017576912826e170398c661) to download the network-watcher digest artifact and pass the resolved image as the `network_watcher_image` Terraform variable.
> - Risk: both workflows now fail if the `xmtpd-network-watcher` digest artifact is missing or empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f898a65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->