### PR TITLE
ci: deploy xmtpd-network-watcher to testnet and testnet-staging

### DIFF
--- a/.github/workflows/build-xmtpd.yml
+++ b/.github/workflows/build-xmtpd.yml
@@ -178,8 +178,8 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: testnet-staging
-          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image"
-          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }}"
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image,network_watcher_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }},${{ needs.prepare.outputs.network_watcher_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"
 
   deploy_testnet:
@@ -197,6 +197,6 @@ jobs:
           terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
           terraform-org: xmtp
           terraform-workspace: testnet
-          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image"
-          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }}"
+          variable-name: "xmtpd_server_docker_image,xmtpd_prune_docker_image,xmtpd_gateway_docker_image,xmtpd_migrator_docker_image,chain_watcher_image,network_watcher_image"
+          variable-value: "${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.prune_image }},${{ needs.prepare.outputs.gateway_image }},${{ needs.prepare.outputs.xmtpd_image }},${{ needs.prepare.outputs.chain_watcher_image }},${{ needs.prepare.outputs.network_watcher_image }}"
           variable-value-required-prefix: "ghcr.io/xmtp/"


### PR DESCRIPTION
## Summary
- Pass the existing `network_watcher_image` prepare output to the terraform-deployer for both `testnet-staging` and `testnet` deploy jobs
- Completes wiring started in #1984 (build) and #1979 (feature), which added the image but not the deploy step

## Test plan
- [ ] CI builds and pushes `xmtpd-network-watcher` image
- [ ] Terraform workspace receives the new `network_watcher_image` variable on deploy to testnet-staging
- [ ] Terraform workspace receives the new `network_watcher_image` variable on deploy to testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deploy `xmtpd-network-watcher` to testnet and testnet-staging
> Passes the `network_watcher_image` variable to the Terraform deployer in both the testnet-staging and testnet deploy steps in [build-xmtpd.yml](.github/workflows/build-xmtpd.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b306c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->