### PR TITLE
fix: correct misleading comments, typos, and incomplete docs

### DIFF
--- a/pkg/api/message/funnel.go
+++ b/pkg/api/message/funnel.go
@@ -12,7 +12,7 @@ type funnel[T any] struct {
 	closed bool
 }
 
-// Funnel many input channels into a single one. Output channel is closed once all input channels are.
+// Funnel many input channels into a single one. Output channel is closed once all input channels are closed.
 // Adding channels after the output channel has been closed is invalid.
 func newFunnel[T any](ch ...<-chan T) *funnel[T] {
 	f := &funnel[T]{

--- a/pkg/blockchain/oracle/oracle.go
+++ b/pkg/blockchain/oracle/oracle.go
@@ -38,7 +38,7 @@
 // # Staleness Handling
 //
 // Gas prices are cached for 250ms. If the cached value is stale, GetGasPrice()
-// fetches a fresh value. If the fetch fails, it returns a safe default (0.1 gwei).
+// fetches a fresh value. If the fetch fails, it returns a safe default value (0.1 gwei on Arbitrum, 10 gwei on other EVM chains).
 package oracle
 
 import (
@@ -148,7 +148,7 @@ func (o *Oracle) Close() {
 // GetGasPrice returns the current gas price.
 // If the cached price is stale (older than 250ms), it fetches a fresh value.
 // Concurrent requests are coalesced to minimize RPC calls.
-// If fetching fails, returns a safe default value (0.1 gwei).
+// If fetching fails, returns a safe default value (0.1 gwei on Arbitrum, 10 gwei on other EVM chains).
 func (o *Oracle) GetGasPrice() int64 {
 	if !o.isStale() {
 		price := o.gasPrice.Load()

--- a/pkg/db/gateway_envelope.go
+++ b/pkg/db/gateway_envelope.go
@@ -139,7 +139,7 @@ func InsertGatewayEnvelopeWithChecksTransactional(
 // automatically creating missing partitions and retrying once.
 //
 // Behavior:
-//   - Performs an insert into the v2 tables.
+//   - Performs an insert into the v3 tables.
 //   - On “no partition of relation …” errors, creates the necessary partitions
 //     in the same connection, and retries the insert once.
 //

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -19,7 +19,7 @@ import (
 // - Build the logger in a way the name chain has readable and meaningful names, such as "xmtpd.api.publish-worker".
 // - Prefer circuit breaking in hot paths, such as "if logger.Core().Enabled(zap.DebugLevel) { ... }".
 // - Always circuit break when using zap.Any, as it relies on reflection.
-// - As a general thumb rule, prefer Debug on hot paths.
+// - As a general rule of thumb, prefer Debug on hot paths.
 // - For repeating fields across different log messages in the same package, use a const.
 // - For repeating fields across different packages, use a field function.
 // - For repeating errors, use a constant error message.


### PR DESCRIPTION
correct misleading comments, typos, and incomplete docs
