### PR TITLE
Remove dead environments

### DIFF
--- a/pkg/config/environments/environments.go
+++ b/pkg/config/environments/environments.go
@@ -8,35 +8,19 @@ import (
 //go:embed anvil.json
 var envAnvil []byte
 
-//go:embed mainnet.json
-var envMainnet []byte
-
 //go:embed testnet.json
 var envTestnet []byte
-
-//go:embed testnet-staging.json
-var envTestnetStaging []byte
-
-//go:embed testnet-dev.json
-var envTestnetDev []byte
 
 type SmartContractEnvironment string
 
 const (
-	Anvil          SmartContractEnvironment = "anvil"
-	Mainnet        SmartContractEnvironment = "mainnet"
-	Testnet        SmartContractEnvironment = "testnet"
-	TestnetStaging SmartContractEnvironment = "testnet-staging"
-	TestnetDev     SmartContractEnvironment = "testnet-dev"
+	Anvil   SmartContractEnvironment = "anvil"
+	Testnet SmartContractEnvironment = "testnet"
 )
 
 func (s *SmartContractEnvironment) UnmarshalFlag(value string) error {
 	switch value {
-	case string(Anvil),
-		string(Mainnet),
-		string(Testnet),
-		string(TestnetStaging),
-		string(TestnetDev):
+	case string(Anvil), string(Testnet):
 		*s = SmartContractEnvironment(value)
 		return nil
 	default:
@@ -49,14 +33,8 @@ func GetEnvironmentConfig(env SmartContractEnvironment) ([]byte, error) {
 	switch env {
 	case Anvil:
 		return envAnvil, nil
-	case Mainnet:
-		return envMainnet, nil
 	case Testnet:
 		return envTestnet, nil
-	case TestnetStaging:
-		return envTestnetStaging, nil
-	case TestnetDev:
-		return envTestnetDev, nil
 	default:
 		return nil, fmt.Errorf("unknown environment: %s", env)
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove dead environments from the environments package
- Removes embedded JSON configs and `SmartContractEnvironment` constants for `mainnet`, `testnet-staging`, and `testnet-dev` in [environments.go](https://github.com/xmtp/xmtpd/pull/1995/files#diff-888aeeb0bd7bca5a6401e5b263b91e45a50100f7b6034a37e9618e33aaa3e93c).
- `GetEnvironmentConfig` now returns an error for any environment other than `anvil` or `testnet`.
- `UnmarshalFlag` rejects the removed environment names; only `anvil` and `testnet` are accepted.
- Risk: the error message in `UnmarshalFlag` still lists `mainnet` as a valid choice despite it being rejected.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0835b92.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->