### PR TITLE
fix(dev): improve argument validation and fix filter typo in dev scripts

### DIFF
--- a/dev/cmd/register-enable-node.sh
+++ b/dev/cmd/register-enable-node.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
+if [[ $# -ne 4 ]]; then
+    echo "Usage: $0 <owner_addr> <signer_pub> <http_addr> <config_file>"
+    echo "Example: $0 0x123... 0xabc... localhost:8080 config.yaml"
+    exit 1
+fi
 OWNER_ADDR="$1"
 SIGNER_PUB="$2"
 HTTP_ADDR="$3"

--- a/dev/gen/migration
+++ b/dev/gen/migration
@@ -5,5 +5,9 @@ set -e
 script_dir=$(dirname "$(realpath "$0")")
 repo_root=$(realpath "${script_dir}/../../")
 cd "${repo_root}"
-
+if [ -z "$1" ]; then
+    echo "Usage: $0 <migration_name>"
+    echo "Example: $0 add_user_balances_table"
+    exit 1
+fi
 go tool -modfile=tools/go.mod migrate create -dir pkg/db/migrations -seq -digits=5 -ext sql "$1"

--- a/dev/test
+++ b/dev/test
@@ -4,7 +4,7 @@ set -e
 ulimit -n 2048
 
 # shellcheck disable=SC2046 # word-split go list output so each package is its own arg
-go test -timeout 30s $(go list ./... | grep -v -e 'pkg/abis' -e 'pkg/config' -e 'pkg/proto' -e 'pkg/mock' -e 'pkg/testing') "$@"
+go test -timeout 30s $(go list ./... | grep -v -e 'pkg/abis' -e 'pkg/config' -e 'pkg/proto' -e 'pkg/mocks' -e 'pkg/testing') "$@"
 
 if [ -n "${RACE:-}" ]; then
     echo


### PR DESCRIPTION
Fix three bugs in dev scripts that cause silent failures or incorrect behavior.

Changes:
register-enable-node.sh: missing argument count check causes unbound variable errors, added `[[ $# -ne 4 ]]` guard with usage and example
dev/gen/migration: missing `$1` check allows empty migration name to be passed to migrate create, added guard with usage and example
dev/test: `'pkg/mock'` → `'pkg/mocks'` — filter never matched real path, causing mock packages to be included in test runs

Test plan:
- `./dev/cmd/register-enable-node.sh` with no args prints usage and exits cleanly
- `./dev/gen/migration` with no args prints usage and exits cleanly
- `dev/test` now correctly excludes `pkg/mocks` packages from test runs

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix filter typo and add argument validation to dev scripts
> - Adds argument count validation to [register-enable-node.sh](https://github.com/xmtp/xmtpd/pull/2008/files#diff-5c85518eadf74c606c04d4f855228c157c845d0bd12495a85014393eb39f8ee8), printing usage and exiting with status 1 when exactly 4 arguments are not provided.
> - Adds missing-argument validation to the [migration script](https://github.com/xmtp/xmtpd/pull/2008/files#diff-7ebe2afdbdee9b3b76c452cd0fa710f9b54d2c9609e88d8dc9b35469c7a72dcb), requiring a migration name before invoking the go migrate tool.
> - Fixes a grep exclusion typo in the [test runner](https://github.com/xmtp/xmtpd/pull/2008/files#diff-20c04bb8529d71d3c6a1a55e5cdf47f9737a908e2592f3f85594fbd71cfb45a0), changing `pkg/mock` to `pkg/mocks` so the correct packages are excluded when generating the test package list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b724a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->