### PR TITLE
docs: replace deleted smart-contracts link

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -19,7 +19,7 @@ Use one of the following methods to deploy a local environment:
 
 You can use the XMTP Contracts Image to deploy a local environment, and test `xmtpd` with it.
 
-The XMTP Contracts Image [documentation](https://github.com/xmtp/smart-contracts/blob/main/doc/xmtp-contracts-image.md#using-the-image) contains the deterministic addresses where all the contracts are deployed, to ease the setup step.
+The XMTP smart-contracts [deployment documentation](https://github.com/xmtp/smart-contracts/blob/main/doc/deployment.md) contains the deterministic addresses where all the contracts are deployed, to ease the setup step.
 
 By default, `dev/local.env` contains sane values for local deployments. Modify what's necessary.
 


### PR DESCRIPTION
Fixes #2017

Replace the deleted smart-contracts image documentation link with the current deployment documentation page.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace deleted smart-contracts link in deploy docs
> Updates the broken link in [doc/deploy.md](https://github.com/xmtp/xmtpd/pull/2032/files#diff-640fb5c5961664476b31d45f5aac4a1b989eeb7d23b9d9da9e7f95cd403c944f) to point to the new XMTP smart-contracts deployment documentation URL, replacing the old 'XMTP Contracts Image documentation' anchor text and URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e688f72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->