### PR TITLE
fix(db): eliminate gateway-envelope partition-creation deadlock via reader/writer advisory lock

### DIFF
--- a/pkg/api/message/publish_worker.go
+++ b/pkg/api/message/publish_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -180,34 +181,58 @@ func (p *publishWorker) processBatch() (int32, error) {
 	originatorID := int32(p.registrant.NodeID())
 
 	var spans []tracing.Span
+	// pendingPartitions captures the batch built inside the transaction so that, if the insert
+	// reports a missing partition, we can create it out-of-band (in its own transaction under the
+	// exclusive partition-creation lock) and retry without ever doing DDL inside the insert tx.
+	var pendingPartitions *types.GatewayEnvelopeBatch
 
-	result, err := db.RunInTxWithResult(
-		p.ctx, p.store.DB(), &sql.TxOptions{},
-		func(ctx context.Context, txQueries *queries.Queries) (batchResult, error) {
-			staged, err := txQueries.SelectAndLockStagedEnvelopes(
-				ctx, numRowsPerBatch,
-			)
-			if err != nil {
-				return batchResult{}, fmt.Errorf("select and lock staged envelopes: %w", err)
-			}
-			if len(staged) == 0 {
-				return batchResult{}, nil
-			}
+	txBody := func(ctx context.Context, txQueries *queries.Queries) (batchResult, error) {
+		// Take the shared partition-creation lock as the first statement, before
+		// BulkFindOrCreatePayers (in persistBatch) locks the payers table. Out-of-band
+		// partition creation needs ShareRowExclusiveLock on payers (via the gateway->payers FK
+		// validated when a partition is attached); acquiring the shared lock first keeps the
+		// lock order consistent and prevents a payers-vs-advisory deadlock.
+		if err := db.NewAdvisoryLocker().SharedLockPartitionCreation(ctx, txQueries); err != nil {
+			return batchResult{}, fmt.Errorf("shared lock partition creation: %w", err)
+		}
 
-			spans = p.startEnvelopeSpans(staged, originatorID)
+		staged, err := txQueries.SelectAndLockStagedEnvelopes(
+			ctx, numRowsPerBatch,
+		)
+		if err != nil {
+			return batchResult{}, fmt.Errorf("select and lock staged envelopes: %w", err)
+		}
+		if len(staged) == 0 {
+			return batchResult{}, nil
+		}
 
-			p.logger.Debug(
-				"processing batch", zap.Int("batch_size", len(staged)),
-			)
+		spans = p.startEnvelopeSpans(staged, originatorID)
 
-			prepared, err := p.prepareEnvelopes(staged, txQueries)
-			if err != nil {
-				return batchResult{}, err
-			}
+		p.logger.Debug(
+			"processing batch", zap.Int("batch_size", len(staged)),
+		)
 
-			return p.persistBatch(ctx, txQueries, prepared)
-		},
-	)
+		prepared, err := p.prepareEnvelopes(staged, txQueries)
+		if err != nil {
+			return batchResult{}, err
+		}
+
+		return p.persistBatch(ctx, txQueries, prepared, &pendingPartitions)
+	}
+
+	result, err := db.RunInTxWithResult(p.ctx, p.store.DB(), &sql.TxOptions{}, txBody)
+	if errors.Is(err, db.ErrGatewayPartitionMissing) && pendingPartitions != nil {
+		p.logger.Info("creating partitions for batch insert")
+		if ensErr := db.EnsureGatewayPartitionsForBatch(
+			p.ctx,
+			p.store.DB(),
+			pendingPartitions,
+		); ensErr != nil {
+			err = ensErr
+		} else {
+			result, err = db.RunInTxWithResult(p.ctx, p.store.DB(), &sql.TxOptions{}, txBody)
+		}
+	}
 
 	// Finish per-envelope spans outside the transaction so we capture
 	// errors from the tx body, commit failures, and rollbacks.
@@ -353,6 +378,7 @@ func (p *publishWorker) persistBatch(
 	ctx context.Context,
 	txQueries *queries.Queries,
 	prepared []preparedEnvelope,
+	pendingPartitions **types.GatewayEnvelopeBatch,
 ) (batchResult, error) {
 	originatorID := int32(p.registrant.NodeID())
 
@@ -387,6 +413,9 @@ func (p *publishWorker) persistBatch(
 		stagedIDs = append(stagedIDs, prep.staged.ID)
 		originatorTimes = append(originatorTimes, prep.staged.OriginatorTime)
 	}
+
+	// Expose the batch so the caller can create any missing partitions out-of-band and retry.
+	*pendingPartitions = batchInput
 
 	insertSpan, _ := tracing.StartSpanFromContext(ctx, tracing.SpanPublishWorkerInsertGateway)
 	inserted, err := db.InsertGatewayEnvelopeBatchV2Transactional(

--- a/pkg/db/advisory_lock.go
+++ b/pkg/db/advisory_lock.go
@@ -20,7 +20,14 @@ const (
 	LockKindSubmitterWorker      LockKind = 0x02
 	LockKindSettlementWorker     LockKind = 0x03
 	LockKindGeneratorWorker      LockKind = 0x04
+	LockKindPartitionCreation    LockKind = 0x05
 )
+
+// partitionCreationLockKey is the single, global advisory-lock key coordinating lazy
+// gateway-envelope partition creation against concurrent inserts. It is not per-originator:
+// the deadlock it prevents is between transactions touching different originators' partitions,
+// so they must contend on the same key.
+const partitionCreationLockKey = int64(LockKindPartitionCreation)
 
 // AdvisoryLocker builds advisory-lock keys and acquires locks using the caller’s
 // connection/transaction via the provided *queries.Queries
@@ -37,6 +44,35 @@ func (a *AdvisoryLocker) LockIdentityUpdateInsert(
 ) error {
 	key := int64((uint64(nodeID) << 8) | uint64(LockKindIdentityUpdateInsert))
 	return queries.AdvisoryLockWithKey(ctx, key)
+}
+
+// SharedLockPartitionCreation takes the shared (reader) side of the partition-creation
+// reader/writer advisory lock. Ordinary gateway-envelope inserts hold it so they run
+// concurrently with each other, but block (and are blocked by) exclusive partition creation.
+func (a *AdvisoryLocker) SharedLockPartitionCreation(
+	ctx context.Context,
+	queries *queries.Queries,
+) error {
+	return queries.SharedAdvisoryLockWithKey(ctx, partitionCreationLockKey)
+}
+
+// LockPartitionCreation takes the exclusive (writer) side of the partition-creation
+// reader/writer advisory lock. It must be acquired in a dedicated transaction (see
+// EnsureGatewayPartitions), never upgraded from the shared lock within an insert transaction,
+// or two upgraders would deadlock.
+//
+// ensure_gateway_parts_v3 ATTACHes partitions to the shared gateway_envelopes_meta and
+// gateway_envelopes_blob parents. Because of the blob->meta and meta->payers foreign keys, each
+// ATTACH validates the FK and takes ShareRowExclusiveLock on both parents once they hold data.
+// That conflicts with the RowExclusiveLock ordinary inserts take, and concurrent transactions
+// acquire the parents' locks in opposite orders and deadlock (SQLSTATE 40P01). Running partition
+// creation as the exclusive writer, while inserts hold the shared lock, guarantees DDL never
+// overlaps DML, removing the conflict.
+func (a *AdvisoryLocker) LockPartitionCreation(
+	ctx context.Context,
+	queries *queries.Queries,
+) error {
+	return queries.AdvisoryLockWithKey(ctx, partitionCreationLockKey)
 }
 
 func (a *AdvisoryLocker) TryLockGeneratorWorker(

--- a/pkg/db/gateway_envelope.go
+++ b/pkg/db/gateway_envelope.go
@@ -3,10 +3,49 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 )
+
+// ErrGatewayPartitionMissing signals that an insert could not proceed because the target
+// gateway-envelope partition does not exist yet. Callers that own the surrounding transaction
+// should roll it back, call EnsureGatewayPartitions (which creates the partition in its own
+// transaction under the exclusive partition-creation lock), and retry the insert.
+var ErrGatewayPartitionMissing = errors.New("gateway partition missing")
+
+func isNoPartitionErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no partition of relation")
+}
+
+// EnsureGatewayPartitions creates the meta/blob partitions for the given originator and
+// sequence id in a dedicated transaction, serialized by the exclusive partition-creation
+// advisory lock.
+//
+// It runs on its own transaction (not the caller's insert transaction): the partition-creation
+// DDL takes ShareRowExclusiveLock on the shared meta/blob parents (via the blob->meta and
+// meta->payers foreign keys), which conflicts with the RowExclusiveLock of concurrent inserts.
+// Holding the exclusive advisory lock here, while inserts hold the shared lock, guarantees DDL
+// never overlaps DML and removes the cross-originator deadlock. A separate transaction also
+// avoids a shared->exclusive advisory-lock upgrade, which would itself deadlock.
+func EnsureGatewayPartitions(
+	ctx context.Context,
+	db *sql.DB,
+	originatorNodeID int32,
+	originatorSequenceID int64,
+) error {
+	return RunInTx(ctx, db, &sql.TxOptions{}, func(ctx context.Context, q *queries.Queries) error {
+		if err := NewAdvisoryLocker().LockPartitionCreation(ctx, q); err != nil {
+			return err
+		}
+		return q.EnsureGatewayPartsV3(ctx, queries.EnsureGatewayPartsV3Params{
+			OriginatorNodeID:     originatorNodeID,
+			OriginatorSequenceID: originatorSequenceID,
+			BandWidth:            GatewayEnvelopeBandWidth,
+		})
+	})
+}
 
 // InsertGatewayEnvelopeAndIncrementUnsettledUsage inserts a gateway envelope and
 // updates unsettled usage and congestion counters within a single database transaction.
@@ -30,77 +69,92 @@ func InsertGatewayEnvelopeAndIncrementUnsettledUsage(
 	incrementParams queries.IncrementUnsettledUsageParams,
 	incrementCongestion bool,
 ) (int64, error) {
-	return RunInTxWithResult(
-		ctx,
-		db,
-		&sql.TxOptions{},
-		func(ctx context.Context, txQueries *queries.Queries) (int64, error) {
-			numInserted, err := InsertGatewayEnvelopeWithChecksTransactional(
-				ctx,
-				txQueries,
-				insertParams,
-			)
-			if err != nil {
-				return 0, err
-			}
-			// If the numInserted is 0 it means the envelope already exists
-			// and we don't need to increment the unsettled usage
-			if numInserted.InsertedMetaRows == 0 {
-				return 0, nil
-			}
+	insertTx := func(ctx context.Context, txQueries *queries.Queries) (int64, error) {
+		numInserted, err := InsertGatewayEnvelopeWithChecksTransactional(
+			ctx,
+			txQueries,
+			insertParams,
+		)
+		if err != nil {
+			return 0, err
+		}
+		// If the numInserted is 0 it means the envelope already exists
+		// and we don't need to increment the unsettled usage
+		if numInserted.InsertedMetaRows == 0 {
+			return 0, nil
+		}
 
-			// Use the sequence ID from the envelope to set the last sequence ID value
-			if incrementParams.SequenceID == 0 {
-				incrementParams.SequenceID = insertParams.OriginatorSequenceID
-			}
-			// In this case, the message count is always 1
-			if incrementParams.MessageCount == 0 {
-				incrementParams.MessageCount = 1
-			}
+		// Use the sequence ID from the envelope to set the last sequence ID value
+		if incrementParams.SequenceID == 0 {
+			incrementParams.SequenceID = insertParams.OriginatorSequenceID
+		}
+		// In this case, the message count is always 1
+		if incrementParams.MessageCount == 0 {
+			incrementParams.MessageCount = 1
+		}
 
-			err = txQueries.IncrementUnsettledUsage(ctx, incrementParams)
-			if err != nil {
-				return 0, err
-			}
+		err = txQueries.IncrementUnsettledUsage(ctx, incrementParams)
+		if err != nil {
+			return 0, err
+		}
 
-			if !incrementCongestion {
-				return numInserted.InsertedMetaRows, nil
-			}
-
-			err = txQueries.IncrementOriginatorCongestion(
-				ctx,
-				queries.IncrementOriginatorCongestionParams{
-					OriginatorID:      incrementParams.OriginatorID,
-					MinutesSinceEpoch: incrementParams.MinutesSinceEpoch,
-				},
-			)
-			if err != nil {
-				return 0, err
-			}
-
+		if !incrementCongestion {
 			return numInserted.InsertedMetaRows, nil
-		},
-	)
+		}
+
+		err = txQueries.IncrementOriginatorCongestion(
+			ctx,
+			queries.IncrementOriginatorCongestionParams{
+				OriginatorID:      incrementParams.OriginatorID,
+				MinutesSinceEpoch: incrementParams.MinutesSinceEpoch,
+			},
+		)
+		if err != nil {
+			return 0, err
+		}
+
+		return numInserted.InsertedMetaRows, nil
+	}
+
+	result, err := RunInTxWithResult(ctx, db, &sql.TxOptions{}, insertTx)
+	if errors.Is(err, ErrGatewayPartitionMissing) {
+		// Create the missing partition out-of-band under the exclusive lock, then retry once.
+		if ensErr := EnsureGatewayPartitions(
+			ctx, db, insertParams.OriginatorNodeID, insertParams.OriginatorSequenceID,
+		); ensErr != nil {
+			return 0, ensErr
+		}
+		result, err = RunInTxWithResult(ctx, db, &sql.TxOptions{}, insertTx)
+	}
+	return result, err
 }
 
-// InsertGatewayEnvelopeWithChecksTransactional attempts to insert a gateway envelope
-// inside the current SQL transaction, with automatic partition creation and retry.
+// InsertGatewayEnvelopeWithChecksTransactional attempts to insert a gateway envelope inside the
+// current SQL transaction.
 //
 // Behavior:
+//   - Takes the shared partition-creation advisory lock so the insert is a reader: it runs
+//     concurrently with other inserts but never overlaps exclusive partition creation.
 //   - Creates a SAVEPOINT before the insert so that a failure does not abort the entire tx.
-//   - On “no partition of relation …” errors, it rolls back to the savepoint,
-//     creates the missing partition(s) using the same connection (within the tx),
-//     and retries the insert once.
+//   - On a missing-partition error, it rolls back to the savepoint and returns
+//     ErrGatewayPartitionMissing. The caller (which owns the transaction) must roll back, call
+//     EnsureGatewayPartitions to create the partition in its own transaction under the exclusive
+//     lock, and retry. Partition creation is NOT done inline here: that would take
+//     ShareRowExclusiveLock on the shared meta/blob parents while a concurrent insert holds a
+//     conflicting lock, deadlocking across originators.
 //   - On success, the savepoint is released.
 //
-// This variant must be called within an active transaction. It avoids full tx rollbacks
-// and ensures inserts can proceed even when new partitions are required.
-// Use for transactional ingestion flows where atomicity must be preserved.
+// This variant must be called within an active transaction. Use
+// InsertGatewayEnvelopeAndIncrementUnsettledUsage for the caller-side ensure-and-retry loop.
 func InsertGatewayEnvelopeWithChecksTransactional(
 	ctx context.Context,
 	q *queries.Queries,
 	row queries.InsertGatewayEnvelopeV3Params,
 ) (queries.InsertGatewayEnvelopeV3Row, error) {
+	if err := NewAdvisoryLocker().SharedLockPartitionCreation(ctx, q); err != nil {
+		return queries.InsertGatewayEnvelopeV3Row{}, err
+	}
+
 	err := q.InsertSavePoint(ctx)
 	if err != nil {
 		return queries.InsertGatewayEnvelopeV3Row{}, err
@@ -113,26 +167,19 @@ func InsertGatewayEnvelopeWithChecksTransactional(
 		return inserted, nil
 	}
 
-	if !strings.Contains(err.Error(), "no partition of relation") {
+	if !isNoPartitionErr(err) {
 		// leave tx in aborted state; caller will handle rollback
 		return queries.InsertGatewayEnvelopeV3Row{}, err
 	}
 
-	err = q.InsertSavePointRollback(ctx)
-	if err != nil {
-		return queries.InsertGatewayEnvelopeV3Row{}, err
+	if rbErr := q.InsertSavePointRollback(ctx); rbErr != nil {
+		return queries.InsertGatewayEnvelopeV3Row{}, rbErr
 	}
 
-	err = q.EnsureGatewayPartsV3(ctx, queries.EnsureGatewayPartsV3Params{
-		OriginatorNodeID:     row.OriginatorNodeID,
-		OriginatorSequenceID: row.OriginatorSequenceID,
-		BandWidth:            GatewayEnvelopeBandWidth,
-	})
-	if err != nil {
-		return queries.InsertGatewayEnvelopeV3Row{}, err
-	}
-
-	return q.InsertGatewayEnvelopeV3(ctx, row)
+	// Partition creation is done out-of-band by the caller (see EnsureGatewayPartitions); doing
+	// it inline here would take ShareRowExclusiveLock on the shared meta/blob parents while a
+	// concurrent insert holds a conflicting lock, deadlocking across originators.
+	return queries.InsertGatewayEnvelopeV3Row{}, ErrGatewayPartitionMissing
 }
 
 // InsertGatewayEnvelopeWithChecksStandalone inserts a gateway envelope in a non-transactional context,

--- a/pkg/db/gateway_envelope_batch.go
+++ b/pkg/db/gateway_envelope_batch.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/xmtp/xmtpd/pkg/db/queries"
 	"github.com/xmtp/xmtpd/pkg/db/types"
@@ -15,22 +14,39 @@ import (
 // InsertGatewayEnvelopeBatchV2AndIncrementUnsettledUsage inserts a batch of gateway envelopes,
 // updates unsettled usage, and tracks originator congestion within a single database transaction.
 //
-// This is a convenience wrapper that creates its own transaction. Use
-// InsertGatewayEnvelopeBatchV2Transactional when you need to participate in an existing transaction.
+// This is a convenience wrapper that creates its own transaction and, on a missing partition,
+// creates it out-of-band under the exclusive partition-creation lock before retrying. Use
+// InsertGatewayEnvelopeBatchV2Transactional when you need to participate in an existing
+// transaction (the caller is then responsible for the ensure-and-retry loop).
 func InsertGatewayEnvelopeBatchV2AndIncrementUnsettledUsage(
 	ctx context.Context,
 	db *sql.DB,
 	logger *zap.Logger,
 	input *types.GatewayEnvelopeBatch,
 ) (int64, error) {
-	return RunInTxWithResult(ctx, db, &sql.TxOptions{},
-		func(ctx context.Context, q *queries.Queries) (int64, error) {
-			return InsertGatewayEnvelopeBatchV2Transactional(ctx, q, logger, input)
-		})
+	insertTx := func(ctx context.Context, q *queries.Queries) (int64, error) {
+		return InsertGatewayEnvelopeBatchV2Transactional(ctx, q, logger, input)
+	}
+
+	result, err := RunInTxWithResult(ctx, db, &sql.TxOptions{}, insertTx)
+	if errors.Is(err, ErrGatewayPartitionMissing) {
+		logger.Info("creating partitions for batch insert")
+		if ensErr := EnsureGatewayPartitionsForBatch(ctx, db, input); ensErr != nil {
+			return 0, ensErr
+		}
+		result, err = RunInTxWithResult(ctx, db, &sql.TxOptions{}, insertTx)
+	}
+	return result, err
 }
 
 // InsertGatewayEnvelopeBatchV2Transactional inserts a batch of gateway envelopes within an
 // existing transaction, using the V2 SQL function that also tracks originator congestion.
+//
+// It takes the shared partition-creation advisory lock (running as a reader, concurrent with
+// other inserts but never overlapping exclusive partition creation). On a missing partition it
+// rolls back to the savepoint and returns ErrGatewayPartitionMissing; the caller that owns the
+// transaction must roll back, call EnsureGatewayPartitionsForBatch, and retry. Partition
+// creation is not done inline (see InsertGatewayEnvelopeWithChecksTransactional for why).
 func InsertGatewayEnvelopeBatchV2Transactional(
 	ctx context.Context,
 	q *queries.Queries,
@@ -43,6 +59,10 @@ func InsertGatewayEnvelopeBatchV2Transactional(
 
 	params := input.ToParamsV3()
 
+	if err := NewAdvisoryLocker().SharedLockPartitionCreation(ctx, q); err != nil {
+		return 0, err
+	}
+
 	err := q.InsertSavePoint(ctx)
 	if err != nil {
 		return 0, err
@@ -54,35 +74,30 @@ func InsertGatewayEnvelopeBatchV2Transactional(
 		return result.InsertedMetaRows, nil
 	}
 
-	if !strings.Contains(err.Error(), "no partition of relation") {
+	if !isNoPartitionErr(err) {
 		return 0, fmt.Errorf("insert batch v2: %w", err)
 	}
 
-	err = q.InsertSavePointRollback(ctx)
-	if err != nil {
-		return 0, err
+	if rbErr := q.InsertSavePointRollback(ctx); rbErr != nil {
+		return 0, rbErr
 	}
 
-	logger.Info("creating partitions for batch insert")
+	return 0, ErrGatewayPartitionMissing
+}
 
+// EnsureGatewayPartitionsForBatch creates the meta/blob partitions for every envelope in the
+// batch, each in its own transaction under the exclusive partition-creation lock.
+func EnsureGatewayPartitionsForBatch(
+	ctx context.Context,
+	db *sql.DB,
+	input *types.GatewayEnvelopeBatch,
+) error {
 	for _, envelope := range input.Envelopes {
-		err = q.EnsureGatewayPartsV3(ctx, queries.EnsureGatewayPartsV3Params{
-			OriginatorNodeID:     envelope.OriginatorNodeID,
-			OriginatorSequenceID: envelope.OriginatorSequenceID,
-			BandWidth:            GatewayEnvelopeBandWidth,
-		})
-		if err != nil {
-			return 0, fmt.Errorf("ensure gateway parts: %w", err)
+		if err := EnsureGatewayPartitions(
+			ctx, db, envelope.OriginatorNodeID, envelope.OriginatorSequenceID,
+		); err != nil {
+			return fmt.Errorf("ensure gateway parts: %w", err)
 		}
 	}
-
-	result, err = q.InsertGatewayEnvelopeBatchV3(ctx, params)
-	if err != nil {
-		return 0, fmt.Errorf(
-			"insert gateway envelope batch v2 and increment unsettled usage: %w",
-			err,
-		)
-	}
-
-	return result.InsertedMetaRows, nil
+	return nil
 }

--- a/pkg/db/gateway_envelope_test.go
+++ b/pkg/db/gateway_envelope_test.go
@@ -3,6 +3,7 @@ package db_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -396,28 +397,43 @@ func TestInsertGatewayEnvelopeWithChecksTransactional_FailsWithoutTx(t *testing.
 	}
 }
 
+// db_runInsertWithEnsure mirrors the production caller contract: run the insert in a
+// transaction, and on ErrGatewayPartitionMissing create the partition out-of-band (its own
+// transaction under the exclusive lock) and retry once.
+func db_runInsertWithEnsure(
+	ctx context.Context,
+	t *testing.T,
+	db *sql.DB,
+	params queries.InsertGatewayEnvelopeV3Params,
+) error {
+	t.Helper()
+	insertTx := func(ctx context.Context, q *queries.Queries) error {
+		_, err := xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(ctx, q, params)
+		return err
+	}
+	err := xmtpd_db.RunInTx(ctx, db, &sql.TxOptions{}, insertTx)
+	if errors.Is(err, xmtpd_db.ErrGatewayPartitionMissing) {
+		require.NoError(t, xmtpd_db.EnsureGatewayPartitions(
+			ctx, db, params.OriginatorNodeID, params.OriginatorSequenceID,
+		))
+		err = xmtpd_db.RunInTx(ctx, db, &sql.TxOptions{}, insertTx)
+	}
+	return err
+}
+
 func TestInsertGatewayEnvelopeWithCheckTransactional(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testutils.NewRawDB(t, ctx)
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	require.NoError(t, err)
-	querier := queries.New(db).WithTx(tx)
-	defer func(tx *sql.Tx) {
-		_ = tx.Rollback()
-	}(tx)
 
 	for i := 1; i < 10; i++ {
-		_, err := xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-			ctx,
-			querier,
-			queries.InsertGatewayEnvelopeV3Params{
-				OriginatorNodeID:     int32(i),
-				OriginatorSequenceID: 1,
-				Topic:                testutils.RandomBytes(32),
-				OriginatorEnvelope:   testutils.RandomBytes(100),
-			},
-		)
-		require.NoError(t, err)
+		// Partitions don't exist yet, so the in-transaction insert reports the missing
+		// partition; the caller creates it out-of-band and retries.
+		require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+			OriginatorNodeID:     int32(i),
+			OriginatorSequenceID: 1,
+			Topic:                testutils.RandomBytes(32),
+			OriginatorEnvelope:   testutils.RandomBytes(100),
+		}))
 	}
 }
 
@@ -426,40 +442,25 @@ func TestInsertGatewayEnvelopeWithChecksTx_AutoCreateAndRetry(t *testing.T) {
 
 	ctx := context.Background()
 	db, _ := testutils.NewRawDB(t, ctx)
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	require.NoError(t, err)
-	q := queries.New(db).WithTx(tx)
-	defer func(tx *sql.Tx) {
-		_ = tx.Rollback()
-	}(tx)
 
 	const nodeID int32 = 42
 	const seqID int64 = 1
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqID,
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(128),
-		},
-	)
-	require.NoError(t, err)
+	// First insert creates the partition out-of-band and retries.
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqID,
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(128),
+	}))
 
 	// A second insert into the SAME band should succeed without needing to create parts again.
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqID + 123, // still within [0..1_000_000) default band
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(128),
-		},
-	)
-	require.NoError(t, err)
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqID + 123, // still within [0..1_000_000) default band
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(128),
+	}))
 }
 
 func TestInsertGatewayEnvelopeWithChecksTx_PreexistingPartitions(t *testing.T) {
@@ -503,12 +504,6 @@ func TestInsertGatewayEnvelopeWithChecksTxn_BandBoundaries(t *testing.T) {
 
 	ctx := context.Background()
 	db, _ := testutils.NewRawDB(t, ctx)
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	require.NoError(t, err)
-	q := queries.New(db).WithTx(tx)
-	defer func(tx *sql.Tx) {
-		_ = tx.Rollback()
-	}(tx)
 
 	const nodeID int32 = 99
 
@@ -516,81 +511,65 @@ func TestInsertGatewayEnvelopeWithChecksTxn_BandBoundaries(t *testing.T) {
 	seqLeft := xmtpd_db.GatewayEnvelopeBandWidth - 1 // falls into band [0, bw)
 	seqRight := xmtpd_db.GatewayEnvelopeBandWidth    // falls into band [bw, 2*bw)
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqLeft,
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
-	require.NoError(t, err)
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqLeft,
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(64),
+	}))
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqRight,
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
-	require.NoError(t, err)
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqRight,
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(64),
+	}))
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqLeft + 123, // still within first band
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
-	require.NoError(t, err)
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqLeft + 123, // still within first band
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(64),
+	}))
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqRight + 456, // still within second band
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
-	require.NoError(t, err)
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqRight + 456, // still within second band
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(64),
+	}))
 }
 
-func TestInsertGatewayEnvelopeWithChecksTx_RollbackDDL(t *testing.T) {
+// TestInsertGatewayEnvelopeWithChecksTx_RollbackInsert verifies that rolling back the insert
+// transaction discards the inserted row while the out-of-band-created partition persists, so a
+// fresh insert into the same partition succeeds.
+func TestInsertGatewayEnvelopeWithChecksTx_RollbackInsert(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	db, _ := testutils.NewRawDB(t, ctx)
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	require.NoError(t, err)
-	q := queries.New(db).WithTx(tx)
 
 	const nodeID int32 = 7
 	const seqID int64 = 10
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqID,
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
-	require.NoError(t, err)
+	params := queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqID,
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(64),
+	}
 
+	// Create the partition out-of-band, then insert in a transaction that we roll back.
+	require.NoError(t, xmtpd_db.EnsureGatewayPartitions(ctx, db, nodeID, seqID))
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	require.NoError(t, err)
+	q := queries.New(db).WithTx(tx)
+	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(ctx, q, params)
+	require.NoError(t, err)
 	_ = tx.Rollback()
 
+	// The partition still exists, so re-inserting the same row in a new transaction succeeds.
 	tx2, err := db.BeginTx(ctx, &sql.TxOptions{})
 	require.NoError(t, err)
 	q2 := queries.New(db).WithTx(tx2)
@@ -598,16 +577,7 @@ func TestInsertGatewayEnvelopeWithChecksTx_RollbackDDL(t *testing.T) {
 		_ = tx2.Rollback()
 	}(tx2)
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q2,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqID,
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
+	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(ctx, q2, params)
 	require.NoError(t, err)
 }
 
@@ -616,25 +586,14 @@ func TestInsertGatewayEnvelopeWithChecksTx_Commit(t *testing.T) {
 
 	ctx := context.Background()
 	db, _ := testutils.NewRawDB(t, ctx)
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	require.NoError(t, err)
-	q := queries.New(db).WithTx(tx)
 
 	const nodeID int32 = 7
 	const seqID int64 = 10
 
-	_, err = xmtpd_db.InsertGatewayEnvelopeWithChecksTransactional(
-		ctx,
-		q,
-		queries.InsertGatewayEnvelopeV3Params{
-			OriginatorNodeID:     nodeID,
-			OriginatorSequenceID: seqID,
-			Topic:                testutils.RandomBytes(32),
-			OriginatorEnvelope:   testutils.RandomBytes(64),
-		},
-	)
-	require.NoError(t, err)
-
-	_ = tx.Commit()
-	t.Logf("tx committed")
+	require.NoError(t, db_runInsertWithEnsure(ctx, t, db, queries.InsertGatewayEnvelopeV3Params{
+		OriginatorNodeID:     nodeID,
+		OriginatorSequenceID: seqID,
+		Topic:                testutils.RandomBytes(32),
+		OriginatorEnvelope:   testutils.RandomBytes(64),
+	}))
 }

--- a/pkg/db/queries/advisory_locks.sql.go
+++ b/pkg/db/queries/advisory_locks.sql.go
@@ -18,6 +18,15 @@ func (q *Queries) AdvisoryLockWithKey(ctx context.Context, lockingKey int64) err
 	return err
 }
 
+const sharedAdvisoryLockWithKey = `-- name: SharedAdvisoryLockWithKey :exec
+SELECT pg_advisory_xact_lock_shared($1)
+`
+
+func (q *Queries) SharedAdvisoryLockWithKey(ctx context.Context, lockingKey int64) error {
+	_, err := q.exec(ctx, q.sharedAdvisoryLockWithKeyStmt, sharedAdvisoryLockWithKey, lockingKey)
+	return err
+}
+
 const tryAdvisoryLockWithKey = `-- name: TryAdvisoryLockWithKey :one
 SELECT pg_try_advisory_xact_lock($1) as lock_succeeded
 `

--- a/pkg/db/queries/db.go
+++ b/pkg/db/queries/db.go
@@ -246,6 +246,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.setReportSubmittedStmt, err = db.PrepareContext(ctx, setReportSubmitted); err != nil {
 		return nil, fmt.Errorf("error preparing query SetReportSubmitted: %w", err)
 	}
+	if q.sharedAdvisoryLockWithKeyStmt, err = db.PrepareContext(ctx, sharedAdvisoryLockWithKey); err != nil {
+		return nil, fmt.Errorf("error preparing query SharedAdvisoryLockWithKey: %w", err)
+	}
 	if q.sumOriginatorCongestionStmt, err = db.PrepareContext(ctx, sumOriginatorCongestion); err != nil {
 		return nil, fmt.Errorf("error preparing query SumOriginatorCongestion: %w", err)
 	}
@@ -630,6 +633,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing setReportSubmittedStmt: %w", cerr)
 		}
 	}
+	if q.sharedAdvisoryLockWithKeyStmt != nil {
+		if cerr := q.sharedAdvisoryLockWithKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing sharedAdvisoryLockWithKeyStmt: %w", cerr)
+		}
+	}
 	if q.sumOriginatorCongestionStmt != nil {
 		if cerr := q.sumOriginatorCongestionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing sumOriginatorCongestionStmt: %w", cerr)
@@ -758,6 +766,7 @@ type Queries struct {
 	setReportAttestationStatusStmt               *sql.Stmt
 	setReportSubmissionStatusStmt                *sql.Stmt
 	setReportSubmittedStmt                       *sql.Stmt
+	sharedAdvisoryLockWithKeyStmt                *sql.Stmt
 	sumOriginatorCongestionStmt                  *sql.Stmt
 	tryAdvisoryLockWithKeyStmt                   *sql.Stmt
 	updateMigrationProgressStmt                  *sql.Stmt
@@ -841,6 +850,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		setReportAttestationStatusStmt:               q.setReportAttestationStatusStmt,
 		setReportSubmissionStatusStmt:                q.setReportSubmissionStatusStmt,
 		setReportSubmittedStmt:                       q.setReportSubmittedStmt,
+		sharedAdvisoryLockWithKeyStmt:                q.sharedAdvisoryLockWithKeyStmt,
 		sumOriginatorCongestionStmt:                  q.sumOriginatorCongestionStmt,
 		tryAdvisoryLockWithKeyStmt:                   q.tryAdvisoryLockWithKeyStmt,
 		updateMigrationProgressStmt:                  q.updateMigrationProgressStmt,

--- a/pkg/db/sqlc/advisory_locks.sql
+++ b/pkg/db/sqlc/advisory_locks.sql
@@ -1,6 +1,9 @@
 -- name: AdvisoryLockWithKey :exec
 SELECT pg_advisory_xact_lock(@locking_key);
 
+-- name: SharedAdvisoryLockWithKey :exec
+SELECT pg_advisory_xact_lock_shared(@locking_key);
+
 -- name: TryAdvisoryLockWithKey :one
 SELECT pg_try_advisory_xact_lock(@locking_key) as lock_succeeded;
 

--- a/pkg/indexer/app_chain/contracts/identity_update_storer.go
+++ b/pkg/indexer/app_chain/contracts/identity_update_storer.go
@@ -133,181 +133,189 @@ func (s *IdentityUpdateStorer) StoreLog(
 	// “could not serialize access due to concurrent update” errors that show
 	// up under REPEATABLE READ with UPSERTs.
 
-	err = db.RunInTx(
-		ctx,
-		s.db,
-		&sql.TxOptions{Isolation: sql.LevelReadCommitted},
-		func(ctx context.Context, querier *queries.Queries) error {
-			err := db.NewAdvisoryLocker().
-				LockIdentityUpdateInsert(ctx, querier, uint32(constants.IdentityUpdateOriginatorID))
-			if err != nil {
-				return re.NewNonRecoverableError(ErrAdvisoryLockSequence, err)
-			}
+	txBody := func(ctx context.Context, querier *queries.Queries) error {
+		err := db.NewAdvisoryLocker().
+			LockIdentityUpdateInsert(ctx, querier, uint32(constants.IdentityUpdateOriginatorID))
+		if err != nil {
+			return re.NewNonRecoverableError(ErrAdvisoryLockSequence, err)
+		}
 
-			latestSequenceID, err := querier.GetLatestSequenceId(
-				ctx,
-				constants.IdentityUpdateOriginatorID,
+		latestSequenceID, err := querier.GetLatestSequenceId(
+			ctx,
+			constants.IdentityUpdateOriginatorID,
+		)
+		if err != nil {
+			return re.NewNonRecoverableError(ErrGetLatestSequenceID, err)
+		}
+
+		if uint64(latestSequenceID) >= msgSent.SequenceId {
+			s.logger.Debug(
+				"identity update already inserted, skipping",
+				utils.LastSequenceIDField(latestSequenceID),
+				utils.SequenceIDField(int64(msgSent.SequenceId)),
 			)
-			if err != nil {
-				return re.NewNonRecoverableError(ErrGetLatestSequenceID, err)
-			}
+			return nil
+		}
 
-			if uint64(latestSequenceID) >= msgSent.SequenceId {
-				s.logger.Debug(
-					"identity update already inserted, skipping",
-					utils.LastSequenceIDField(latestSequenceID),
-					utils.SequenceIDField(int64(msgSent.SequenceId)),
-				)
-				return nil
-			}
+		messageTopic := topic.NewTopic(topic.TopicKindIdentityUpdatesV1, msgSent.InboxId[:])
 
-			messageTopic := topic.NewTopic(topic.TopicKindIdentityUpdatesV1, msgSent.InboxId[:])
+		if s.logger.Core().Enabled(zap.DebugLevel) {
+			s.logger.Debug(
+				"inserting identity update from contract",
+				utils.TopicField(messageTopic.String()),
+			)
+		}
 
+		clientEnvelope, err := envelopes.NewClientEnvelopeFromBytes(msgSent.Update)
+		if err != nil {
+			s.logger.Error(
+				ErrParseClientEnvelope,
+				utils.TopicField(messageTopic.String()),
+				zap.Error(err),
+			)
+			return re.NewNonRecoverableError(ErrParseClientEnvelope, err)
+		}
+
+		associationState, validationError := s.validateIdentityUpdate(
+			ctx,
+			querier,
+			msgSent.InboxId,
+			clientEnvelope,
+		)
+		if validationError != nil {
+			s.logger.Error(
+				ErrValidateIdentityUpdate,
+				utils.TopicField(messageTopic.String()),
+				zap.Error(validationError),
+			)
+
+			return validationError
+		}
+
+		var (
+			inboxID     = utils.HexEncode(msgSent.InboxId[:])
+			sequenceID  = int64(msgSent.SequenceId)
+			insertBatch = make([]string, 0)
+			revokeBatch = make([]string, 0)
+		)
+
+		for _, newMember := range associationState.StateDiff.GetNewMembers() {
 			if s.logger.Core().Enabled(zap.DebugLevel) {
-				s.logger.Debug(
-					"inserting identity update from contract",
-					utils.TopicField(messageTopic.String()),
-				)
+				s.logger.Debug("new member", utils.BodyField(newMember))
 			}
 
-			clientEnvelope, err := envelopes.NewClientEnvelopeFromBytes(msgSent.Update)
+			if address, ok := newMember.GetKind().(*associations.MemberIdentifier_EthereumAddress); ok {
+				insertBatch = append(insertBatch, address.EthereumAddress)
+			}
+		}
+
+		for _, removedMember := range associationState.StateDiff.GetRemovedMembers() {
+			if s.logger.Core().Enabled(zap.DebugLevel) {
+				s.logger.Debug("removed member", utils.BodyField(removedMember))
+			}
+
+			if address, ok := removedMember.GetKind().(*associations.MemberIdentifier_EthereumAddress); ok {
+				revokeBatch = append(revokeBatch, address.EthereumAddress)
+			}
+		}
+
+		if len(insertBatch) > 0 {
+			_, err := querier.InsertAddressLogsBatch(ctx, queries.InsertAddressLogsBatchParams{
+				Addresses:             insertBatch,
+				InboxID:               inboxID,
+				AssociationSequenceID: sequenceID,
+			})
 			if err != nil {
-				s.logger.Error(
-					ErrParseClientEnvelope,
-					utils.TopicField(messageTopic.String()),
-					zap.Error(err),
-				)
-				return re.NewNonRecoverableError(ErrParseClientEnvelope, err)
+				return re.NewRecoverableError(ErrInsertAddressLog, err)
 			}
+		}
 
-			associationState, validationError := s.validateIdentityUpdate(
+		if len(revokeBatch) > 0 {
+			_, err := querier.RevokeAddressFromLogBatch(
 				ctx,
-				querier,
-				msgSent.InboxId,
-				clientEnvelope,
-			)
-			if validationError != nil {
-				s.logger.Error(
-					ErrValidateIdentityUpdate,
-					utils.TopicField(messageTopic.String()),
-					zap.Error(validationError),
-				)
-
-				return validationError
-			}
-
-			var (
-				inboxID     = utils.HexEncode(msgSent.InboxId[:])
-				sequenceID  = int64(msgSent.SequenceId)
-				insertBatch = make([]string, 0)
-				revokeBatch = make([]string, 0)
-			)
-
-			for _, newMember := range associationState.StateDiff.GetNewMembers() {
-				if s.logger.Core().Enabled(zap.DebugLevel) {
-					s.logger.Debug("new member", utils.BodyField(newMember))
-				}
-
-				if address, ok := newMember.GetKind().(*associations.MemberIdentifier_EthereumAddress); ok {
-					insertBatch = append(insertBatch, address.EthereumAddress)
-				}
-			}
-
-			for _, removedMember := range associationState.StateDiff.GetRemovedMembers() {
-				if s.logger.Core().Enabled(zap.DebugLevel) {
-					s.logger.Debug("removed member", utils.BodyField(removedMember))
-				}
-
-				if address, ok := removedMember.GetKind().(*associations.MemberIdentifier_EthereumAddress); ok {
-					revokeBatch = append(revokeBatch, address.EthereumAddress)
-				}
-			}
-
-			if len(insertBatch) > 0 {
-				_, err := querier.InsertAddressLogsBatch(ctx, queries.InsertAddressLogsBatchParams{
-					Addresses:             insertBatch,
-					InboxID:               inboxID,
-					AssociationSequenceID: sequenceID,
-				})
-				if err != nil {
-					return re.NewRecoverableError(ErrInsertAddressLog, err)
-				}
-			}
-
-			if len(revokeBatch) > 0 {
-				_, err := querier.RevokeAddressFromLogBatch(
-					ctx,
-					queries.RevokeAddressFromLogBatchParams{
-						Addresses:            revokeBatch,
-						InboxID:              inboxID,
-						RevocationSequenceID: sequenceID,
-					},
-				)
-				if err != nil {
-					return re.NewRecoverableError(ErrRevokeAddressFromLog, err)
-				}
-			}
-
-			originatorEnvelope, err := buildOriginatorEnvelope(
-				constants.IdentityUpdateOriginatorID,
-				msgSent.SequenceId,
-				msgSent.Update,
-			)
-			if err != nil {
-				s.logger.Error(
-					ErrBuildOriginatorEnvelope,
-					utils.TopicField(messageTopic.String()),
-					zap.Error(err),
-				)
-				return re.NewNonRecoverableError(ErrBuildOriginatorEnvelope, err)
-			}
-
-			signedOriginatorEnvelope, err := buildSignedOriginatorEnvelope(
-				originatorEnvelope,
-				event.TxHash,
-			)
-			if err != nil {
-				s.logger.Error(
-					ErrBuildSignedOriginatorEnvelope,
-					utils.TopicField(messageTopic.String()),
-					zap.Error(err),
-				)
-				return re.NewNonRecoverableError(ErrBuildSignedOriginatorEnvelope, err)
-			}
-
-			originatorEnvelopeBytes, err := proto.Marshal(signedOriginatorEnvelope)
-			if err != nil {
-				s.logger.Error(
-					ErrMarshallOriginatorEnvelope,
-					utils.TopicField(messageTopic.String()),
-					zap.Error(err),
-				)
-				return re.NewNonRecoverableError(ErrMarshallOriginatorEnvelope, err)
-			}
-
-			_, err = db.InsertGatewayEnvelopeWithChecksTransactional(
-				ctx,
-				querier,
-				queries.InsertGatewayEnvelopeV3Params{
-					OriginatorNodeID:     constants.IdentityUpdateOriginatorID,
-					OriginatorSequenceID: int64(msgSent.SequenceId),
-					Topic:                messageTopic.Bytes(),
-					OriginatorEnvelope:   originatorEnvelopeBytes,
-					Expiry:               math.MaxInt64,
+				queries.RevokeAddressFromLogBatchParams{
+					Addresses:            revokeBatch,
+					InboxID:              inboxID,
+					RevocationSequenceID: sequenceID,
 				},
 			)
 			if err != nil {
-				s.logger.Error(
-					ErrInsertEnvelopeFromSmartContract,
-					utils.TopicField(messageTopic.String()),
-					zap.Error(err),
-				)
-				return re.NewRecoverableError(ErrInsertEnvelopeFromSmartContract, err)
+				return re.NewRecoverableError(ErrRevokeAddressFromLog, err)
 			}
+		}
 
-			return nil
-		},
-	)
+		originatorEnvelope, err := buildOriginatorEnvelope(
+			constants.IdentityUpdateOriginatorID,
+			msgSent.SequenceId,
+			msgSent.Update,
+		)
+		if err != nil {
+			s.logger.Error(
+				ErrBuildOriginatorEnvelope,
+				utils.TopicField(messageTopic.String()),
+				zap.Error(err),
+			)
+			return re.NewNonRecoverableError(ErrBuildOriginatorEnvelope, err)
+		}
+
+		signedOriginatorEnvelope, err := buildSignedOriginatorEnvelope(
+			originatorEnvelope,
+			event.TxHash,
+		)
+		if err != nil {
+			s.logger.Error(
+				ErrBuildSignedOriginatorEnvelope,
+				utils.TopicField(messageTopic.String()),
+				zap.Error(err),
+			)
+			return re.NewNonRecoverableError(ErrBuildSignedOriginatorEnvelope, err)
+		}
+
+		originatorEnvelopeBytes, err := proto.Marshal(signedOriginatorEnvelope)
+		if err != nil {
+			s.logger.Error(
+				ErrMarshallOriginatorEnvelope,
+				utils.TopicField(messageTopic.String()),
+				zap.Error(err),
+			)
+			return re.NewNonRecoverableError(ErrMarshallOriginatorEnvelope, err)
+		}
+
+		_, err = db.InsertGatewayEnvelopeWithChecksTransactional(
+			ctx,
+			querier,
+			queries.InsertGatewayEnvelopeV3Params{
+				OriginatorNodeID:     constants.IdentityUpdateOriginatorID,
+				OriginatorSequenceID: int64(msgSent.SequenceId),
+				Topic:                messageTopic.Bytes(),
+				OriginatorEnvelope:   originatorEnvelopeBytes,
+				Expiry:               math.MaxInt64,
+			},
+		)
+		if err != nil {
+			s.logger.Error(
+				ErrInsertEnvelopeFromSmartContract,
+				utils.TopicField(messageTopic.String()),
+				zap.Error(err),
+			)
+			return re.NewRecoverableError(ErrInsertEnvelopeFromSmartContract, err)
+		}
+
+		return nil
+	}
+
+	// Ensure the partition exists up-front, out-of-band under the exclusive partition-creation
+	// lock, so the in-transaction insert never has to create it inline (which would deadlock
+	// across originators). EnsureGatewayPartitions is idempotent and cheap once the partition
+	// exists. We know the single fixed originator and sequence id here, so this avoids the
+	// sentinel/retry dance (and re-validating the identity update).
+	if ensErr := db.EnsureGatewayPartitions(
+		ctx, s.db, constants.IdentityUpdateOriginatorID, int64(msgSent.SequenceId),
+	); ensErr != nil {
+		return re.NewRecoverableError(ErrInsertEnvelopeFromSmartContract, ensErr)
+	}
+
+	err = db.RunInTx(ctx, s.db, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, txBody)
 	if err != nil {
 		var logStorageErr re.RetryableError
 		if errors.As(err, &logStorageErr) {

--- a/pkg/migrator/writer.go
+++ b/pkg/migrator/writer.go
@@ -34,34 +34,47 @@ func (w *Worker) insertOriginatorEnvelopeDatabaseBatch(
 		return re.NewNonRecoverableError("", errors.New("batch is nil"))
 	}
 
-	err := db.RunInTx(
-		ctx,
-		w.writer.Write(),
-		nil,
-		func(ctx context.Context, querier *queries.Queries) error {
-			_, err := querier.SetLocalWorkMem(ctx, batchWorkMem)
-			if err != nil {
-				logger.Error("set local work mem failed", zap.Error(err))
-				return re.NewRecoverableError("set local work mem failed", err)
-			}
+	txBody := func(ctx context.Context, querier *queries.Queries) error {
+		_, err := querier.SetLocalWorkMem(ctx, batchWorkMem)
+		if err != nil {
+			logger.Error("set local work mem failed", zap.Error(err))
+			return re.NewRecoverableError("set local work mem failed", err)
+		}
 
-			_, err = db.InsertGatewayEnvelopeBatchV2Transactional(ctx, querier, logger, batch)
-			if err != nil {
-				logger.Error("insert originator envelope batch failed", zap.Error(err))
-				return re.NewRecoverableError("insert originator envelope batch failed", err)
+		_, err = db.InsertGatewayEnvelopeBatchV2Transactional(ctx, querier, logger, batch)
+		if err != nil {
+			// Propagate ErrGatewayPartitionMissing unwrapped so we can create the partition
+			// out-of-band below; other errors are recoverable retries.
+			if errors.Is(err, db.ErrGatewayPartitionMissing) {
+				return err
 			}
+			logger.Error("insert originator envelope batch failed", zap.Error(err))
+			return re.NewRecoverableError("insert originator envelope batch failed", err)
+		}
 
-			err = querier.UpdateMigrationProgress(ctx, queries.UpdateMigrationProgressParams{
-				LastMigratedID: batch.LastSequenceID(),
-				SourceTable:    w.tableName,
-			})
-			if err != nil {
-				logger.Error("update migration progress failed", zap.Error(err))
-				return re.NewRecoverableError("update migration progress failed", err)
-			}
-
-			return nil
+		err = querier.UpdateMigrationProgress(ctx, queries.UpdateMigrationProgressParams{
+			LastMigratedID: batch.LastSequenceID(),
+			SourceTable:    w.tableName,
 		})
+		if err != nil {
+			logger.Error("update migration progress failed", zap.Error(err))
+			return re.NewRecoverableError("update migration progress failed", err)
+		}
+
+		return nil
+	}
+
+	err := db.RunInTx(ctx, w.writer.Write(), nil, txBody)
+	if errors.Is(err, db.ErrGatewayPartitionMissing) {
+		if ensErr := db.EnsureGatewayPartitionsForBatch(
+			ctx,
+			w.writer.Write(),
+			batch,
+		); ensErr != nil {
+			return re.NewRecoverableError("ensure gateway parts failed", ensErr)
+		}
+		err = db.RunInTx(ctx, w.writer.Write(), nil, txBody)
+	}
 	if err != nil {
 		var retryableError re.RetryableError
 		if errors.As(err, &retryableError) {

--- a/pkg/payerreport/store.go
+++ b/pkg/payerreport/store.go
@@ -402,6 +402,28 @@ func (s *Store) CreateAttestation(
 	)
 }
 
+// runGatewayInsertTx runs a gateway-envelope insert transaction and, if it reports a missing
+// partition, creates the partition out-of-band under the exclusive partition-creation lock and
+// retries once. Partition creation is never done inside the insert transaction to avoid the
+// cross-originator deadlock between partition-creation DDL and concurrent inserts.
+func (s *Store) runGatewayInsertTx(
+	ctx context.Context,
+	originatorNodeID int32,
+	originatorSequenceID int64,
+	txBody func(ctx context.Context, txQueries *queries.Queries) error,
+) error {
+	err := db.RunInTx(ctx, s.db.DB(), &sql.TxOptions{}, txBody)
+	if errors.Is(err, db.ErrGatewayPartitionMissing) {
+		if ensErr := db.EnsureGatewayPartitions(
+			ctx, s.db.DB(), originatorNodeID, originatorSequenceID,
+		); ensErr != nil {
+			return ensErr
+		}
+		err = db.RunInTx(ctx, s.db.DB(), &sql.TxOptions{}, txBody)
+	}
+	return err
+}
+
 // StoreSyncedReport stores a report that has been received through a stream from another node.
 func (s *Store) StoreSyncedReport(
 	ctx context.Context,
@@ -450,31 +472,33 @@ func (s *Store) StoreSyncedReport(
 		return err
 	}
 
-	return db.RunInTx(
-		ctx,
-		s.db.DB(),
-		&sql.TxOptions{},
-		func(ctx context.Context, txQueries *queries.Queries) error {
-			_, err := db.InsertGatewayEnvelopeWithChecksTransactional(ctx, txQueries,
-				queries.InsertGatewayEnvelopeV3Params{
-					OriginatorNodeID:     int32(envelope.OriginatorNodeID()),
-					OriginatorSequenceID: int64(envelope.OriginatorSequenceID()),
-					Topic:                envelope.TargetTopic().Bytes(),
-					OriginatorEnvelope:   originatorEnvelopeBytes,
-					PayerID:              db.NullInt32(payerID),
-					Expiry: int64(
-						envelope.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime(),
-					),
-				},
-			)
-			if err != nil {
-				return err
-			}
-
-			_, err = txQueries.InsertOrIgnorePayerReport(ctx, *storeReportParams)
-
+	txBody := func(ctx context.Context, txQueries *queries.Queries) error {
+		_, err := db.InsertGatewayEnvelopeWithChecksTransactional(ctx, txQueries,
+			queries.InsertGatewayEnvelopeV3Params{
+				OriginatorNodeID:     int32(envelope.OriginatorNodeID()),
+				OriginatorSequenceID: int64(envelope.OriginatorSequenceID()),
+				Topic:                envelope.TargetTopic().Bytes(),
+				OriginatorEnvelope:   originatorEnvelopeBytes,
+				PayerID:              db.NullInt32(payerID),
+				Expiry: int64(
+					envelope.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime(),
+				),
+			},
+		)
+		if err != nil {
 			return err
-		},
+		}
+
+		_, err = txQueries.InsertOrIgnorePayerReport(ctx, *storeReportParams)
+
+		return err
+	}
+
+	return s.runGatewayInsertTx(
+		ctx,
+		int32(envelope.OriginatorNodeID()),
+		int64(envelope.OriginatorSequenceID()),
+		txBody,
 	)
 }
 
@@ -496,36 +520,38 @@ func (s *Store) StoreSyncedAttestation(
 
 	attestationProto := attestationProtoWrapper.PayerReportAttestation
 
-	return db.RunInTx(
-		ctx,
-		s.db.DB(),
-		&sql.TxOptions{},
-		func(ctx context.Context, txQueries *queries.Queries) error {
-			_, err := db.InsertGatewayEnvelopeWithChecksTransactional(ctx, txQueries,
-				queries.InsertGatewayEnvelopeV3Params{
-					OriginatorNodeID:     int32(envelope.OriginatorNodeID()),
-					OriginatorSequenceID: int64(envelope.OriginatorSequenceID()),
-					Topic:                envelope.TargetTopic().Bytes(),
-					OriginatorEnvelope:   originatorEnvelopeBytes,
-					PayerID:              db.NullInt32(payerID),
-					Expiry: int64(
-						envelope.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime(),
-					),
-				},
-			)
-			if err != nil {
-				return err
-			}
+	txBody := func(ctx context.Context, txQueries *queries.Queries) error {
+		_, err := db.InsertGatewayEnvelopeWithChecksTransactional(ctx, txQueries,
+			queries.InsertGatewayEnvelopeV3Params{
+				OriginatorNodeID:     int32(envelope.OriginatorNodeID()),
+				OriginatorSequenceID: int64(envelope.OriginatorSequenceID()),
+				Topic:                envelope.TargetTopic().Bytes(),
+				OriginatorEnvelope:   originatorEnvelopeBytes,
+				PayerID:              db.NullInt32(payerID),
+				Expiry: int64(
+					envelope.UnsignedOriginatorEnvelope.Proto().GetExpiryUnixtime(),
+				),
+			},
+		)
+		if err != nil {
+			return err
+		}
 
-			return txQueries.InsertOrIgnorePayerReportAttestation(
-				ctx,
-				queries.InsertOrIgnorePayerReportAttestationParams{
-					PayerReportID: attestationProto.GetReportId(),
-					NodeID:        int64(attestationProto.GetSignature().GetNodeId()),
-					Signature:     attestationProto.GetSignature().GetSignature().GetBytes(),
-				},
-			)
-		},
+		return txQueries.InsertOrIgnorePayerReportAttestation(
+			ctx,
+			queries.InsertOrIgnorePayerReportAttestationParams{
+				PayerReportID: attestationProto.GetReportId(),
+				NodeID:        int64(attestationProto.GetSignature().GetNodeId()),
+				Signature:     attestationProto.GetSignature().GetSignature().GetBytes(),
+			},
+		)
+	}
+
+	return s.runGatewayInsertTx(
+		ctx,
+		int32(envelope.OriginatorNodeID()),
+		int64(envelope.OriginatorSequenceID()),
+		txBody,
 	)
 }
 


### PR DESCRIPTION
## Problem

`TestCreateServer` was failing intermittently, and the root cause turned out to be a **real production availability bug**, not a test-only flake.

Lazy, on-the-fly partition creation deadlocks under concurrent writers. When a gateway-envelope insert hits a missing partition, `ensure_gateway_parts_v3` runs `ALTER TABLE … ATTACH PARTITION` against the two shared parent tables `gateway_envelopes_meta` and `gateway_envelopes_blob`.

The lock-ordering inversion (proven with `pg_locks` + the actual deadlock reports):

- `gateway_envelopes_blob` has an FK → `gateway_envelopes_meta`, and `gateway_envelopes_meta` has an FK → `payers`.
- Once the parents hold data, each `ATTACH` validates the inherited FK and takes `ShareRowExclusiveLock` (SROX) on **both** parents. SROX conflicts with the `RowExclusiveLock` an ordinary insert takes.
- A single transaction therefore touches **meta → blob → meta** (the last via the blob insert's FK check). Two concurrent transactions for **different originators** — e.g. the publish-worker for its own originator and a sync-worker replicating another — acquire the two parents' locks in opposite orders → deadlock (SQLSTATE 40P01).

The publish-worker exhausts its 3 retries and then sleeps, so it can stall ingest. The test amplifies it: fresh DBs mean both originators create their partitions at startup simultaneously.

**Production impact:** every node runs a publish-worker plus N sync-workers, all writing to one DB for different originators. Partition creation fires whenever a node first sees a new originator, or when any originator crosses a 1,000,000-sequence band boundary. Two such events concurrently hit the exact inversion. Rare, but real.

## Fix: reader/writer advisory lock + out-of-band partition creation

- Ordinary gateway inserts take the **shared** side of a new transaction-scoped advisory lock (`LockKindPartitionCreation`), so they still run concurrently with each other.
- Partition creation runs in its **own** transaction under the **exclusive** side (`EnsureGatewayPartitions`), so DDL never overlaps DML — removing the SROX-vs-`RowExclusive` conflict entirely. It is a separate transaction specifically to avoid a shared→exclusive upgrade deadlock.
- Insert helpers now return a typed `ErrGatewayPartitionMissing` instead of creating partitions inline; the transaction-owning callers (`publish_worker`, `migrator`, `payerreport`, the identity-update indexer) create the partition out-of-band and retry. The publish path takes the shared lock before resolving payers, for a consistent lock order.

## Verification

- **Deadlock eliminated:** clean-start comparison, 50 `-race` iterations each — **baseline `main`: 17 Postgres deadlocks; this branch: 0.** Across 300+ total `-race` `TestCreateServer` iterations: **0** deadlock detections, **0** publish-worker batch retries.
- `golangci-lint` v2.10.1, `gofmt`, `go vet`, `go build ./...`: clean.
- Unit tests pass: `pkg/db` (race, 2×), `pkg/migrator`, `pkg/payerreport`, `pkg/api/message`, `pkg/indexer/app_chain/contracts`.

## A separate, pre-existing flake remains (out of scope here)

`TestCreateServer` also has an **independent replication flake** — the envelope publishes fine but cross-node replication stalls (`Condition never satisfied`). That is issue #1970 (previously patched in #1975), unrelated to this deadlock and **not** introduced here: a clean-start comparison shows the same ~4% rate on both baseline and this branch. It should be tracked and fixed separately.

## Diff note

The large diffs in `identity_update_storer.go` and `payerreport/store.go` are mostly closure-extraction reindentation (wrapping the insert in the ensure-and-retry contract); the actual logic change in each is small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gateway-envelope partition-creation deadlock using reader/writer advisory locks
> - Replaces inline DDL partition creation inside insert transactions with an out-of-band ensure-and-retry pattern across all gateway envelope insert paths ([gateway_envelope.go](https://github.com/xmtp/xmtpd/pull/2026/files#diff-a41762f1583f16a22a90bd90a773d5e56ab4d77754ba991347c8a67b8e1229db), [gateway_envelope_batch.go](https://github.com/xmtp/xmtpd/pull/2026/files#diff-3b81b47f7dc103297421e66828594182df1ae56fb06cd67801cdd424621be120), [publish_worker.go](https://github.com/xmtp/xmtpd/pull/2026/files#diff-a985e2d18aa8bb7ea586f77e5bc52dad0a4c4989e5a220806f737fb1c9c50415), [identity_update_storer.go](https://github.com/xmtp/xmtpd/pull/2026/files#diff-719fcd3f6b2a547b6c6f299d70464725ddf9c1161c104099b3c3cab140cb2354), [migrator/writer.go](https://github.com/xmtp/xmtpd/pull/2026/files#diff-79de0174d18bbb97eb4c62be1eeec1e2132ff3060f5beafb3b8721044791b258), [payerreport/store.go](https://github.com/xmtp/xmtpd/pull/2026/files#diff-1557531d1361293f11123bbcc86167d7a99f261d62a4a71af45f898ac3b5c770)).
> - Transactional inserts now acquire a shared (reader) advisory lock via `SharedLockPartitionCreation`; partition creation acquires an exclusive (writer) lock via `LockPartitionCreation`, serializing DDL against concurrent DML.
> - When an insert fails due to a missing partition, the transactional function returns `ErrGatewayPartitionMissing` instead of creating the partition inline; callers then call `EnsureGatewayPartitions`/`EnsureGatewayPartitionsForBatch` outside the transaction and retry once.
> - Risk: all callers of transactional gateway insert functions must now handle `ErrGatewayPartitionMissing` and perform the ensure-and-retry; callers that do not are updated in this PR but any future callers must follow the same contract.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4f4aeb2. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->