### PR TITLE
chore: fix some typos in comment

### DIFF
--- a/pkg/db/worker/worker.go
+++ b/pkg/db/worker/worker.go
@@ -33,7 +33,7 @@ type Config struct {
 }
 
 // partition config controls when should the database worker create new partitions.
-// TODO: Perhaps use a lis of originators and setup partitions even for nodes that do not have any yet.
+// TODO: Perhaps use a list of originators and setup partitions even for nodes that do not have any yet.
 
 type PartitionConfig struct {
 	FillThreshold float64

--- a/pkg/merkle/tree_test.go
+++ b/pkg/merkle/tree_test.go
@@ -126,7 +126,7 @@ func TestUnbalancedTrees(t *testing.T) {
 				)
 			}
 
-			// TODO: Check that all internal nodes, let of the upperBound, up to the root are not nil.
+			// TODO: Check that all internal nodes, set of the upperBound, up to the root are not nil.
 		})
 	}
 }


### PR DESCRIPTION
fix some typos in comment

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix typos in comments in worker and merkle tree test files
> Corrects two typos in TODO comments: 'lis' → 'list' in [worker.go](https://github.com/xmtp/xmtpd/pull/2029/files#diff-876e36ec46340c59a9a78fe2512259ea16ade4ed29377924623d1abf4580236b) and 'let' → 'set' in [tree_test.go](https://github.com/xmtp/xmtpd/pull/2029/files#diff-aa27c0aa647f6683e3d149d6596a81a4837849a512296c4f6419f26e088a8c7d). No functional changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 996a3cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->