### PR TITLE
fix(fees): commit rates pagination cursor transactionally

### DIFF
--- a/pkg/fees/contract_rates.go
+++ b/pkg/fees/contract_rates.go
@@ -117,26 +117,33 @@ func (c *ContractRatesFetcher) refreshData() error {
 	newRates := make([]*indexedRates, 0)
 	newRates = append(newRates, c.rates...)
 
-	for c.currentIndex.Cmp(availableRatesCount) < 0 {
+	// Track the cursor locally and only publish it once the fetched rates are
+	// committed below. Advancing c.currentIndex here would leak progress on a
+	// mid-pagination failure: the accumulated newRates are discarded on early
+	// return, so a persisted cursor would make the next refresh resume past the
+	// discarded rates and leave a permanent gap in the set.
+	nextIndex := new(big.Int).Set(c.currentIndex)
+
+	for nextIndex.Cmp(availableRatesCount) < 0 {
 		toFetch := big.NewInt(c.pageSize)
 
 		// Adjust page size if near the end
-		remaining := new(big.Int).Sub(availableRatesCount, c.currentIndex)
+		remaining := new(big.Int).Sub(availableRatesCount, nextIndex)
 		if remaining.Cmp(toFetch) < 0 {
 			toFetch = remaining
 		}
 
 		c.logger.Info("getting page",
-			zap.Int64(fromIndexField, c.currentIndex.Int64()),
+			zap.Int64(fromIndexField, nextIndex.Int64()),
 			utils.CountField(toFetch.Int64()),
 		)
 
 		// Step 3: Get rates
-		resp, err := c.contract.GetRates(&bind.CallOpts{Context: c.ctx}, c.currentIndex, toFetch)
+		resp, err := c.contract.GetRates(&bind.CallOpts{Context: c.ctx}, nextIndex, toFetch)
 		if err != nil {
 			c.logger.Error("error calling contract",
 				zap.Error(err),
-				zap.Int64(fromIndexField, c.currentIndex.Int64()),
+				zap.Int64(fromIndexField, nextIndex.Int64()),
 			)
 			return err
 		}
@@ -144,7 +151,7 @@ func (c *ContractRatesFetcher) refreshData() error {
 		newRates = append(newRates, transformRates(resp)...)
 
 		// Step 4: Increment the index for the next page
-		c.currentIndex = c.currentIndex.Add(c.currentIndex, toFetch)
+		nextIndex.Add(nextIndex, toFetch)
 	}
 
 	if err = validateRates(newRates); err != nil {
@@ -152,7 +159,9 @@ func (c *ContractRatesFetcher) refreshData() error {
 		return err
 	}
 
+	// Commit the rates and the cursor together so they can never diverge.
 	c.rates = newRates
+	c.currentIndex = nextIndex
 	c.lastRefresh = time.Now()
 	c.logger.Debug("refreshed rates", utils.CountField(int64(len(newRates))))
 

--- a/pkg/fees/contract_rates_test.go
+++ b/pkg/fees/contract_rates_test.go
@@ -2,6 +2,7 @@ package fees
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -198,4 +199,59 @@ func TestCanContinue(t *testing.T) {
 
 	require.NoError(t, fetcher.refreshData())
 	require.Len(t, fetcher.rates, 6)
+}
+
+// TestPartialRefreshFailureDoesNotSkipRates guards the incremental-refresh
+// cursor against a mid-pagination failure.
+//
+// refreshData accumulates fetched pages into a local slice and only commits it
+// to c.rates at the very end, but it advances c.currentIndex inside the loop as
+// each page is fetched. If a later page fails, the already-fetched pages are
+// discarded (the local slice is dropped) while the cursor stays advanced. The
+// next successful refresh then resumes past the discarded rates, leaving a
+// permanent gap in the rate set.
+//
+// Concretely: 10 rates, page size 5. First refresh fetches [0,5) then fails on
+// [5,10). Recovery refresh must re-fetch [0,5) — not resume at [5,10) and drop
+// the first five rates.
+func TestPartialRefreshFailureDoesNotSkipRates(t *testing.T) {
+	fetcher, mockContract := buildFetcher(t)
+
+	mockContract.EXPECT().
+		GetRatesCount(mock.Anything).
+		Return(big.NewInt(10), nil)
+
+	// Page [0,5) always succeeds.
+	mockContract.EXPECT().
+		GetRates(mock.Anything, big.NewInt(0), mock.Anything).
+		Return([]rateregistry.IRateRegistryRates{
+			buildRates(100, 1), buildRates(200, 2), buildRates(300, 3),
+			buildRates(400, 4), buildRates(500, 5),
+		}, nil)
+
+	// Page [5,10): fails the first time it is requested, succeeds the second.
+	mockContract.EXPECT().
+		GetRates(mock.Anything, big.NewInt(5), mock.Anything).
+		Return(nil, errors.New("transient rpc error")).
+		Once()
+	mockContract.EXPECT().
+		GetRates(mock.Anything, big.NewInt(5), mock.Anything).
+		Return([]rateregistry.IRateRegistryRates{
+			buildRates(600, 6), buildRates(700, 7), buildRates(800, 8),
+			buildRates(900, 9), buildRates(1000, 10),
+		}, nil).
+		Once()
+
+	// First refresh fails on the second page and must not commit anything.
+	require.Error(t, fetcher.refreshData())
+	require.Empty(t, fetcher.rates, "a failed refresh must not commit partial rates")
+
+	// Recovery refresh: with a correct cursor this re-fetches [0,5) then [5,10)
+	// for all 10 rates; a leaked cursor resumes at [5,10) and drops the first 5.
+	require.NoError(t, fetcher.refreshData())
+
+	require.Len(t, fetcher.rates, 10,
+		"recovery refresh skipped the rates dropped by the failed one (cursor advanced without committing)")
+	require.Equal(t, currency.PicoDollar(100), fetcher.rates[0].rates.MessageFee)
+	require.Equal(t, currency.PicoDollar(1000), fetcher.rates[9].rates.MessageFee)
 }


### PR DESCRIPTION
Closes #2049

## Problem

`refreshData` paginates rates into a local `newRates` slice and commits it to `c.rates` only at
the end, but advances the persistent cursor `c.currentIndex` inside the loop, per page:

```go
resp, err := c.contract.GetRates(&bind.CallOpts{Context: c.ctx}, c.currentIndex, toFetch)
if err != nil {
    return err                                            // newRates discarded here...
}
newRates = append(newRates, transformRates(resp)...)
c.currentIndex = c.currentIndex.Add(c.currentIndex, toFetch)  // ...cursor already moved
```

If `GetRates` fails on any page after the first, the accumulated `newRates` is thrown away (it's
a local) but `c.currentIndex` keeps the progress from the pages that succeeded. The cursor is
persistent by design — `refreshLoop` calls `refreshData` repeatedly and only fetches rates newer
than `c.currentIndex` (`TestCanContinue` covers this incremental path). So the next refresh
resumes *past* the discarded rates and never re-fetches them, leaving a permanent contiguous gap
in the in-memory rate set.

## Impact

One transient RPC failure mid-pagination silently drops a block of rates until the process
restarts. `GetRates`/`findMatchingRate` binary-search for the newest rate at-or-before a message
timestamp, so any timestamp inside the missing window resolves to the rate just before the gap —
messages there are priced at a stale rate, with no error surfaced. These rates drive fee
calculation and settlement, so the result is silently incorrect charges. The trigger is
realistic: one `GetRates` RPC per page, and the failure only has to land on the second-or-later
page of a multi-page refresh.

## Fix

Track the cursor in a local `nextIndex` during the loop and publish it to `c.currentIndex` only
after `c.rates` is committed, so the cursor and the committed rates can never diverge:

```go
nextIndex := new(big.Int).Set(c.currentIndex)
for nextIndex.Cmp(availableRatesCount) < 0 {
    // ... fetch using nextIndex; on error return without touching c.currentIndex ...
    nextIndex.Add(nextIndex, toFetch)
}
// after validateRates:
c.rates = newRates
c.currentIndex = nextIndex
```

On failure `c.currentIndex` is untouched, so the next refresh re-fetches the discarded pages.
Successful refreshes are unchanged — the incremental behavior in `TestCanContinue` still holds.

## Testing

Added `TestPartialRefreshFailureDoesNotSkipRates` using the existing `MockRatesContract` (no DB):
first refresh fetches page `[0,5)` then fails on `[5,10)`; the recovery refresh succeeds on both.

- On `main` it fails at the post-recovery `require.Len(fetcher.rates, 10)` — the fetcher holds
  only 5 rates, the first five silently dropped.
- With this change it passes, and the whole `pkg/fees` suite (`go test ./pkg/fees/... -v`),
  `gofmt -l` and `go vet ./pkg/fees/...` are clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ContractRatesFetcher.refreshData` to commit pagination cursor transactionally
> - Introduces a local `nextIndex` cursor in `refreshData` so `c.currentIndex` is not mutated during pagination; on any mid-pagination error, both `c.rates` and `c.currentIndex` remain unchanged.
> - Only after all pages are fetched successfully are `c.rates` and `c.currentIndex` committed together atomically.
> - Adds a test ([contract_rates_test.go](https://github.com/xmtp/xmtpd/pull/2050/files#diff-e54e3c123879df99227a1cf95103637e4dd9c1e63be52754fc2a310dd32bef76)) that simulates a transient failure on the second page and asserts no partial rates are committed, then verifies a retry yields all 10 rates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f65e5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->