### PR TITLE
chore: fix function name mismatch in test comment

### DIFF
--- a/pkg/payerreport/workers/submitter_test.go
+++ b/pkg/payerreport/workers/submitter_test.go
@@ -55,7 +55,7 @@ func testSubmitterWorker(
 	return worker, store, reportsManager
 }
 
-// TestSubmitReports covers all possible valid and invalid states for the submitter worker.
+// TestSubmitterStatesAndTransitions covers all possible valid and invalid states for the submitter worker.
 //
 // Valid transitions:
 //


### PR DESCRIPTION
The doc comment referenced TestSubmitReports but the actual function name is TestSubmitterStatesAndTransitions. 

Updated the comment to match the function declaration for consistency.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix test comment function name in `submitter_test.go`
> Corrects a stale comment in [submitter_test.go](https://github.com/xmtp/xmtpd/pull/2005/files#diff-165e3a68504713325c22cd71089075b425dd7d5a43d6f54dbf97ffbab3a5d602) that referenced `TestSubmitReports` instead of the actual test function `TestSubmitterStatesAndTransitions`. No test logic or code is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3777f42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->