### PR TITLE
fix: register missing flags and add fee validation in xmtpd-cli

### DIFF
--- a/cmd/xmtpd-cli/commands/key_management.go
+++ b/cmd/xmtpd-cli/commands/key_management.go
@@ -79,6 +79,9 @@ xmtpd-cli keys get-public-key --private-key <private-key>
 `,
 	}
 
+	cmd.Flags().String("private-key", "", "Private key (hex) to derive public key from")
+	_ = viper.BindPFlag("private-key", cmd.Flags().Lookup("private-key"))
+
 	return &cmd
 }
 

--- a/cmd/xmtpd-cli/commands/rate_registry.go
+++ b/cmd/xmtpd-cli/commands/rate_registry.go
@@ -82,6 +82,10 @@ func addRatesHandler(opts AddRatesOpts) error {
 		return fmt.Errorf("could not build logger: %w", err)
 	}
 
+	if opts.MessageFee < 0 || opts.StorageFee < 0 || opts.CongestionFee < 0 {
+		return errors.New("fees cannot be negative")
+		}
+
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(15*time.Second))
 	defer cancel()
 

--- a/cmd/xmtpd-cli/commands/version.go
+++ b/cmd/xmtpd-cli/commands/version.go
@@ -33,7 +33,7 @@ func getVersionCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().
-		Var(&target, "target", "settlement-chain-gateway|payer-registry|distribution-manager")
+		Var(&target, "target", "settlement-chain-gateway|payer-registry|distribution-manager|settlement-parameter-registry|payer-report-manager|rate-registry|group|identity|app-chain-gateway|app-parameter-registry|node-registry")
 	_ = cmd.MarkFlagRequired("target")
 	return cmd
 }


### PR DESCRIPTION
Fix three bugs in xmtpd-cli command flag handling.

Changes:
key_management.go: missing `--private-key` flag registered in `getPubKeyCommand` and bound to viper so the value can be passed via CLI
rate_registry.go: added validation in `addRatesHandler` to reject negative fee values before passing to `currency.PicoDollar`
version.go: `"settlement-chain-gateway|payer-registry|distribution-manager"` → `"settlement-chain-gateway|payer-registry|distribution-manager|settlement-parameter-registry|payer-report-manager|rate-registry|group|identity|app-chain-gateway|app-parameter-registry|node-registry"`

Test plan:
- `xmtpd-cli keys get-public-key --private-key <key>` now works via CLI
- `xmtpd-cli rates add` with negative fee returns error
- `xmtpd-cli version get --help` shows all supported targets

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing `--private-key` flag registration and add negative fee validation in `xmtpd-cli`
> - Registers a `--private-key` (hex) flag on the key management command and binds it to viper, making it usable via CLI.
> - Adds validation in `addRatesHandler` to reject negative values for `MessageFee`, `StorageFee`, and `CongestionFee`, returning an error immediately.
> - Expands the `--target` flag help text in the version command to list additional supported targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2809d0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->